### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
       dist: xenial
     - python: "3.6"
     - python: "3.5"
-    - python: "3.4"
     - python: "2.7"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 cache: pip
-sudo: false
 
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
@@ -9,7 +8,6 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
-      sudo: required
     - python: "3.6"
     - python: "3.5"
     - python: "3.4"

--- a/prettytable.py
+++ b/prettytable.py
@@ -362,7 +362,7 @@ class PrettyTable(object):
             assert int(val) >= 0
         except AssertionError:
             raise Exception(
-                "Invalid value for %s: %s!" % (name, self._unicode(val)))
+                "Invalid value for {}: {}!".format(name, self._unicode(val)))
 
     def _validate_true_or_false(self, name, val):
         try:
@@ -489,7 +489,7 @@ class PrettyTable(object):
     def align(self, val):
         if not self._field_names:
             self._align = {}
-        elif val is None or (isinstance(val, dict) and len(val) is 0):
+        elif val is None or (isinstance(val, dict) and len(val) == 0):
             for field in self._field_names:
                 self._align[field] = "c"
         else:
@@ -509,7 +509,7 @@ class PrettyTable(object):
     def valign(self, val):
         if not self._field_names:
             self._valign = {}
-        elif val is None or (isinstance(val, dict) and len(val) is 0):
+        elif val is None or (isinstance(val, dict) and len(val) == 0):
             for field in self._field_names:
                 self._valign[field] = "t"
         else:
@@ -527,7 +527,7 @@ class PrettyTable(object):
 
     @max_width.setter
     def max_width(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._max_width = {}
         else:
             self._validate_option("max_width", val)
@@ -544,7 +544,7 @@ class PrettyTable(object):
 
     @min_width.setter
     def min_width(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._min_width = {}
         else:
             self._validate_option("min_width", val)
@@ -742,7 +742,7 @@ class PrettyTable(object):
 
     @int_format.setter
     def int_format(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._int_format = {}
         else:
             self._validate_option("int_format", val)
@@ -759,7 +759,7 @@ class PrettyTable(object):
 
     @float_format.setter
     def float_format(self, val):
-        if val is None or (isinstance(val, dict) and len(val) is 0):
+        if val is None or (isinstance(val, dict) and len(val) == 0):
             self._float_format = {}
         else:
             self._validate_option("float_format", val)

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,12 @@ with open('README.md') as f:
 setup(
     name='prettytable',
     version=version,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.* !=3.4.*',
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for prettytable from PyPI for July 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 2.7      |  78.60% | 1,380,358 |
| 3.6      |  10.89% |   191,172 |
| 3.7      |   5.10% |    89,496 |
| 3.5      |   4.53% |    79,487 |
| 3.4      |   0.56% |     9,875 |
| null     |   0.29% |     5,045 |
| 3.8      |   0.02% |       373 |
| 2.6      |   0.01% |       236 |
| 3.3      |   0.00% |        36 |
| 3.1      |   0.00% |         2 |
| 3.9      |   0.00% |         1 |
| Total    |         | 1,756,081 |

Source: `pip install -U pypistats && pypistats python_minor prettytable --last-month`
