### PR TITLE
Test on and declare support for Python 3.9

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
             ${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,50 +12,32 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Ubuntu cache
-        uses: actions/cache@v1
-        if: startsWith(matrix.os, 'ubuntu')
-        with:
-          path: ~/.cache/pip
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
-
-      - name: macOS cache
-        uses: actions/cache@v1
-        if: startsWith(matrix.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
-
-      - name: Windows cache
-        uses: actions/cache@v1
-        if: startsWith(matrix.os, 'windows')
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key:
-            ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('**/setup.py')
-            }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-
+      - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Get pip cache dir
+        id: pip-cache
+        run: |
+          echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key:
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-${{
+            hashFiles('**/setup.py') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.python-version }}-v1-
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade tox
+          python -m pip install -U pip
+          python -m pip install -U tox
 
       - name: Tox tests
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9-dev]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9-dev]
+        python-version: ["3.6", "3.7", "3.8", "3.9-dev"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          # Include new variables for Codecov
+          - { codecov-flag: GHA_Ubuntu, os: ubuntu-latest }
+          - { codecov-flag: GHA_macOS, os: macos-latest }
+          - { codecov-flag: GHA_Windows, os: windows-latest }
 
     steps:
       - uses: actions/checkout@v2
@@ -46,3 +51,9 @@ jobs:
         shell: bash
         run: |
           tox -e py
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.codecov-flag }}
+          name: ${{ matrix.os }} Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # PrettyTable 1.0 - Unreleased
 
 * Dropped support for EOL Python 2.4-2.6 and 3.0-3.4.
-* Added support for Python 3.5-3.8.
+* Added support for Python 3.5-3.9.
 * New `paginate` method can be used to produce strings suitable
   for piping to lp/lpr.
 * `from_html` now handles HTML tables with colspan, rather than

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal = 1
 
 [flake8]
-ignore = E203, W503
+extend-ignore = E203
 max_line_length = 88
 
 [tool:isort]

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: BSD License",
         "Topic :: Text Processing",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist =
 [testenv]
 extras = tests
 commands =
-    {envpython} -m pytest --cov prettytable --cov prettytable_test {posargs}
+    {envpython} -m pytest --cov prettytable --cov prettytable_test --cov-report xml {posargs}
 
 [testenv:lint]
 deps = pre-commit


### PR DESCRIPTION
Python 3.9.0 final is expected on Monday, 2020-10-05

* https://www.python.org/dev/peps/pep-0596/

This adds the Trove classifier and also tests GitHub Actions on `3.9-dev` (already tested on `3.9-dev` on Travis CI). These can be flipped to 3.9 when that's available.

So should be safe to declare support already.

Also some config cleanup and send coverage from GHA to Codecov.