### PR TITLE
Fix string comparison and deprecation warning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,33 +1,34 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.0.1
+    rev: v2.7.2
     hooks:
       - id: pyupgrade
 
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
         args: ["--target-version", "py27"]
 
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.5.4
+    hooks:
+      - id: isort
+
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
-    hooks:
-      - id: isort
-
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml

--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ To pass options changing the look of the table, use the `get_string()` method
 documented below:
 
 ```python
-print x.get_string()
+print(x.get_string())
 ```
 
 #### Stringing
 
 If you don't want to actually print your table in ASCII form but just get a
-string containing what _would_ be printed if you use `print x`, you can use
+string containing what _would_ be printed if you use `print(x)`, you can use
 the `get_string` method:
 
 ```python
@@ -177,19 +177,19 @@ mystring = x.get_string()
 ```
 
 This string is guaranteed to look exactly the same as what would be printed by
-doing `print x`.  You can now do all the usual things you can do with a
+doing `print(x)`.  You can now do all the usual things you can do with a
 string, like write your table to a file or insert it into a GUI.
 
 #### Controlling which data gets displayed
 
-If you like, you can restrict the output of `print x` or `x.get_string` to
+If you like, you can restrict the output of `print(x)` or `x.get_string` to
 only the fields or rows you like.
 
 The `fields` argument to these methods takes a list of field names to be
 printed:
 
 ```python
-print x.get_string(fields=["City name", "Population"])
+print(x.get_string(fields=["City name", "Population"]))
 ```
 
 gives:
@@ -215,7 +215,7 @@ is row 0, so the second is row 1) and set `end` to 4 (the index of the 4th row,
 plus 1):
 
 ```python
-print x.get_string(start=1,end=4)
+print(x.get_string(start=1,end=4))
 ```
 
 prints:
@@ -242,7 +242,7 @@ a one character string to the `align` attribute.  The allowed strings are "l",
 
 ```python
 x.align = "r"
-print x
+print(x)
 ```
 
 gives:
@@ -272,7 +272,7 @@ x.align["City name"] = "l"
 x.align["Area"] = "c"
 x.align["Population"] = "r"
 x.align["Annual Rainfall"] = "c"
-print x
+print(x)
 ```
 
 gives:
@@ -301,7 +301,7 @@ For example, to print the example table we built earlier of Australian capital
 city data, so that the most populated city comes last, we can do this:
 
 ```python
-print x.get_string(sortby="Population")
+print(x.get_string(sortby="Population"))
 ```
 
 to get
@@ -328,9 +328,9 @@ the setting long term like this:
 
 ```python
 x.sortby = "Population"
-print x
-print x
-print x
+print(x)
+print(x)
+print(x)
 ```
 
 All three tables printed by this code will be sorted by population (you could
@@ -368,7 +368,7 @@ which works nicely with Microsoft Word's "Convert to table" feature:
 ```python
 from prettytable import MSWORD_FRIENDLY
 x.set_style(MSWORD_FRIENDLY)
-print x
+print(x)
 ```
 
 In addition to `MSWORD_FRIENDLY` there are currently two other in-built styles
@@ -411,9 +411,9 @@ The options are these:
   * `vrules` - Controls printing of vertical rules between columns.  Allowed
     values: FRAME, ALL, NONE.
   * `int_format` - A string which controls the way integer data is printed.
-    This works like: print "%<int_format>d" % data
+    This works like: `print("%<int_format>d" % data)`
   * `float_format` - A string which controls the way floating point data is
-     printed.  This works like: print "%<float_format>f" % data
+     printed.  This works like: `print("%<float_format>f" % data)`
   * `padding_width` - Number of spaces on either side of column data (only used
     if left and right paddings are None).
   * `left_padding_width` - Number of spaces on left hand side of column data.
@@ -435,9 +435,9 @@ attributes.  If you never want your tables to have borders you can do this:
 
 ```python
 x.border = False
-print x
-print x
-print x
+print(x)
+print(x)
+print(x)
 ```
 
 Neither of the 3 tables printed by this will have borders, even if you do
@@ -473,9 +473,9 @@ in the previous section, you can make changes that last for just one
 "normal" tables with one borderless table between them, you could do this:
 
 ```python
-print x
-print x.get_string(border=False)
-print x
+print(x)
+print(x.get_string(border=False))
+print(x)
 ```
 
 ### Displaying your table in JSON

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ x.sortby = None
 If you want to specify a custom sorting function, you can use the `sort_key`
 keyword argument.  Pass this a function which accepts two lists of values
 and returns a negative or positive value depending on whether the first list
-should appeare before or after the second one.  If your table has n columns,
+should appear before or after the second one.  If your table has n columns,
 each list will have n+1 elements.  Each list corresponds to one row of the
 table.  The first element will be whatever data is in the relevant row, in
 the column specified by the `sort_by` argument.  The remaining n elements
@@ -441,7 +441,7 @@ print x
 ```
 
 Neither of the 3 tables printed by this will have borders, even if you do
