### PR TITLE
Fix DeprecationWarning: invalid escape sequence

### DIFF
--- a/prettytable.py
+++ b/prettytable.py
@@ -73,7 +73,7 @@ MSWORD_FRIENDLY = 11
 PLAIN_COLUMNS = 12
 RANDOM = 20
 
-_re = re.compile("\033\[[0-9;]*m")
+_re = re.compile(r"\033\[[0-9;]*m")
 
 def _get_size(text):
     lines = text.split("\n")
@@ -926,9 +926,9 @@ class PrettyTable(object):
         self._vrules = random.choice((ALL, FRAME, NONE))
         self.left_padding_width = random.randint(0,5)
         self.right_padding_width = random.randint(0,5)
-        self.vertical_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
-        self.horizontal_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
-        self.junction_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
+        self.vertical_char = random.choice(r"~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
+        self.horizontal_char = random.choice(r"~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
+        self.junction_char = random.choice(r"~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
 
     ##############################
     # DATA INPUT METHODS         #


### PR DESCRIPTION
Fixes several DeprecationWarning:
```python
prettytable.py:76: DeprecationWarning: invalid escape sequence \[
  _re = re.compile("\033\[[0-9;]*m")
prettytable.py:929: DeprecationWarning: invalid escape sequence \{
  self.vertical_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
prettytable.py:930: DeprecationWarning: invalid escape sequence \{
  self.horizontal_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
prettytable.py:931: DeprecationWarning: invalid escape sequence \{
  self.junction_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
```