### PR TITLE
Add Org mode table style

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ made
   * `PLAIN_COLUMNS` - A borderless style that works well with command line
 programs for columnar data
   * `MARKDOWN` - A style that follows Markdown syntax
-  * `ORGMODE` - A table style that fits Org mode syntax
+  * `ORGMODE` - A table style that fits [Org mode](https://orgmode.org/) syntax
 
 Other styles are likely to appear in future releases.
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ made
   * `PLAIN_COLUMNS` - A borderless style that works well with command line
 programs for columnar data
   * `MARKDOWN` - A style that follows Markdown syntax
+  * `ORGMODE` - A table style that fits Org mode syntax
 
 Other styles are likely to appear in future releases.
 

--- a/prettytable.py
+++ b/prettytable.py
@@ -71,6 +71,7 @@ DEFAULT = 10
 MSWORD_FRIENDLY = 11
 PLAIN_COLUMNS = 12
 MARKDOWN = 13
+ORGMODE = 14
 RANDOM = 20
 
 _re = re.compile(r"\033\[[0-9;]*m")
@@ -976,10 +977,16 @@ class PrettyTable(object):
             self._set_columns_style()
         elif style == MARKDOWN:
             self._set_markdown_style()
+        elif style == ORGMODE:
+            self._set_orgmode_style()
         elif style == RANDOM:
             self._set_random_style()
         else:
             raise Exception("Invalid pre-set style!")
+
+    def _set_orgmode_style(self):
+        self._set_default_style()
+        self.orgmode = True
 
     def _set_markdown_style(self):
         self.header = True
@@ -1316,6 +1323,12 @@ class PrettyTable(object):
         if options["border"] and options["hrules"] == FRAME:
             lines.append(self._hrule)
 
+        if "orgmode" in self.__dict__ and self.orgmode is True:
+            tmp = list()
+            for line in lines:
+                tmp.extend(line.split("\n"))
+            lines = ["|" + line[1:-1] + "|" for line in tmp]
+            
         return self._unicode("\n").join(lines)
 
     def _stringify_hrule(self, options):

--- a/prettytable.py
+++ b/prettytable.py
@@ -1328,7 +1328,7 @@ class PrettyTable(object):
             for line in lines:
                 tmp.extend(line.split("\n"))
             lines = ["|" + line[1:-1] + "|" for line in tmp]
-            
+
         return self._unicode("\n").join(lines)
 
     def _stringify_hrule(self, options):

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -680,6 +680,7 @@ class OrgmodeStyleTest(BasicTests):
 """.strip()
         )
 
+        
 class CsvConstructorTest(BasicTests):
     def setUp(self):
 

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -34,7 +34,7 @@ else:
 
 class BuildEquivelanceTest(unittest.TestCase):
     """Make sure that building a table row-by-row and column-by-column yield the same
-     results"""
+    results"""
 
     def setUp(self):
 
@@ -680,7 +680,7 @@ class OrgmodeStyleTest(BasicTests):
 """.strip()
         )
 
-        
+
 class CsvConstructorTest(BasicTests):
     def setUp(self):
 

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -8,6 +8,7 @@ from math import e, pi, sqrt
 from prettytable import (
     ALL,
     MARKDOWN,
+    ORGMODE,
     MSWORD_FRIENDLY,
     NONE,
     PrettyTable,
@@ -657,6 +658,27 @@ class MarkdownStyleTest(BasicTests):
 """.strip()
         )
 
+
+class OrgmodeStyleTest(BasicTests):
+    def testOrgmodeStyle(self):
+        t = PrettyTable(["Field 1", "Field 2", "Field 3"])
+        t.add_row(["value 1", "value2", "value3"])
+        t.add_row(["value 4", "value5", "value6"])
+        t.add_row(["value 7", "value8", "value9"])
+        t.set_style(ORGMODE)
+        result = t.get_string()
+        assert (
+            result.strip()
+            == """
+|---------+---------+---------|
+| Field 1 | Field 2 | Field 3 |
+|---------+---------+---------|
+| value 1 |  value2 |  value3 |
+| value 4 |  value5 |  value6 |
+| value 7 |  value8 |  value9 |
+|---------+---------+---------|
+""".strip()
+        )
 
 class CsvConstructorTest(BasicTests):
     def setUp(self):

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -8,9 +8,9 @@ from math import e, pi, sqrt
 from prettytable import (
     ALL,
     MARKDOWN,
-    ORGMODE,
     MSWORD_FRIENDLY,
     NONE,
+    ORGMODE,
     PrettyTable,
     from_csv,
     from_db_cursor,


### PR DESCRIPTION
The [Org-mode](https://orgmode.org/) is for keeping notes, maintaining TODO lists, planning projects, and authoring documents with a fast and effective plain-text system.

We may need the prettytable to support the org-mode table style for Emacer.

A sample table in org-mode is present below:

```
|---------+---------+---------|
| Field 1 | Field 2 | Field 3 |
|---------+---------+---------|
| value 1 |  value2 |  value3 |
| value 4 |  value5 |  value6 |
| value 7 |  value8 |  value9 |
|---------+---------+---------|
```
This is slightly different from the default style, specifically, the junction character includes `+` and `|` instead of only a single char, e.g "+" in the default style.

As much as possible to modify a few codes, I modify a few lines in the function `def get_string(self, **kwargs):`.
