### PR TITLE
fix PLAIN_COLUMN to PLAIN_COLUMNS in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ you can use for your tables:
 
   * `DEFAULT` - The default look, used to undo any style changes you may have 
 made
-  * `PLAIN_COLUMN` - A borderless style that works well with command line 
+  * `PLAIN_COLUMNS` - A borderless style that works well with command line 
 programs for columnar data
 
 Other styles are likely to appear in future releases.


### PR DESCRIPTION
Documentation references `PLAIN_COLUMN`; code specifies `PLAIN_COLUMNS`.

This PR updates the documentation to be consistent.

https://github.com/jazzband/prettytable/blob/master/prettytable.py#L933