### PR TITLE
CI: Only run deploy stage for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ cache:
   pip: true
   directories:
   - "$HOME/.cache/pre-commit"
-# Supported CPython versions:
-# https://en.wikipedia.org/wiki/CPython#Version_history
 python:
   - 2.7
   - 3.5
@@ -20,8 +18,8 @@ jobs:
   fast_finish: true
   include:
     - stage: deploy
-      env:
-      python: 3.7
+      if: tag IS present
+      python: 3.8
       script: skip
       deploy:
         provider: pypi
@@ -33,6 +31,5 @@ jobs:
         on:
           tags: true
           repo: jazzband/prettytable
-          python: 3.8
 after_success:
 - codecov


### PR DESCRIPTION
`deploy.on` only applies to the deploy task. A conditional at the job level is needed to skip the job/stage.

> `on:` is only valid for, and located under, the `deploy:` clause. And it only sets a condition for a specific deployment in the [deploy phase ](https://docs.travis-ci.com/user/job-lifecycle/#deploying-your-code), not for the entire job.
>
> If you need to run an entire job conditionally, use `if:` as per [Conditional Builds, Stages and Jobs - Travis CI ](https://docs.travis-ci.com/user/conditional-builds-stages-jobs#conditional-jobs).

https://travis-ci.community/t/deploy-running-with-deploy-on-tags-true-even-on-non-tag-builds/7511/5?u=hugovk

Docs:

* https://docs.travis-ci.com/user/conditional-builds-stages-jobs#conditional-jobs
* https://docs.travis-ci.com/user/conditions-v1

Also:

* Use newest Python 3.8 for deploy
* Remove blank `env:`
* Remove `deploy.on.python`, don't need to specify as deploy is in a stage, and not part of main matrix
* Remove redundant Wikipedia link

# Before

On my fork:

![image](https://user-images.githubusercontent.com/1324225/94929561-ed3df700-04cd-11eb-8b85-24c1da7e92b3.png)

https://travis-ci.org/github/hugovk/prettytable/builds/732251030

# After

![image](https://user-images.githubusercontent.com/1324225/94929595-f929b900-04cd-11eb-82e9-a93fdb83dfdc.png)

https://travis-ci.org/github/hugovk/prettytable/builds/732254811