### PR TITLE
fix UnboundLocalError

### DIFF
--- a/prettytable.py
+++ b/prettytable.py
@@ -457,6 +457,7 @@ class PrettyTable(object):
     def field_names(self, val):
         val = [self._unicode(x) for x in val]
         self._validate_option("field_names", val)
+        old_names = None
         if self._field_names:
             old_names = self._field_names[:]
         self._field_names = val


### PR DESCRIPTION
fix  'UnboundLocalError: local variable 'old_names' referenced before assignment'   when I  re-add field_names after I user `x.clear()` to clear the table