### PR TITLE
GHA: Update linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,21 +9,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: pip cache
+      - name: Cache
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: lint-pip-${{ hashFiles('**/setup.py') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key:
+            lint-v2-${{ hashFiles('**/setup.py') }}-${{
+            hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
-            lint-pip-
-
-      - name: pre-commit cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pre-commit
-          key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
-          restore-keys: |
-            lint-pre-commit-
+            lint-v2-
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,15 +5,12 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.8]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
           key: lint-pip-${{ hashFiles('**/setup.py') }}
@@ -21,22 +18,22 @@ jobs:
             lint-pip-
 
       - name: pre-commit cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
           key: lint-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
           restore-keys: |
             lint-pre-commit-
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade tox
+          python -m pip install -U pip
+          python -m pip install -U tox
 
       - name: Lint
         run: tox -e lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,3 +33,5 @@ jobs:
 
       - name: Lint
         run: tox -e lint
+        env:
+          PRE_COMMIT_COLOR: always

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{27, 35, 36, 37, 38}
+    py{27, 35, 36, 37, 38, 39}
 
 [testenv]
 extras = tests
@@ -10,6 +10,6 @@ commands =
 
 [testenv:lint]
 deps = pre-commit
-commands = pre-commit run --all-files
+commands = pre-commit run --all-files --show-diff-on-failure
 skip_install = true
 passenv = PRE_COMMIT_COLOR

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,4 @@ commands =
 deps = pre-commit
 commands = pre-commit run --all-files
 skip_install = true
+passenv = PRE_COMMIT_COLOR


### PR DESCRIPTION
Update linting on GitHub Actions:

* Show diff if pre-commit lint fails on CI, so people don't need to install pre-commit/lint tools locally if they don't want
* Colour the output of pre-commit linting
* Combine pip and pre-commit caches
* Update some actions to v2
* Simplify config