### PR TITLE
Add setuptools as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     license="BSD (3 clause)",
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
-    install_requires=["wcwidth"],
+    install_requires=["setuptools", "wcwidth"],
     extras_require={"tests": ["pytest", "pytest-cov"]},
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[


### PR DESCRIPTION
`pkg_resources` is imported (to get the version number), which is provided by setuptools