-things like add extra rows inbetween them.  The lack of borders will last until
+things like add extra rows in between them.  The lack of borders will last until
 you do:
 
 ```python
@@ -520,7 +520,7 @@ quite simple.  It looks like this:
 </table>
 ```
 
-If you like, you can ask PrettyTable to do its best to mimick the style options
+If you like, you can ask PrettyTable to do its best to mimic the style options
 that your table has set using inline CSS.  This is done by giving a
 `format=True` keyword argument to `get_html_string` method.  Note that if you
 _always_ want to print formatted HTML you can do:

--- a/prettytable.py
+++ b/prettytable.py
@@ -43,7 +43,6 @@ import sys
 import textwrap
 
 import pkg_resources
-
 import wcwidth
 
 __version__ = pkg_resources.get_distribution(__name__).version
@@ -54,15 +53,16 @@ if py3k:
     itermap = map
     iterzip = zip
     uni_chr = chr
-    from html.parser import HTMLParser
     from html import escape
+    from html.parser import HTMLParser
     from io import StringIO
 else:
     itermap = itertools.imap
     iterzip = itertools.izip
     uni_chr = unichr  # noqa: F821
-    from HTMLParser import HTMLParser
     from cgi import escape
+
+    from HTMLParser import HTMLParser
     from StringIO import StringIO
 
 # hrule styles
@@ -1312,7 +1312,7 @@ class PrettyTable(object):
         sort_key - sorting key function, applied to data points before sorting
         reversesort - True or False to sort in descending or ascending order
         print empty - if True, stringify just the header for an empty table,
-            if False return an empty string """
+            if False return an empty string"""
 
         options = self._get_options(kwargs)
 
@@ -1426,7 +1426,7 @@ class PrettyTable(object):
                 bits.append(options["vertical_char"])
             else:
                 bits.append(" ")
-        for field, width, in zip(self._field_names, self._widths):
+        for (field, width) in zip(self._field_names, self._widths):
             if options["fields"] and field not in options["fields"]:
                 continue
             if self._header_style == "cap":
@@ -1461,7 +1461,7 @@ class PrettyTable(object):
 
     def _stringify_row(self, row, options):
 
