### PR TITLE
Use setuptools_scm to simplify versioning during release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.26.2
+    rev: v2.0.1
     hooks:
       - id: pyupgrade
 
@@ -21,12 +21,12 @@ repos:
       - id: isort
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.4
+    rev: v1.5.1
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v2.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include COPYING
-include CHANGELOG.md
-include README.md
-include prettytable_test.py

--- a/prettytable.py
+++ b/prettytable.py
@@ -30,8 +30,6 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-__version__ = "trunk"
-
 import copy
 import csv
 import itertools
@@ -43,6 +41,9 @@ import sys
 import textwrap
 import unicodedata
 
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution(__name__).version
 py3k = sys.version_info[0] >= 3
 if py3k:
     unicode = str

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
-#!/usr/bin/env python
 from setuptools import setup
-
-from prettytable import __version__ as version
 
 with open("README.md") as f:
     long_description = f.read()
+
+
+def local_scheme(version):
+    """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
+    to be able to upload to Test PyPI"""
+    return ""
+
 
 setup(
     name="prettytable",
@@ -17,7 +21,8 @@ setup(
     maintainer="Jazzband",
     url="https://github.com/jazzband/prettytable",
     license="BSD (3 clause)",
-    version=version,
+    use_scm_version={"local_scheme": local_scheme},
+    setup_requires=["setuptools_scm"],
     extras_require={"tests": ["pytest", "pytest-cov"]},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,15 @@ with open("README.md") as f:
 
 setup(
     name="prettytable",
+    description="A simple Python library for easily displaying tabular data in a "
+    "visually appealing ASCII table format",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Luke Maurits",
+    author_email="luke@maurits.id.au",
+    maintainer="Jazzband",
+    url="https://github.com/jazzband/prettytable",
+    license="BSD (3 clause)",
     version=version,
     extras_require={"tests": ["pytest", "pytest-cov"]},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
@@ -23,15 +32,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Topic :: Text Processing",
     ],
-    license="BSD (3 clause)",
-    description="A simple Python library for easily displaying tabular data in a "
-    "visually appealing ASCII table format",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Luke Maurits",
-    author_email="luke@maurits.id.au",
-    maintainer="Jazzband",
-    url="https://github.com/jazzband/prettytable",
     py_modules=["prettytable"],
     test_suite="prettytable_test",
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author_email="luke@maurits.id.au",
     maintainer="Jazzband",
     url="https://github.com/jazzband/prettytable",
+    project_urls={"Source": "https://github.com/jazzband/prettytable"},
     license="BSD (3 clause)",
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],


### PR DESCRIPTION
No editing of files, just add the version tag.

Can check with:

```console
$ python setup.py --version
0.7.3.dev85
```

Also add `Source` metadata to `project_urls`, which can be useful on PyPI and for programmatic access to packages.
