### PR TITLE
Test on Python 3.8 beta to avoid surprises

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache: pip
 matrix:
   fast_finish: true
   include:
+    - python: "3.8-dev"
+      dist: xenial
     - python: "3.7"
       dist: xenial
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 cache: pip
-sudo: false
 
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
@@ -9,7 +8,6 @@ matrix:
   include:
     - python: "3.7"
       dist: xenial
-      sudo: required
     - python: "3.6"
     - python: "3.5"
     - python: "3.4"


### PR DESCRIPTION
Python 3.8 is in beta and due for release on 2019-10-21.

* https://www.python.org/dev/peps/pep-0569/#schedule

Now is a good to time to start testing on Python 3.8 to make sure there are no surprises when it is released.
