### PR TITLE
Test on Travis CI and fix tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,12 @@
+# .coveragerc to control coverage.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma:
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+    def main()

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: python
+cache: pip
+sudo: false
+
+# Supported CPython versions:
+# https://en.wikipedia.org/wiki/CPython#Version_history
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.7"
+      dist: xenial
+      sudo: required
+    - python: "3.6"
+    - python: "3.5"
+    - python: "3.4"
+    - python: "2.7"
+
+install:
+ - pip install -U pytest pytest-cov
+
+script:
+ - pytest --cov prettytable
+
+after_script:
+ - pip install -U flake8
+ - flake8 . --statistics --count
+
+after_success:
+ - coverage report
+ - pip install -U codecov
+ - codecov

--- a/prettytable.py
+++ b/prettytable.py
@@ -370,7 +370,8 @@ class PrettyTable(object):
             bits = val.split(".")
             assert len(bits) <= 2
             assert bits[0] == "" or bits[0].isdigit()
-            assert bits[1] == "" or bits[1].isdigit()
+            assert bits[1] == "" or bits[1].isdigit() or (
+                    bits[1][-1] == "f" and bits[1].rstrip("f").isdigit())
         except AssertionError:
             raise Exception("Invalid value for %s!  Must be a float format string." % name)
 

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -116,23 +116,23 @@ class OptionOverrideTests(CityDataTest):
     def testBorder(self):
         default = self.x.get_string()
         override = self.x.get_string(border=False)
-        self.assertTrue(default != override)
+        self.assertNotEqual(default, override)
 
     def testHeader(self):
         default = self.x.get_string()
         override = self.x.get_string(header=False)
-        self.assertTrue(default != override)
+        self.assertNotEqual(default, override)
 
     def testHrulesAll(self):
         default = self.x.get_string()
         override = self.x.get_string(hrules=ALL)
-        self.assertTrue(default != override)
+        self.assertNotEqual(default, override)
 
     def testHrulesNone(self):
 
         default = self.x.get_string()
         override = self.x.get_string(hrules=NONE)
-        self.assertTrue(default != override)
+        self.assertNotEqual(default, override)
 
 class OptionAttributeTests(CityDataTest):
 
@@ -180,7 +180,7 @@ class BasicTests(CityDataTest):
 
         string = self.x.get_string()
         lines = string.split("\n")
-        self.assertTrue("" not in lines)
+        self.assertNotIn("", lines)
 
     def testAllLengthsEqual(self):
 


### PR DESCRIPTION

This PR:

* Adds config to test on Travis CI, for example: https://travis-ci.org/hugovk/prettytable/builds/430064736

* Python 3.7 needs a little workaround with Xenial and sudo, see https://github.com/travis-ci/travis-ci/issues/9815

* Runs the tests using pytest with coverage

* Runs flake8, but for information only, doesn't fail the build. When they're fixed, these could be moved to the `script:` section to keep them fixed.

* On success, coverage is send to Codecov, for example: https://codecov.io/gh/hugovk/prettytable/tree/3c8737bdc93f7349d5d643ea6675fd1358a54417

* Finally, 5 tests were failing `_validate_float_format` for float formats like `0.6f`.
  * It only accepted formats like `0.6`, 
  * However, general support was added in https://github.com/jazzband/prettytable/commit/8cfc7911e7403850dad9707efb17bbaf254e443f to use the "fancy new Python string formatting" (in 2012 :) but the validation wasn't updated
  * So update `_validate_float_format` to allow `0.6f`-style formats

Before merge, please enable this repo:

* [x] Travis CI
* [ ] Codecov
