### PR TITLE
add from_json and get_json_string to prettytable

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,12 @@ print x.get_string(border=False)
 print x
 ```
 
+### Displaying your table in JSON
+
+PrettyTable will also print your tables in JSON, as a list of fields and an array 
+of rows.  Just like in ASCII form, you can actually get a string representation - just use 
+`get_json_string()`. 
+
 ### Displaying your table in HTML form
 
 PrettyTable will also print your tables in HTML form, as `<table>`s.  Just like 

--- a/prettytable.py
+++ b/prettytable.py
@@ -1459,7 +1459,7 @@ class PrettyTable(object):
         for row in self._get_rows(options):
             objects.append(dict(zip(self._field_names, row)))
 
-        return json.dumps(objects,indent=4,separators=(',', ': '))
+        return json.dumps(objects,indent=4,separators=(',', ': '),sort_keys=True)
 
     ##############################
     # HTML STRING METHODS        #

--- a/prettytable.py
+++ b/prettytable.py
@@ -41,6 +41,7 @@ import re
 import sys
 import textwrap
 import unicodedata
+import json
 
 py3k = sys.version_info[0] >= 3
 if py3k:
@@ -1442,6 +1443,25 @@ class PrettyTable(object):
         return "\f".join(pages)
 
     ##############################
+    # JSON STRING METHODS        #
+    ##############################
+    def get_json_string(self,**kwargs):
+
+        """Return string representation of JSON formatted table in the current state
+
+        Arguments:
+
+        none yet"""
+
+        options = self._get_options(kwargs)
+
+        objects = [self.field_names]
+        for row in self._get_rows(options):
+            objects.append(dict(zip(self._field_names, row)))
+
+        return json.dumps(objects,indent=4,separators=(',', ': '))
+
+    ##############################
     # HTML STRING METHODS        #
     ##############################
 
@@ -1689,6 +1709,14 @@ def from_db_cursor(cursor, **kwargs):
             table.add_row(row)
         return table
 
+def from_json(json_string, **kwargs):
+    table = PrettyTable(**kwargs)
+    objects = json.loads(json_string)
+    table.field_names = objects[0]
+    for obj in objects[1:]:
+        row = [obj[key] for key in table.field_names]
+        table.add_row(row)
+    return table
 
 class TableHandler(HTMLParser):
 

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -6,7 +6,7 @@ import unittest
 from math import e, pi, sqrt
 
 from prettytable import (ALL, MSWORD_FRIENDLY, NONE, PrettyTable, from_csv,
-                         from_db_cursor, from_html, from_html_one)
+                         from_db_cursor, from_html, from_html_one, from_json)
 
 py3k = sys.version_info[0] >= 3
 try:
@@ -487,6 +487,37 @@ class BreakLineTests(unittest.TestCase):
 """.strip()
 
 
+class JSONOutputTests(unittest.TestCase):
+
+    def testJSONOutput(self):
+        t = PrettyTable(['Field 1', 'Field 2', 'Field 3'])
+        t.add_row(['value 1', 'value2', 'value3'])
+        t.add_row(['value 4', 'value5', 'value6'])
+        t.add_row(['value 7', 'value8', 'value9'])
+        result = t.get_json_string()
+        assert result.strip() == """[
+    [
+        "Field 1",
+        "Field 2",
+        "Field 3"
+    ],
+    {
+        "Field 3": "value3",
+        "Field 2": "value2",
+        "Field 1": "value 1"
+    },
+    {
+        "Field 3": "value6",
+        "Field 2": "value5",
+        "Field 1": "value 4"
+    },
+    {
+        "Field 3": "value9",
+        "Field 2": "value8",
+        "Field 1": "value 7"
+    }
+]""".strip()
+
 class HtmlOutputTests(unittest.TestCase):
 
     def testHtmlOutput(self):
@@ -589,6 +620,13 @@ if _have_sqlite:
             self.cur.execute("INSERT INTO cities VALUES (\"Adelaide\", 1295, 1158259, 600.5)")
             assert from_db_cursor(self.cur) is None
 
+
+class JSONConstructorTest(CityDataTest):
+
+    def testJSONAndBack(self):
+        json_string = self.x.get_json_string()
+        new_table = from_json(json_string)
+        assert new_table.get_string() == self.x.get_string()
 
 class HtmlConstructorTest(CityDataTest):
 

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -502,19 +502,19 @@ class JSONOutputTests(unittest.TestCase):
         "Field 3"
     ],
     {
-        "Field 3": "value3",
+        "Field 1": "value 1",
         "Field 2": "value2",
-        "Field 1": "value 1"
+        "Field 3": "value3"
     },
     {
-        "Field 3": "value6",
+        "Field 1": "value 4",
         "Field 2": "value5",
-        "Field 1": "value 4"
+        "Field 3": "value6"
     },
     {
-        "Field 3": "value9",
+        "Field 1": "value 7",
         "Field 2": "value8",
-        "Field 1": "value 7"
+        "Field 3": "value9"
     }
 ]""".strip()
 


### PR DESCRIPTION
This adds tools to work with json data to prettytable.  it adds a get_json_string() function to pull a json formatted string, and then it can be re-imported with from_json().

This is helpful in making it possible to generate html tables for web, text tables for console, and now json data for an API that want to format it the way it wants, all in the same code.

