### PR TITLE
Drop support for EOL Python

### DIFF
--- a/prettytable.py
+++ b/prettytable.py
@@ -1657,7 +1657,7 @@ class TableHandler(HTMLParser):
                 for i in range(1,appends):
                     row[0].append("-")
 
-            if row[1] == True:
+            if row[1]:
                 self.make_fields_unique(row[0])
                 table.field_names = row[0]
             else:

--- a/prettytable.py
+++ b/prettytable.py
@@ -1409,8 +1409,7 @@ class PrettyTable(object):
         else:
             linebreak = "<br>"
 
-        open_tag = []
-        open_tag.append("<table")
+        open_tag = ["<table"]
         if options["attributes"]:
             for attr_name in options["attributes"]:
                 open_tag.append(" {}=\"{}\"".format(attr_name, options["attributes"][attr_name]))
@@ -1458,8 +1457,7 @@ class PrettyTable(object):
         else:
             linebreak = "<br>"
 
-        open_tag = []
-        open_tag.append("<table")
+        open_tag = ["<table"]
         if options["border"]:
             if options["hrules"] == ALL and options["vrules"] == ALL:
                 open_tag.append(" frame=\"box\" rules=\"all\"")

--- a/prettytable.py
+++ b/prettytable.py
@@ -344,7 +344,7 @@ class PrettyTable(object):
         try:
             assert int(val) >= 0
         except AssertionError:
-            raise Exception("Invalid value for %s: %s!" % (name, self._unicode(val)))
+            raise Exception("Invalid value for {}: {}!".format(name, self._unicode(val)))
 
     def _validate_true_or_false(self, name, val):
         try:
@@ -1413,7 +1413,7 @@ class PrettyTable(object):
         open_tag.append("<table")
         if options["attributes"]:
             for attr_name in options["attributes"]:
-                open_tag.append(" %s=\"%s\"" % (attr_name, options["attributes"][attr_name]))
+                open_tag.append(" {}=\"{}\"".format(attr_name, options["attributes"][attr_name]))
         open_tag.append(">")
         lines.append("".join(open_tag))
 
@@ -1477,7 +1477,7 @@ class PrettyTable(object):
                 open_tag.append(" frame=\"vsides\" rules=\"cols\"")
         if options["attributes"]:
             for attr_name in options["attributes"]:
-                open_tag.append(" %s=\"%s\"" % (attr_name, options["attributes"][attr_name]))
+                open_tag.append(" {}=\"{}\"".format(attr_name, options["attributes"][attr_name]))
         open_tag.append(">")
         lines.append("".join(open_tag))
 

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,15 @@ from prettytable import __version__ as version
 setup(
     name='prettytable',
     version=version,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.4',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: BSD License',
         'Topic :: Text Processing'
     ],


### PR DESCRIPTION
Python 2.4-2.6 are EOL (since at least 2008, 2011 and 2013 respectively) and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for prettytable from PyPI for August 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  88.65% |      1,064,121 |
| 3.6            |   6.53% |         78,341 |
| 3.5            |   2.55% |         30,639 |
| 3.4            |   1.30% |         15,582 |
| 3.7            |   0.91% |         10,976 |
| 2.6            |   0.04% |            471 |
| 3.3            |   0.02% |            185 |
| 3.8            |   0.00% |             15 |
| Total          |         |      1,200,330 |

Source: `pypinfo --start-date 2018-08-01 --end-date 2018-08-31 --json prettytable pyversion`

This PR drops support and upgrades some code for newer Python versions.