### PR TITLE
Update release checklist to deploy from GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,20 +16,5 @@ script:
 - tox -v
 jobs:
   fast_finish: true
-  include:
-  - stage: deploy
-    if: tag IS present
-    python: 3.8
-    script: skip
-    deploy:
-      provider: pypi
-      user: jazzband
-      server: https://jazzband.co/projects/prettytable/upload
-      distributions: sdist bdist_wheel
-      password:
-        secure: sf1NovYo7asxb/z7TidjQA+Xjn8h/ubaFqE/rN/xmKHMBOjL0F5VQqQteHDxL8pSWYdCcv4tIsjsbXzsMrg4phdEhj0++4uMuZzNT3NR+gniRkH31U+csP+YtvKa7ssW/Pg3+MW95X4FxORuPkJlTuoinTQmGX+A7nPtpAAXVau7mq9SCXbJiOkSHAr/LbnvjUG8OgsWdCwUzEk4ssjSj9GBJ7+vjsVVI+Fap3C8PhHMj0W6u+H9kAGRUfe/2msW0g/oCJtiWHKDBucNhcAEWamxRZTk9KQmdHKDNwQmMSOkvEcEjDwgnWwlVNGlLMamG9/T3y2mYOo7IvFFStriqmTFq6W+afuFEIShPLgwgw3S0oiNze42LzjjTZKsVN/FwyL+LLQqJnTkVSv7Uuzwbp/YPH2+/hjonPq8Vf84ttLjf/tQktOqlR8JB9gQF77fFDoPRze80XmpxLa5IxYzhzNR6QF24l1+jj2VEURQWMZf8OXWLqExOF0DR1SuBH9pzIoSG+UhBhwVMB/a6GHxDqCCVU87fzISxKaZJz7hb+91c3DPksp0ritd5ASEP7UwM+HkbzsTiKOotIjp7oXKhbn6F/NfXCe4tIDLWd3xv16sD0My+1HGcKwVVxPa/ZoM8/tEDW+EeL4SY/f7gzA1YurBJ9WYYe/bY8L09fijLaM=
-      on:
-        tags: true
-        repo: jazzband/prettytable
 after_success:
 - codecov

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,11 @@ git tag -a 1.0.0 -m "Release 1.0.0"
 git push --tags
 ```
 
-* [ ] Once Travis CI has built and uploaded distributions, check files at
+* [ ] Create new GitHub release: https://github.com/jazzband/prettytable/releases/new
+  * Tag: Pick existing tag "1.0.0"
+
+* [ ] Once [GitHub Actions](https://github.com/jazzband/prettytable/actions?query=workflow%3ADeploy)
+      has built and uploaded distributions, check files at
       [Jazzband](https://jazzband.co/projects/prettytable) and release to
       [PyPI](https://pypi.org/pypi/prettytable)
 
@@ -29,6 +33,3 @@ pip uninstall -y prettytable
 pip install -U prettytable
 python3 -c "import prettytable; print(prettytable.__version__)"
 ```
-
-* [ ] Create new GitHub release: https://github.com/jazzband/prettytable/releases/new
-  * Tag: Pick existing tag "1.0.0"


### PR DESCRIPTION
We had problems getting Travis CI to deploy to the Jazzband package index (details in https://github.com/jazzband/prettytable/pull/57), but got it working from GHA pretty easily.

So don't try to deploy from Travis CI any more, and update the release checklist.