-        for index, field, value, width, in zip(
+        for (index, field, value, width) in zip(
             range(0, len(row)), self._field_names, row, self._widths
         ):
             # Enforce max widths
@@ -1491,7 +1491,7 @@ class PrettyTable(object):
                 else:
                     bits[y].append(" ")
 
-        for field, value, width, in zip(self._field_names, row, self._widths):
+        for (field, value, width) in zip(self._field_names, row, self._widths):
 
             valign = self._valign[field]
             lines = value.split("\n")

--- a/prettytable.py
+++ b/prettytable.py
@@ -1495,18 +1495,18 @@ class PrettyTable(object):
 
             valign = self._valign[field]
             lines = value.split("\n")
-            dHeight = row_height - len(lines)
-            if dHeight:
+            d_height = row_height - len(lines)
+            if d_height:
                 if valign == "m":
                     lines = (
-                        [""] * int(dHeight / 2)
+                        [""] * int(d_height / 2)
                         + lines
-                        + [""] * (dHeight - int(dHeight / 2))
+                        + [""] * (d_height - int(d_height / 2))
                     )
                 elif valign == "b":
-                    lines = [""] * dHeight + lines
+                    lines = [""] * d_height + lines
                 else:
-                    lines = lines + [""] * dHeight
+                    lines = lines + [""] * d_height
 
             y = 0
             for line in lines:

--- a/prettytable.py
+++ b/prettytable.py
@@ -86,7 +86,7 @@ def _get_size(text):
     lines = text.split("\n")
     height = len(lines)
     width = max(_str_block_width(line) for line in lines)
-    return (width, height)
+    return width, height
 
 
 class PrettyTable(object):

--- a/prettytable.py
+++ b/prettytable.py
@@ -304,7 +304,7 @@ class PrettyTable(object):
     # persistent settings
 
     def _validate_option(self, option, val):
-        if option in ("field_names"):
+        if option == "field_names":
             self._validate_field_names(val)
         elif option in (
             "start",
@@ -319,15 +319,15 @@ class PrettyTable(object):
             "format",
         ):
             self._validate_nonnegative_int(option, val)
-        elif option in ("sortby"):
+        elif option == "sortby":
             self._validate_field_name(option, val)
-        elif option in ("sort_key"):
+        elif option == "sort_key":
             self._validate_function(option, val)
-        elif option in ("hrules"):
+        elif option == "hrules":
             self._validate_hrules(option, val)
-        elif option in ("vrules"):
+        elif option == "vrules":
             self._validate_vrules(option, val)
-        elif option in ("fields"):
+        elif option == "fields":
             self._validate_all_field_names(option, val)
         elif option in (
             "header",
@@ -338,15 +338,15 @@ class PrettyTable(object):
             "oldsortslice",
         ):
             self._validate_true_or_false(option, val)
-        elif option in ("header_style"):
+        elif option == "header_style":
             self._validate_header_style(val)
-        elif option in ("int_format"):
+        elif option == "int_format":
             self._validate_int_format(option, val)
-        elif option in ("float_format"):
+        elif option == "float_format":
             self._validate_float_format(option, val)
         elif option in ("vertical_char", "horizontal_char", "junction_char"):
             self._validate_single_char(option, val)
-        elif option in ("attributes"):
+        elif option == "attributes":
             self._validate_attributes(option, val)
 
     def _validate_field_names(self, val):

--- a/prettytable.py
+++ b/prettytable.py
@@ -1979,7 +1979,7 @@ def main():
     x.add_row(["Perth", 5386, 1554769, 869.4])
     print(x)
 
-    print
+    print()
 
     print("Generated using constructor arguments:")
 

--- a/prettytable.py
+++ b/prettytable.py
@@ -860,7 +860,7 @@ class PrettyTable(object):
 
     @property
     def vertical_char(self):
-        """The charcter used when printing table borders to draw vertical lines
+        """The character used when printing table borders to draw vertical lines
 
         Arguments:
 
@@ -875,7 +875,7 @@ class PrettyTable(object):
 
     @property
     def horizontal_char(self):
-        """The charcter used when printing table borders to draw horizontal lines
+        """The character used when printing table borders to draw horizontal lines
 
         Arguments:
 
@@ -890,7 +890,7 @@ class PrettyTable(object):
 
     @property
     def junction_char(self):
-        """The charcter used when printing table borders to draw line junctions
+        """The character used when printing table borders to draw line junctions
 
         Arguments:
 
@@ -1083,7 +1083,7 @@ class PrettyTable(object):
 
         if row_index > len(self._rows) - 1:
             raise Exception(
-                "Cant delete row at index %d, table only has %d rows!"
+                "Can't delete row at index %d, table only has %d rows!"
                 % (row_index, len(self._rows))
             )
         del self._rows[row_index]
@@ -1128,7 +1128,7 @@ class PrettyTable(object):
 
         if fieldname not in self._field_names:
             raise Exception(
-                "Cant delete column %r which is not a field name of this table."
+                "Can't delete column %r which is not a field name of this table."
                 " Field names are: %s"
                 % (fieldname, ", ".join(map(repr, self._field_names)))
             )

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -724,13 +724,13 @@ class CsvOutputTests(unittest.TestCase):
         t.add_row(["value 1", "value2", "value3"])
         t.add_row(["value 4", "value5", "value6"])
         t.add_row(["value 7", "value8", "value9"])
-        self.assertEquals(
+        self.assertEqual(
             t.get_csv_string(delimiter="\t", header=False),
             "value 1\tvalue2\tvalue3\r\n"
             "value 4\tvalue5\tvalue6\r\n"
             "value 7\tvalue8\tvalue9\r\n",
         )
-        self.assertEquals(
+        self.assertEqual(
             t.get_csv_string(),
             "Field 1,Field 2,Field 3\r\n"
             "value 1,value2,value3\r\n"

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -32,7 +32,7 @@ else:
     import StringIO
 
 
-class BuildEquivelanceTest(unittest.TestCase):
+class BuildEquivalenceTest(unittest.TestCase):
     """Make sure that building a table row-by-row and column-by-column yield the same
     results"""
 
@@ -773,7 +773,7 @@ if _have_sqlite:
             self.cur.execute("SELECT * FROM cities")
             self.x = from_db_cursor(self.cur)
 
-        def testNonSelectCurosr(self):
+        def testNonSelectCursor(self):
             self.cur.execute(
                 'INSERT INTO cities VALUES ("Adelaide", 1295, 1158259, 600.5)'
             )
@@ -810,7 +810,7 @@ class PrintEnglishTest(CityDataTest):
         print(self.x)
 
 
-class PrintJapanestTest(unittest.TestCase):
+class PrintJapaneseTest(unittest.TestCase):
     def setUp(self):
 
         self.x = PrettyTable(["Kanji", "Hiragana", "English"])


### PR DESCRIPTION
* Fix string comparison bug (see below)
* Fix DeprecationWarning: Please use assertEqual instead
* PEP 8: Variable in function should be lowercase
* Remove redundant parentheses
* pre-commit autoupdate

---

```python
option in ("vrules")
```

is the same as:

```python
option in "vrules"  # string in string
```

when we really wanted:

```python
option in ("vrules",)  # string in tuple
```

but let's use more explicit and clearer:

```python
option == "vrules"  # string == string
```
