### PR TITLE
Fix for Python 4: don't compare sys.version_info[1] to integer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: 3.7.9
     hooks:
       - id: flake8
+        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21

--- a/prettytable.py
+++ b/prettytable.py
@@ -51,15 +51,12 @@ if py3k:
     iterzip = zip
     uni_chr = chr
     from html.parser import HTMLParser
+    from html import escape
 else:
     itermap = itertools.imap
     iterzip = itertools.izip
     uni_chr = unichr  # noqa: F821
     from HTMLParser import HTMLParser
-
-if py3k and sys.version_info[1] >= 2:
-    from html import escape
-else:
     from cgi import escape
 
 # hrule styles


### PR DESCRIPTION
`html.escape` is [new in Python 3.2](https://docs.python.org/3/library/html.html#html.escape).

The  intention of this original code is to use `html.escape` for Python 3.2+, and `cgi.escape` for older versions:


```python
py3k = sys.version_info[0] >= 3
...
if py3k and sys.version_info[1] >= 2:
    from html import escape
else:
    from cgi import escape
```

But on Python 4.0-4.1, it would try to use `cgi.escape`, removed in Python 3.8. Instead, compare to a tuple:

```diff
-if py3k and sys.version_info[1] >= 2:
+if sys.version_info >= (3, 2):
```

But as the lowest 3.x supported is 3.5, a check for `py3k` is enough.

---

Found using https://github.com/asottile/flake8-2020, and added to pre-commit. Also added https://github.com/keisheiled/flake8-implicit-str-concat which can find oddities after formatting with Black.
