### PR TITLE
GHA: Testing one version of Ubuntu should be enough

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-18.04, ubuntu-16.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Follow on from https://github.com/jazzband/prettytable/pull/29.

Testing a single version of Linux on the CI should be enough for this type of project.

It's more important to test Linux/macOS/Windows differences, which is already covered here.