### PR TITLE
Update tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
       - id: black
         args: ["--target-version", "py27"]
 
-
   - repo: https://github.com/PyCQA/isort
     rev: 5.5.4
     hooks:
@@ -32,3 +31,9 @@ repos:
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
+
+  - repo: https://github.com/prettier/prettier
+    rev: 2.1.2
+    hooks:
+      - id: prettier
+        args: [--prose-wrap=always, --print-width=88]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
       - id: check-merge-conflict
       - id: check-yaml
 
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 0.4.0
+    hooks:
+      - id: tox-ini-fmt
+
   - repo: https://github.com/prettier/prettier
     rev: 2.1.2
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,23 @@ language: python
 cache:
   pip: true
   directories:
-  - "$HOME/.cache/pre-commit"
+    - "$HOME/.cache/pre-commit"
+
 python:
-- 2.7
-- 3.5
-- 3.6
-- 3.7
-- 3.8
-- 3.9-dev
-install:
-- travis_retry pip install tox-travis codecov
-script:
-- tox -v
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9-dev
+
 jobs:
   fast_finish: true
+
+install:
+  - travis_retry pip install tox-travis codecov
+script:
+  - tox -v
+
 after_success:
-- codecov
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
     - "$HOME/.cache/pre-commit"
 
 python:
-  - 2.7
-  - 3.5
   - 3.6
   - 3.7
   - 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,170 +1,150 @@
 # PrettyTable 1.0 - October 4, 2020
 
-* Dropped support for EOL Python 2.4-2.6 and 3.0-3.4.
-* Added support for Python 3.5-3.9.
-* Added `del_column(field_name)`.
-* Added `get_csv_string` with `delimiter` option (comma or tab) and optional `header`.
-* Use wcwidth for better wide char support.
-* New `paginate` method can be used to produce strings suitable
-  for piping to lp/lpr.
-* `from_html` now handles HTML tables with colspan, rather than
-  choking on them.
-* Added `min_width`, `min_table_width` and `max_table_width`
-  attribute/options for better control of table sizing.
-* Added "title" attribute/option for table titles.
-* When slice syntax is used to create a new sub-table out of an
-  existing table, the rows are sorted before, not after, the slicing.
-  The old behaviour (slice then sort) can be achieved by setting
-  `oldsortslice=True`.
-* The `from_csv` table factory now accepts CSV format parameters as
-  keyword arguments (e.g. `delimiter`, `doublequote`, `escapechar`, etc.)
-* Added 0x000f to the list of special characters with width 0, to fix
-  problems with coloured strings produced by the Blessings library.
-* Fixed constructor argument `float_format` to work as intended.
-* Removed `print_html()` from README.
-* Added `from_json` and `get_json_string` to PrettyTable.
-* Fixed `PLAIN_COLUMN` to `PLAIN_COLUMNS` in README.
-* Added Markdown and Org mode styles.
+- Dropped support for EOL Python 2.4-2.6 and 3.0-3.4.
+- Added support for Python 3.5-3.9.
+- Added `del_column(field_name)`.
+- Added `get_csv_string` with `delimiter` option (comma or tab) and optional `header`.
+- Use wcwidth for better wide char support.
+- New `paginate` method can be used to produce strings suitable for piping to lp/lpr.
+- `from_html` now handles HTML tables with colspan, rather than choking on them.
+- Added `min_width`, `min_table_width` and `max_table_width` attribute/options for
+  better control of table sizing.
+- Added "title" attribute/option for table titles.
+- When slice syntax is used to create a new sub-table out of an existing table, the rows
+  are sorted before, not after, the slicing. The old behaviour (slice then sort) can be
+  achieved by setting `oldsortslice=True`.
+- The `from_csv` table factory now accepts CSV format parameters as keyword arguments
+  (e.g. `delimiter`, `doublequote`, `escapechar`, etc.)
+- Added 0x000f to the list of special characters with width 0, to fix problems with
+  coloured strings produced by the Blessings library.
+- Fixed constructor argument `float_format` to work as intended.
+- Removed `print_html()` from README.
+- Added `from_json` and `get_json_string` to PrettyTable.
+- Fixed `PLAIN_COLUMN` to `PLAIN_COLUMNS` in README.
+- Added Markdown and Org mode styles.
 
 # PrettyTable 0.7 - Feb 17, 2013
 
-* Improved Python 2 and 3 compatibility (2.4-3.2).
-* Improved support for non-Latin characters.  Table widths should
-  now be calculated correctly for tables with e.g. Japanese text.
-* Table contents can now be read in from a .csv file
-* Table contents can now be read in from a DB-API compatible cursor
-* Table contents can now be read in from a string containing a
-  HTML table (thanks to Christoph Robbert for submitting this patch!)
-* New `valign` attribute controls vertical alignment of text when
-  some cells in a row have multiple lines of text and others don't.
-  (thanks to Google Code user maartendb for submitting this patch!)
-* `hrules` attribute can now be set to HEADER, which draws a rule only
-  under the header row
-* New `vrules` attribute controls drawing of vertical rules and can
-  be set to `FRAME`, `ALL` or `NONE`
-* New `header_style` attribute controls formatting of text in table
-  headers and can be set to `cap`, `title`, `upper`, `lower` or `None`
-* Fixed a simple bug regarding validation of `max_width` (thanks to
-  Anthony Toole for pointing out this bug and providing a patch).
-* Fixed a simple bug regarding initialisation of `int_format` value
-  for new tables (thanks to Ingo Schmiegel for pointing out this
-  bug!)
-* Fixed a bug regarding some constructor keywords, such as `border`,
-  being ignored (thanks to Google Code user antonio.s.messina for
-  reporting this bug).
+- Improved Python 2 and 3 compatibility (2.4-3.2).
+- Improved support for non-Latin characters. Table widths should now be calculated
+  correctly for tables with e.g. Japanese text.
+- Table contents can now be read in from a .csv file
+- Table contents can now be read in from a DB-API compatible cursor
+- Table contents can now be read in from a string containing a HTML table (thanks to
+  Christoph Robbert for submitting this patch!)
+- New `valign` attribute controls vertical alignment of text when some cells in a row
+  have multiple lines of text and others don't. (thanks to Google Code user maartendb
+  for submitting this patch!)
+- `hrules` attribute can now be set to HEADER, which draws a rule only under the header
+  row
+- New `vrules` attribute controls drawing of vertical rules and can be set to `FRAME`,
+  `ALL` or `NONE`
+- New `header_style` attribute controls formatting of text in table headers and can be
+  set to `cap`, `title`, `upper`, `lower` or `None`
+- Fixed a simple bug regarding validation of `max_width` (thanks to Anthony Toole for
+  pointing out this bug and providing a patch).
+- Fixed a simple bug regarding initialisation of `int_format` value for new tables
+  (thanks to Ingo Schmiegel for pointing out this bug!)
+- Fixed a bug regarding some constructor keywords, such as `border`, being ignored
+  (thanks to Google Code user antonio.s.messina for reporting this bug).
 
 # PrettyTable 0.6 - May 5, 2012
 
-* Code is now simultaneously compatible with Python 2 and 3
-* Replaced all setter methods with managed attributes
-* All styling options can now be set persistently as managed attributes
-* Added `add_style` method to make setting style options easily
-* Added `del_row`, `clear_rows` and `clear` methods to facilitate
-  removal of data from table.
-* Added `copy` method to facilitate cloning of a table.
-* Removed caching functionality, which added complexity and fragility
-  for relatively little gain
-* Removed methods that just printed strings produced by `get_string` and
+- Code is now simultaneously compatible with Python 2 and 3
+- Replaced all setter methods with managed attributes
+- All styling options can now be set persistently as managed attributes
+- Added `add_style` method to make setting style options easily
+- Added `del_row`, `clear_rows` and `clear` methods to facilitate removal of data from
+  table.
+- Added `copy` method to facilitate cloning of a table.
+- Removed caching functionality, which added complexity and fragility for relatively
+  little gain
+- Removed methods that just printed strings produced by `get_string` and
   `get_html_string` - just use inbuilt print!
-* Improved unicode support (thanks to Google Code user ru.w31rd0 for
-  patch!)
-* Added support for decimal and floating point number formatting
-  support (thanks to Google Code user willfurnass for the suggestion!)
-* Added support for using a custom key sorting methods (thanks to
-  Google Code user amannijhawan for the suggestion!)
-* Added support for line breaks in data (suggested and implemented by
-  Klein Stephane)
-* Added support for max column widths (thanks to Tibor Arpas for the
-  suggestion!)
-* Fixed table slicing
-* Fixed bug where closing `<tr/>` tags in HTML tables were not printed
-  (thanks to Google Code user kehander for reporting this bug!)
-* Fixed HTML table sorting bug (thanks to Google Code user dougbeal
-  for reporting this bug!)
-* Fixed bug whereby changing field_names did not recompute widths
-  (thanks to Google Code user denilsonsa for reporting this bug!)
+- Improved unicode support (thanks to Google Code user ru.w31rd0 for patch!)
+- Added support for decimal and floating point number formatting support (thanks to
+  Google Code user willfurnass for the suggestion!)
+- Added support for using a custom key sorting methods (thanks to Google Code user
+  amannijhawan for the suggestion!)
+- Added support for line breaks in data (suggested and implemented by Klein Stephane)
+- Added support for max column widths (thanks to Tibor Arpas for the suggestion!)
+- Fixed table slicing
+- Fixed bug where closing `<tr/>` tags in HTML tables were not printed (thanks to Google
+  Code user kehander for reporting this bug!)
+- Fixed HTML table sorting bug (thanks to Google Code user dougbeal for reporting this
+  bug!)
+- Fixed bug whereby changing field_names did not recompute widths (thanks to Google Code
+  user denilsonsa for reporting this bug!)
 
 # PrettyTable 0.5 - May 26, 2009
 
-* Fixed a bug whereby printing with `headers=False` and `border=False` 
-  would introduce an extraneous newline. Thanks to Alexander Lamaison 
-  for reporting this bug. 
-* When printing with `headers=False`, column widths will now be reduced 
-  as appropriate in columns where the field name is wider than the 
-  data. Thanks to Alexander Lamaison for suggesting this behaviour. 
-* Support for Unicode has improved. Thanks to Chris Clark for 
-  submitting this improvement. 
-* The value of the `border` argument now correctly controls the 
-  presence of a border when printing HTML tables with print_html or 
-  `get_html_string`, instead of being incorrectly ignored. Thanks to 
-  Chris Clark for fixing this. 
-* The `print_html` and `get_html_string` methods now accept an 
-  `attributes` argument which is a dictionary of name/value pairs to be 
-  placed inside the `<table>` tag (so you can, e.g. set `class`, `name` or `id` 
-  values in order to style your table with CSS). Thanks to Chris Clark 
-  for submitting this feature. 
-* The print_html and get_html_string methods now, by default, do their 
-  best to match the various formatting options in their HTML output. 
-  They use inline CSS to adjust the alignment of data in columns, the 
-  padding widths of columns and in some cases the border settings. You 
-  can give either method a `format=False` attribute to turn this 
-  behaviour off if you want to do your own styling. With `format=False` 
-  the methods print a "bare bones" table, similar to the default 
-  behaviour in 0.4.
+- Fixed a bug whereby printing with `headers=False` and `border=False` would introduce
+  an extraneous newline. Thanks to Alexander Lamaison for reporting this bug.
+- When printing with `headers=False`, column widths will now be reduced as appropriate
+  in columns where the field name is wider than the data. Thanks to Alexander Lamaison
+  for suggesting this behaviour.
+- Support for Unicode has improved. Thanks to Chris Clark for submitting this
+  improvement.
+- The value of the `border` argument now correctly controls the presence of a border
+  when printing HTML tables with print_html or `get_html_string`, instead of being
+  incorrectly ignored. Thanks to Chris Clark for fixing this.
+- The `print_html` and `get_html_string` methods now accept an `attributes` argument
+  which is a dictionary of name/value pairs to be placed inside the `<table>` tag (so
+  you can, e.g. set `class`, `name` or `id` values in order to style your table with
+  CSS). Thanks to Chris Clark for submitting this feature.
+- The print_html and get_html_string methods now, by default, do their best to match the
+  various formatting options in their HTML output. They use inline CSS to adjust the
+  alignment of data in columns, the padding widths of columns and in some cases the
+  border settings. You can give either method a `format=False` attribute to turn this
+  behaviour off if you want to do your own styling. With `format=False` the methods
+  print a "bare bones" table, similar to the default behaviour in 0.4.
 
 # PrettyTable 0.4 - May 13, 2009
 
-* Added `add_column` method to enable building tables up column-by-column.
-* Added `print_HTML` and `get_HTML_string` methods to enable HTML table
-  production.
-* Added `set_border_chars` method to enable control over characters used to
-  draw the table border.
-* Added `set_left_padding` and `set_right_padding` methods to allow
-  independent padding control for both sides of a column.
-* Added `sortby` option to enable column sorting.
-* Added `header` option to enable switching off field name printing at top of
-  table.
-* Modified `hrules` option to enable greater control over presence of
-  horizontal lines.
-* Added `border` option to enable switching off all line printing.
+- Added `add_column` method to enable building tables up column-by-column.
+- Added `print_HTML` and `get_HTML_string` methods to enable HTML table production.
+- Added `set_border_chars` method to enable control over characters used to draw the
+  table border.
+- Added `set_left_padding` and `set_right_padding` methods to allow independent padding
+  control for both sides of a column.
+- Added `sortby` option to enable column sorting.
+- Added `header` option to enable switching off field name printing at top of table.
+- Modified `hrules` option to enable greater control over presence of horizontal lines.
+- Added `border` option to enable switching off all line printing.
 
-Thanks to Tim Cera, Chris Clark, Alexander Lamaison for suggesting and helping
-to test many of the new features in this release.
+Thanks to Tim Cera, Chris Clark, Alexander Lamaison for suggesting and helping to test
+many of the new features in this release.
 
 # PrettyTable 0.3 - May 01, 2009
 
-* Added `padding_width` option to control the number of spaces between the
-  vertical line rules at the edges of a column and its content.  This can be
-  set as a keyword argument to the constructor or after instantiation using
-  the `set_padding_width` method.  The value is set to `1` by default.  If your
-  table is too wide for a small screen with this value, setting it to `0` might
-  help you squeeze it in.
+- Added `padding_width` option to control the number of spaces between the vertical line
+  rules at the edges of a column and its content. This can be set as a keyword argument
+  to the constructor or after instantiation using the `set_padding_width` method. The
+  value is set to `1` by default. If your table is too wide for a small screen with this
+  value, setting it to `0` might help you squeeze it in.
 
-Thanks to Chris Clark for contributing a patch against 0.2.1 to add this
-feature!
+Thanks to Chris Clark for contributing a patch against 0.2.1 to add this feature!
 
 # PrettyTable 0.2.1 - April 29, 2009
 
-* Caching no longer breaks when using the `printt(fields=[...])` syntax.  The
-  list of fields was not hashable and hence could not be used as a dictionary
-  key.  I fixed this using the output of the `cPickle` module's `dumps`
-  function as the dictionary key instead.
-* Horizontal lines are now the appropriate length when the above syntax is
-  used.
+- Caching no longer breaks when using the `printt(fields=[...])` syntax. The list of
+  fields was not hashable and hence could not be used as a dictionary key. I fixed this
+  using the output of the `cPickle` module's `dumps` function as the dictionary key
+  instead.
+- Horizontal lines are now the appropriate length when the above syntax is used.
 
 Thanks to Julien Koesten for reporting these bugs and testing the fixes almost
 immediately after the release of 0.2!
 
 # PrettyTable 0.2 - April 29, 2009
 
-* Added `get_string` method.
-* Added `__str__` method (which just calls `get_string`) to enable nice
- `print x` syntax. 
-* Can now pass field names as a constructor argument.
-* Return values of `get_string` are cached in a dictionary that is only
-  cleared after a call to `add_row` or something else which invalidates the
-  cache.
+- Added `get_string` method.
+- Added `__str__` method (which just calls `get_string`) to enable nice `print x`
+  syntax.
+- Can now pass field names as a constructor argument.
+- Return values of `get_string` are cached in a dictionary that is only cleared after a
+  call to `add_row` or something else which invalidates the cache.
 
 # PrettyTable 0.1 - February 26, 2009
 
-* Original release
+- Original release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 [![Jazzband](https://jazzband.co/static/img/jazzband.svg)](https://jazzband.co/)
 
-This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to
-abide by the [Contributor Code of Conduct](https://jazzband.co/docs/conduct) and
-follow the [guidelines](https://jazzband.co/docs/guidelines).
+This is a [Jazzband](https://jazzband.co/) project. By contributing you agree to abide
+by the [Contributor Code of Conduct](https://jazzband.co/docs/conduct) and follow the
+[guidelines](https://jazzband.co/docs/guidelines).

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 
 Install via pip:
 
-    pip install -U prettytable
+    python -m pip install -U prettytable
 
 Install latest development version:
 
-    pip install -U git+https://github.com/jazzband/prettytable
+    python -m pip install -U git+https://github.com/jazzband/prettytable
 
 Or from `requirements.txt`:
 
@@ -582,6 +582,6 @@ new_table = old_table[0:5]
 After editing files, use the [black](https://github.com/psf/black) linter to auto-format changed lines.
 
 ```sh
-pip install black
+python -m pip install black
 black prettytable*.py
 ```

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ from prettytable import PrettyTable
 x = PrettyTable()
 ```
 
-and you want to put some data into it.  You have a few options.
+and you want to put some data into it. You have a few options.
 
 #### Row by row
 
-You can add data one row at a time.  To do this you can set the field names
-first using the `field_names` attribute, and then add the rows one at a time
-using the `add_row` method:
+You can add data one row at a time. To do this you can set the field names first using
+the `field_names` attribute, and then add the rows one at a time using the `add_row`
+method:
 
 ```python
 x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
@@ -55,10 +55,9 @@ x.add_row(["Perth", 5386, 1554769, 869.4])
 
 #### Column by column
 
-You can add data one column at a time as well.  To do this you use the
-`add_column` method, which takes two arguments - a string which is the name for
-the field the column you are adding corresponds to, and a list or tuple which
-contains the column data:
+You can add data one column at a time as well. To do this you use the `add_column`
+method, which takes two arguments - a string which is the name for the field the column
+you are adding corresponds to, and a list or tuple which contains the column data:
 
 ```python
 x.add_column("City name",
@@ -72,15 +71,15 @@ x.add_column("Annual Rainfall",[600.5, 1146.4, 1714.7, 619.5, 1214.8, 646.9,
 
 #### Mixing and matching
 
-If you really want to, you can even mix and match `add_row` and `add_column`
-and build some of your table in one way and some of it in the other. Tables built
-this way are kind of confusing for other people to read, though, so don't do
-this unless you have a good reason.
+If you really want to, you can even mix and match `add_row` and `add_column` and build
+some of your table in one way and some of it in the other. Tables built this way are
+kind of confusing for other people to read, though, so don't do this unless you have a
+good reason.
 
 #### Importing data from a CSV file
 
-If you have your table data in a comma-separated values file (.csv), you can
-read this data into a PrettyTable like this:
+If you have your table data in a comma-separated values file (.csv), you can read this
+data into a PrettyTable like this:
 
 ```python
 from prettytable import from_csv
@@ -109,19 +108,19 @@ mytable = from_cursor(cursor)
 There are three ways to get data out of a PrettyTable, in increasing order of
 completeness:
 
-  * The `del_row` method takes an integer index of a single row to delete.
-  * The `del_column` method takes a field name of a single column to delete.
-  * The `clear_rows` method takes no arguments and deletes all the rows in the
-table - but keeps the field names as they were so you that you can repopulate
-it with the same kind of data.
-  * The `clear` method takes no arguments and deletes all rows and all field
-names.  It's not quite the same as creating a fresh table instance, though -
-style related settings, discussed later, are maintained.
+- The `del_row` method takes an integer index of a single row to delete.
+- The `del_column` method takes a field name of a single column to delete.
+- The `clear_rows` method takes no arguments and deletes all the rows in the table - but
+  keeps the field names as they were so you that you can repopulate it with the same
+  kind of data.
+- The `clear` method takes no arguments and deletes all rows and all field names. It's
+  not quite the same as creating a fresh table instance, though - style related
+  settings, discussed later, are maintained.
 
 ### Displaying your table in ASCII form
 
-PrettyTable's main goal is to let you print tables in an attractive ASCII form,
-like this:
+PrettyTable's main goal is to let you print tables in an attractive ASCII form, like
+this:
 
 ```
 +-----------+------+------------+-----------------+
@@ -137,8 +136,7 @@ like this:
 +-----------+------+------------+-----------------+
 ```
 
-You can print tables like this to `stdout` or get string representations of
-them.
+You can print tables like this to `stdout` or get string representations of them.
 
 #### Printing
 
@@ -158,8 +156,8 @@ in Python 3.x.
 
 The old `x.printt()` method from versions 0.5 and earlier has been removed.
 
-To pass options changing the look of the table, use the `get_string()` method
-documented below:
+To pass options changing the look of the table, use the `get_string()` method documented
+below:
 
 ```python
 print(x.get_string())
@@ -167,25 +165,24 @@ print(x.get_string())
 
 #### Stringing
 
-If you don't want to actually print your table in ASCII form but just get a
-string containing what _would_ be printed if you use `print(x)`, you can use
-the `get_string` method:
+If you don't want to actually print your table in ASCII form but just get a string
+containing what _would_ be printed if you use `print(x)`, you can use the `get_string`
+method:
 
 ```python
 mystring = x.get_string()
 ```
 
-This string is guaranteed to look exactly the same as what would be printed by
-doing `print(x)`.  You can now do all the usual things you can do with a
-string, like write your table to a file or insert it into a GUI.
+This string is guaranteed to look exactly the same as what would be printed by doing
+`print(x)`. You can now do all the usual things you can do with a string, like write
+your table to a file or insert it into a GUI.
 
 #### Controlling which data gets displayed
 
-If you like, you can restrict the output of `print(x)` or `x.get_string` to
-only the fields or rows you like.
+If you like, you can restrict the output of `print(x)` or `x.get_string` to only the
+fields or rows you like.
 
-The `fields` argument to these methods takes a list of field names to be
-printed:
+The `fields` argument to these methods takes a list of field names to be printed:
 
 ```python
 print(x.get_string(fields=["City name", "Population"]))
@@ -207,11 +204,10 @@ gives:
 +-----------+------------+
 ```
 
-The `start` and `end` arguments take the index of the first and last row to
-print respectively.  Note that the indexing works like Python list slicing - to
-print the 2nd, 3rd and 4th rows of the table, set `start` to 1 (the first row
-is row 0, so the second is row 1) and set `end` to 4 (the index of the 4th row,
-plus 1):
+The `start` and `end` arguments take the index of the first and last row to print
+respectively. Note that the indexing works like Python list slicing - to print the 2nd,
+3rd and 4th rows of the table, set `start` to 1 (the first row is row 0, so the second
+is row 1) and set `end` to 4 (the index of the 4th row, plus 1):
 
 ```python
 print(x.get_string(start=1, end=4))
@@ -235,9 +231,9 @@ By default, all columns in a table are centre aligned.
 
 ##### All columns at once
 
-You can change the alignment of all the columns in a table at once by assigning
-a one character string to the `align` attribute.  The allowed strings are `"l"`,
-`"r"` and `"c"` for left, right and centre alignment, respectively:
+You can change the alignment of all the columns in a table at once by assigning a one
+character string to the `align` attribute. The allowed strings are `"l"`, `"r"` and
+`"c"` for left, right and centre alignment, respectively:
 
 ```python
 x.align = "r"
@@ -262,9 +258,8 @@ gives:
 
 ##### One column at a time
 
-You can also change the alignment of individual columns based on the
-corresponding field name by treating the `align` attribute as if it were a
-dictionary.
+You can also change the alignment of individual columns based on the corresponding field
+name by treating the `align` attribute as if it were a dictionary.
 
 ```python
 x.align["City name"] = "l"
@@ -292,12 +287,12 @@ gives:
 
 ##### Sorting your table by a field
 
-You can make sure that your ASCII tables are produced with the data sorted by
-one particular field by giving `get_string` a `sortby` keyword argument, which
- must be a string containing the name of one field.
+You can make sure that your ASCII tables are produced with the data sorted by one
+particular field by giving `get_string` a `sortby` keyword argument, which must be a
+string containing the name of one field.
 
-For example, to print the example table we built earlier of Australian capital
-city data, so that the most populated city comes last, we can do this:
+For example, to print the example table we built earlier of Australian capital city
+data, so that the most populated city comes last, we can do this:
 
 ```python
 print(x.get_string(sortby="Population"))
@@ -322,8 +317,8 @@ to get:
 If we want the most populated city to come _first_, we can also give a
 `reversesort=True` argument.
 
-If you _always_ want your tables to be sorted in a certain way, you can make
-the setting long-term like this:
+If you _always_ want your tables to be sorted in a certain way, you can make the setting
+long-term like this:
 
 ```python
 x.sortby = "Population"
@@ -332,37 +327,36 @@ print(x)
 print(x)
 ```
 
-All three tables printed by this code will be sorted by population (you could
-do `x.reversesort = True` as well, if you wanted).  The behaviour will persist
-until you turn it off:
+All three tables printed by this code will be sorted by population (you could do
+`x.reversesort = True` as well, if you wanted). The behaviour will persist until you
+turn it off:
 
 ```python
 x.sortby = None
 ```
 
-If you want to specify a custom sorting function, you can use the `sort_key`
-keyword argument.  Pass this a function which accepts two lists of values
-and returns a negative or positive value depending on whether the first list
-should appear before or after the second one.  If your table has n columns,
-each list will have n+1 elements.  Each list corresponds to one row of the
-table.  The first element will be whatever data is in the relevant row, in
-the column specified by the `sort_by` argument.  The remaining n elements
-are the data in each of the table's columns, in order, including a repeated
+If you want to specify a custom sorting function, you can use the `sort_key` keyword
+argument. Pass this a function which accepts two lists of values and returns a negative
+or positive value depending on whether the first list should appear before or after the
+second one. If your table has n columns, each list will have n+1 elements. Each list
+corresponds to one row of the table. The first element will be whatever data is in the
+relevant row, in the column specified by the `sort_by` argument. The remaining n
+elements are the data in each of the table's columns, in order, including a repeated
 instance of the data in the `sort_by` column.
 
 ### Changing the appearance of your table - the easy way
 
-By default, PrettyTable produces ASCII tables that look like the ones used in
-SQL database shells.  But if can print them in a variety of other formats as
-well. If the format you want to use is common, PrettyTable makes this
-easy for you to do using the `set_style` method.  If you want to produce an
-uncommon table, you'll have to do things slightly harder (see later).
+By default, PrettyTable produces ASCII tables that look like the ones used in SQL
+database shells. But if can print them in a variety of other formats as well. If the
+format you want to use is common, PrettyTable makes this easy for you to do using the
+`set_style` method. If you want to produce an uncommon table, you'll have to do things
+slightly harder (see later).
 
 #### Setting a table style
 
-You can set the style for your table using the `set_style` method before any
-calls to `print` or `get_string`.  Here's how to print a table in a format
-which works nicely with Microsoft Word's "Convert to table" feature:
+You can set the style for your table using the `set_style` method before any calls to
+`print` or `get_string`. Here's how to print a table in a format which works nicely with
+Microsoft Word's "Convert to table" feature:
 
 ```python
 from prettytable import MSWORD_FRIENDLY
@@ -370,67 +364,61 @@ x.set_style(MSWORD_FRIENDLY)
 print(x)
 ```
 
-In addition to `MSWORD_FRIENDLY` there are currently two other in-built styles
-you can use for your tables:
+In addition to `MSWORD_FRIENDLY` there are currently two other in-built styles you can
+use for your tables:
 
-  * `DEFAULT` - The default look, used to undo any style changes you may have
-made
-  * `PLAIN_COLUMNS` - A borderless style that works well with command line
-programs for columnar data
-  * `MARKDOWN` - A style that follows Markdown syntax
-  * `ORGMODE` - A table style that fits [Org mode](https://orgmode.org/) syntax
+- `DEFAULT` - The default look, used to undo any style changes you may have made
+- `PLAIN_COLUMNS` - A borderless style that works well with command line programs for
+  columnar data
+- `MARKDOWN` - A style that follows Markdown syntax
+- `ORGMODE` - A table style that fits [Org mode](https://orgmode.org/) syntax
 
 Other styles are likely to appear in future releases.
 
 ### Changing the appearance of your table - the hard way
 
-If you want to display your table in a style other than one of the in-built
-styles listed above, you'll have to set things up the hard way.
+If you want to display your table in a style other than one of the in-built styles
+listed above, you'll have to set things up the hard way.
 
 Don't worry, it's not really that hard!
 
 #### Style options
 
-PrettyTable has a number of style options which control various aspects of how
-tables are displayed.  You have the freedom to set each of these options
-individually to whatever you prefer.  The `set_style` method just does this
-automatically for you.
+PrettyTable has a number of style options which control various aspects of how tables
+are displayed. You have the freedom to set each of these options individually to
+whatever you prefer. The `set_style` method just does this automatically for you.
 
 The options are these:
 
-  * `border` - A boolean option (must be `True` or `False`).  Controls whether
-    or not a border is drawn around the table.
-  * `header` - A boolean option (must be `True` or `False`).  Controls whether
-    or not the first row of the table is a header showing the names of all the
-    fields.
-  * `hrules` - Controls printing of horizontal rules after rows. Allowed
-    values: `FRAME`, `HEADER`, `ALL`, `NONE` - note that these are variables defined
-    inside the `prettytable` module so make sure you import them or use
-    `prettytable.FRAME` etc.
-  * `vrules` - Controls printing of vertical rules between columns.  Allowed
-    values: `FRAME`, `ALL`, `NONE`.
-  * `int_format` - A string which controls the way integer data is printed.
-    This works like: `print("%<int_format>d" % data)`
-  * `float_format` - A string which controls the way floating point data is
-     printed.  This works like: `print("%<float_format>f" % data)`
-  * `padding_width` - Number of spaces on either side of column data (only used
-    if left and right paddings are `None`).
-  * `left_padding_width` - Number of spaces on left hand side of column data.
-  * `right_padding_width` - Number of spaces on right hand side of column data.
-  * `vertical_char` - Single character string used to draw vertical lines.
-     Default is `|`.
-  * `horizontal_char` - Single character string used to draw horizontal lines.
-     Default is `-`.
-  * `junction_char` - Single character string used to draw line junctions.
-     Default is `+`.
+- `border` - A boolean option (must be `True` or `False`). Controls whether or not a
+  border is drawn around the table.
+- `header` - A boolean option (must be `True` or `False`). Controls whether or not the
+  first row of the table is a header showing the names of all the fields.
+- `hrules` - Controls printing of horizontal rules after rows. Allowed values: `FRAME`,
+  `HEADER`, `ALL`, `NONE` - note that these are variables defined inside the
+  `prettytable` module so make sure you import them or use `prettytable.FRAME` etc.
+- `vrules` - Controls printing of vertical rules between columns. Allowed values:
+  `FRAME`, `ALL`, `NONE`.
+- `int_format` - A string which controls the way integer data is printed. This works
+  like: `print("%<int_format>d" % data)`
+- `float_format` - A string which controls the way floating point data is printed. This
+  works like: `print("%<float_format>f" % data)`
+- `padding_width` - Number of spaces on either side of column data (only used if left
+  and right paddings are `None`).
+- `left_padding_width` - Number of spaces on left hand side of column data.
+- `right_padding_width` - Number of spaces on right hand side of column data.
+- `vertical_char` - Single character string used to draw vertical lines. Default is `|`.
+- `horizontal_char` - Single character string used to draw horizontal lines. Default is
+  `-`.
+- `junction_char` - Single character string used to draw line junctions. Default is `+`.
 
 You can set the style options to your own settings in two ways:
 
 #### Setting style options for the long term
 
-If you want to print your table with a different style several times, you can
-set your option for the long term just by changing the appropriate
-attributes.  If you never want your tables to have borders you can do this:
+If you want to print your table with a different style several times, you can set your
+option for the long term just by changing the appropriate attributes. If you never want
+your tables to have borders you can do this:
 
 ```python
 x.border = False
@@ -439,21 +427,19 @@ print(x)
 print(x)
 ```
 
-Neither of the 3 tables printed by this will have borders, even if you do
-things like add extra rows in between them.  The lack of borders will last until
-you do:
+Neither of the 3 tables printed by this will have borders, even if you do things like
+add extra rows in between them. The lack of borders will last until you do:
 
 ```python
 x.border = True
 ```
 
-to turn them on again.  This sort of long-term setting is exactly how
-`set_style` works.  `set_style` just sets a bunch of attributes to pre-set
-values for you.
+to turn them on again. This sort of long-term setting is exactly how `set_style` works.
+`set_style` just sets a bunch of attributes to pre-set values for you.
 
-Note that if you know what style options you want at the moment you are
-creating your table, you can specify them using keyword arguments to the
-constructor.  For example, the following two code blocks are equivalent:
+Note that if you know what style options you want at the moment you are creating your
+table, you can specify them using keyword arguments to the constructor. For example, the
+following two code blocks are equivalent:
 
 ```python
 x = PrettyTable()
@@ -466,10 +452,10 @@ x = PrettyTable(border=False, header=False, padding_width=5)
 
 #### Changing style options just once
 
-If you don't want to make long-term style changes by changing an attribute like
-in the previous section, you can make changes that last for just one
-``get_string`` by giving those methods keyword arguments.  To print two
-"normal" tables with one borderless table between them, you could do this:
+If you don't want to make long-term style changes by changing an attribute like in the
+previous section, you can make changes that last for just one `get_string` by giving
+those methods keyword arguments. To print two "normal" tables with one borderless table
+between them, you could do this:
 
 ```python
 print(x)
@@ -479,48 +465,51 @@ print(x)
 
 ### Displaying your table in JSON
 
-PrettyTable will also print your tables in JSON, as a list of fields and an array
-of rows.  Just like in ASCII form, you can actually get a string representation - just use
+PrettyTable will also print your tables in JSON, as a list of fields and an array of
+rows. Just like in ASCII form, you can actually get a string representation - just use
 `get_json_string()`.
 
 ### Displaying your table in HTML form
 
-PrettyTable will also print your tables in HTML form, as `<table>`s.  Just like
-in ASCII form, you can actually get a string representation - just use
-`get_html_string()`.  HTML printing supports the `fields`, `start`, `end`,
-`sortby` and `reversesort` arguments in exactly the same way as ASCII printing.
+PrettyTable will also print your tables in HTML form, as `<table>`s. Just like in ASCII
+form, you can actually get a string representation - just use `get_html_string()`. HTML
+printing supports the `fields`, `start`, `end`, `sortby` and `reversesort` arguments in
+exactly the same way as ASCII printing.
 
 #### Styling HTML tables
 
-By default, PrettyTable outputs HTML for "vanilla" tables.  The HTML code is
-quite simple.  It looks like this:
+By default, PrettyTable outputs HTML for "vanilla" tables. The HTML code is quite
+simple. It looks like this:
 
 ```html
 <table>
-    <tr>
-        <th>City name</th>
-        <th>Area</th>
-        <th>Population</th>
-        <th>Annual Rainfall</th>
-    </tr>
-    <tr>
-        <td>Adelaide</td>
-        <td>1295</td>
-        <td>1158259</td>
-        <td>600.5</td>
-    <tr>
-        <td>Brisbane</td>
-        <td>5905</td>
-        <td>1857594</td>
-        <td>1146.4</td>
+  <tr>
+    <th>City name</th>
+    <th>Area</th>
+    <th>Population</th>
+    <th>Annual Rainfall</th>
+  </tr>
+  <tr>
+    <td>Adelaide</td>
+    <td>1295</td>
+    <td>1158259</td>
+    <td>600.5</td>
+  </tr>
+
+  <tr>
+    <td>Brisbane</td>
+    <td>5905</td>
+    <td>1857594</td>
+    <td>1146.4</td>
     ...
+  </tr>
 </table>
 ```
 
-If you like, you can ask PrettyTable to do its best to mimic the style options
-that your table has set using inline CSS.  This is done by giving a
-`format=True` keyword argument to `get_html_string` method.  Note that if you
-_always_ want to print formatted HTML you can do:
+If you like, you can ask PrettyTable to do its best to mimic the style options that your
+table has set using inline CSS. This is done by giving a `format=True` keyword argument
+to `get_html_string` method. Note that if you _always_ want to print formatted HTML you
+can do:
 
 ```python
 x.format = True
@@ -528,17 +517,16 @@ x.format = True
 
 and the setting will persist until you turn it off.
 
-Just like with ASCII tables, if you want to change the table's style for just
-one `get_html_string` you can pass those methods keyword arguments - exactly
-like `print` and `get_string`.
+Just like with ASCII tables, if you want to change the table's style for just one
+`get_html_string` you can pass those methods keyword arguments - exactly like `print`
+and `get_string`.
 
 #### Setting HTML attributes
 
-You can provide a dictionary of HTML attribute name/value pairs to the
-`get_html_string` method using the `attributes` keyword argument.
-This lets you specify common HTML attributes like `name`, `id` and
-`class` that can be used for linking to your tables or customising their
-appearance using CSS.  For example:
+You can provide a dictionary of HTML attribute name/value pairs to the `get_html_string`
+method using the `attributes` keyword argument. This lets you specify common HTML
+attributes like `name`, `id` and `class` that can be used for linking to your tables or
+customising their appearance using CSS. For example:
 
 ```python
 print(x.get_html_string(attributes={"name":"my_table", "class":"red_table"}))
@@ -548,15 +536,13 @@ will print:
 
 ```html
 <table name="my_table" class="red_table">
-    <tr>
-        <th>City name</th>
-        <th>Area</th>
-        <th>Population</th>
-        <th>Annual Rainfall</th>
-    </tr>
-    ...
-    ...
-    ...
+  <tr>
+    <th>City name</th>
+    <th>Area</th>
+    <th>Population</th>
+    <th>Annual Rainfall</th>
+  </tr>
+  ... ... ...
 </table>
 ```
 
@@ -564,11 +550,11 @@ will print:
 
 #### Copying a table
 
-You can call the `copy` method on a PrettyTable object without arguments to
-return an identical independent copy of the table.
+You can call the `copy` method on a PrettyTable object without arguments to return an
+identical independent copy of the table.
 
-If you want a copy of a PrettyTable object with just a subset of the rows,
-you can use list slicing notation:
+If you want a copy of a PrettyTable object with just a subset of the rows, you can use
+list slicing notation:
 
 ```python
 new_table = old_table[0:5]
@@ -576,7 +562,8 @@ new_table = old_table[0:5]
 
 ## Contributing
 
-After editing files, use the [Black](https://github.com/psf/black) linter to auto-format changed lines.
+After editing files, use the [Black](https://github.com/psf/black) linter to auto-format
+changed lines.
 
 ```sh
 python -m pip install black

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ using the `add_row` method:
 
 ```python
 x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
-x.add_row(["Adelaide",1295, 1158259, 600.5])
-x.add_row(["Brisbane",5905, 1857594, 1146.4])
+x.add_row(["Adelaide", 1295, 1158259, 600.5])
+x.add_row(["Brisbane", 5905, 1857594, 1146.4])
 x.add_row(["Darwin", 112, 120900, 1714.7])
 x.add_row(["Hobart", 1357, 205556, 619.5])
 x.add_row(["Sydney", 2058, 4336374, 1214.8])
@@ -58,7 +58,7 @@ x.add_row(["Perth", 5386, 1554769, 869.4])
 You can add data one column at a time as well.  To do this you use the
 `add_column` method, which takes two arguments - a string which is the name for
 the field the column you are adding corresponds to, and a list or tuple which
-contains the column data"
+contains the column data:
 
 ```python
 x.add_column("City name",
@@ -73,27 +73,26 @@ x.add_column("Annual Rainfall",[600.5, 1146.4, 1714.7, 619.5, 1214.8, 646.9,
 #### Mixing and matching
 
 If you really want to, you can even mix and match `add_row` and `add_column`
-and build some of your table in one way and some of it in the other.  There's a
-unit test which makes sure that doing things this way will always work out
-nicely as if you'd done it using just one of the two approaches.  Tables built
+and build some of your table in one way and some of it in the other. Tables built
 this way are kind of confusing for other people to read, though, so don't do
 this unless you have a good reason.
 
 #### Importing data from a CSV file
 
-If you have your table data in a comma separated values file (.csv), you can
+If you have your table data in a comma-separated values file (.csv), you can
 read this data into a PrettyTable like this:
 
 ```python
 from prettytable import from_csv
-fp = open("myfile.csv", "r")
-mytable = from_csv(fp)
-fp.close()
+with open("myfile.csv") as fp:
+    mytable = from_csv(fp)
 ```
 
 #### Importing data from a database cursor
 
-If you have your table data in a database which you can access using a library which confirms to the Python DB-API (e.g. an SQLite database accessible using the sqlite module), then you can build a PrettyTable using a cursor object, like this:
+If you have your table data in a database which you can access using a library which
+confirms to the Python DB-API (e.g. an SQLite database accessible using the `sqlite`
+module), then you can build a PrettyTable using a cursor object, like this:
 
 ```python
 import sqlite3
@@ -215,7 +214,7 @@ is row 0, so the second is row 1) and set `end` to 4 (the index of the 4th row,
 plus 1):
 
 ```python
-print(x.get_string(start=1,end=4))
+print(x.get_string(start=1, end=4))
 ```
 
 prints:
@@ -237,8 +236,8 @@ By default, all columns in a table are centre aligned.
 ##### All columns at once
 
 You can change the alignment of all the columns in a table at once by assigning
-a one character string to the `align` attribute.  The allowed strings are "l",
-"r" and "c" for left, right and centre alignment, respectively:
+a one character string to the `align` attribute.  The allowed strings are `"l"`,
+`"r"` and `"c"` for left, right and centre alignment, respectively:
 
 ```python
 x.align = "r"
@@ -304,7 +303,7 @@ city data, so that the most populated city comes last, we can do this:
 print(x.get_string(sortby="Population"))
 ```
 
-to get
+to get:
 
 ```
 +-----------+------+------------+-----------------+
@@ -324,7 +323,7 @@ If we want the most populated city to come _first_, we can also give a
 `reversesort=True` argument.
 
 If you _always_ want your tables to be sorted in a certain way, you can make
-the setting long term like this:
+the setting long-term like this:
 
 ```python
 x.sortby = "Population"
@@ -355,7 +354,7 @@ instance of the data in the `sort_by` column.
 
 By default, PrettyTable produces ASCII tables that look like the ones used in
 SQL database shells.  But if can print them in a variety of other formats as
-well.  If the format you want to use is common, PrettyTable makes this very
+well. If the format you want to use is common, PrettyTable makes this
 easy for you to do using the `set_style` method.  If you want to produce an
 uncommon table, you'll have to do things slightly harder (see later).
 
@@ -404,18 +403,18 @@ The options are these:
   * `header` - A boolean option (must be `True` or `False`).  Controls whether
     or not the first row of the table is a header showing the names of all the
     fields.
-  * `hrules` - Controls printing of horizontal rules after rows.  Allowed
-    values: FRAME, HEADER, ALL, NONE - note that these are variables defined
+  * `hrules` - Controls printing of horizontal rules after rows. Allowed
+    values: `FRAME`, `HEADER`, `ALL`, `NONE` - note that these are variables defined
     inside the `prettytable` module so make sure you import them or use
     `prettytable.FRAME` etc.
   * `vrules` - Controls printing of vertical rules between columns.  Allowed
-    values: FRAME, ALL, NONE.
+    values: `FRAME`, `ALL`, `NONE`.
   * `int_format` - A string which controls the way integer data is printed.
     This works like: `print("%<int_format>d" % data)`
   * `float_format` - A string which controls the way floating point data is
      printed.  This works like: `print("%<float_format>f" % data)`
   * `padding_width` - Number of spaces on either side of column data (only used
-    if left and right paddings are None).
+    if left and right paddings are `None`).
   * `left_padding_width` - Number of spaces on left hand side of column data.
   * `right_padding_width` - Number of spaces on right hand side of column data.
   * `vertical_char` - Single character string used to draw vertical lines.
@@ -430,7 +429,7 @@ You can set the style options to your own settings in two ways:
 #### Setting style options for the long term
 
 If you want to print your table with a different style several times, you can
-set your option for the "long term" just by changing the appropriate
+set your option for the long term just by changing the appropriate
 attributes.  If you never want your tables to have borders you can do this:
 
 ```python
@@ -448,7 +447,7 @@ you do:
 x.border = True
 ```
 
-to turn them on again.  This sort of long term setting is exactly how
+to turn them on again.  This sort of long-term setting is exactly how
 `set_style` works.  `set_style` just sets a bunch of attributes to pre-set
 values for you.
 
@@ -467,7 +466,7 @@ x = PrettyTable(border=False, header=False, padding_width=5)
 
 #### Changing style options just once
 
-If you don't want to make long term style changes by changing an attribute like
+If you don't want to make long-term style changes by changing an attribute like
 in the previous section, you can make changes that last for just one
 ``get_string`` by giving those methods keyword arguments.  To print two
 "normal" tables with one borderless table between them, you could do this:
@@ -514,8 +513,6 @@ quite simple.  It looks like this:
         <td>5905</td>
         <td>1857594</td>
         <td>1146.4</td>
-    ...
-    ...
     ...
 </table>
 ```
@@ -579,7 +576,7 @@ new_table = old_table[0:5]
 
 ## Contributing
 
-After editing files, use the [black](https://github.com/psf/black) linter to auto-format changed lines.
+After editing files, use the [Black](https://github.com/psf/black) linter to auto-format changed lines.
 
 ```sh
 python -m pip install black

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,10 @@
 
 Jazzband guidelines: https://jazzband.co/about/releases
 
-* [ ] Get master to the appropriate code release state.
+- [ ] Get master to the appropriate code release state.
       [Travis CI](https://travis-ci.org/jazzband/prettytable) and
-      [GitHub Actions](https://github.com/jazzband/prettytable/actions)
-      should pass on master.
+      [GitHub Actions](https://github.com/jazzband/prettytable/actions) should pass on
+      master.
       [![Travis CI Status](https://img.shields.io/travis/jazzband/prettytable/master?label=Travis%20CI&logo=travis)](https://travis-ci.org/jazzband/prettytable)
       [![GitHub Actions status](https://github.com/jazzband/prettytable/workflows/Test/badge.svg)](https://github.com/jazzband/prettytable/actions)
 
@@ -13,21 +13,25 @@ Jazzband guidelines: https://jazzband.co/about/releases
       [CHANGELOG.md](https://github.com/jazzband/prettytable/blob/master/CHANGELOG.md),
       update version number and release date
 
-* [ ] Tag with version number and push tag, for example:
+- [ ] Tag with version number and push tag, for example:
+
 ```bash
 git tag -a 1.0.0 -m "Release 1.0.0"
 git push --tags
 ```
 
-* [ ] Create new GitHub release: https://github.com/jazzband/prettytable/releases/new
-  * Tag: Pick existing tag "1.0.0"
+- [ ] Create new GitHub release: https://github.com/jazzband/prettytable/releases/new
 
-* [ ] Once [GitHub Actions](https://github.com/jazzband/prettytable/actions?query=workflow%3ADeploy)
+  - Tag: Pick existing tag "1.0.0"
+
+- [ ] Once
+      [GitHub Actions](https://github.com/jazzband/prettytable/actions?query=workflow%3ADeploy)
       has built and uploaded distributions, check files at
       [Jazzband](https://jazzband.co/projects/prettytable) and release to
       [PyPI](https://pypi.org/pypi/prettytable)
 
-* [ ] Check installation:
+- [ ] Check installation:
+
 ```bash
 pip uninstall -y prettytable
 pip install -U prettytable

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -673,7 +673,7 @@ class HtmlOutputTests(unittest.TestCase):
 @pytest.mark.parametrize(
     "test_style, expected",
     [
-        (
+        pytest.param(
             DEFAULT,
             """
 +---------+---------+---------+
@@ -684,8 +684,9 @@ class HtmlOutputTests(unittest.TestCase):
 | value 7 |  value8 |  value9 |
 +---------+---------+---------+
 """,
+            id="DEFAULT",
         ),
-        (
+        pytest.param(
             MARKDOWN,
             """
 | Field 1 | Field 2 | Field 3 |
@@ -694,8 +695,9 @@ class HtmlOutputTests(unittest.TestCase):
 | value 4 |  value5 |  value6 |
 | value 7 |  value8 |  value9 |
 """,
+            id="MARKDOWN",
         ),
-        (
+        pytest.param(
             MSWORD_FRIENDLY,
             """
 | Field 1 | Field 2 | Field 3 |
@@ -703,8 +705,9 @@ class HtmlOutputTests(unittest.TestCase):
 | value 4 |  value5 |  value6 |
 | value 7 |  value8 |  value9 |
 """,
+            id="MSWORD_FRIENDLY",
         ),
-        (
+        pytest.param(
             ORGMODE,
             """
 |---------+---------+---------|
@@ -715,8 +718,9 @@ class HtmlOutputTests(unittest.TestCase):
 | value 7 |  value8 |  value9 |
 |---------+---------+---------|
 """,
+            id="ORGMODE",
         ),
-        (
+        pytest.param(
             PLAIN_COLUMNS,
             """
 Field 1        Field 2        Field 3        
@@ -724,8 +728,9 @@ value 1         value2         value3
 value 4         value5         value6        
 value 7         value8         value9
 """,  # noqa: W291
+            id="PLAIN_COLUMNS",
         ),
-        (
+        pytest.param(
             RANDOM,
             """
 '^^^^^^^^^^^'^^^^^^^^^^'^^^^^^^^^^'
@@ -736,6 +741,7 @@ value 7         value8         value9
 %    value 7%    value8%    value9%
 '^^^^^^^^^^^'^^^^^^^^^^'^^^^^^^^^^'
 """,
+            id="RANDOM",
         ),
     ],
 )

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -129,29 +129,33 @@ class DeleteColumnTest(unittest.TestCase):
             table.del_column("City not-a-name")
 
 
-# class FieldnamelessTableTest(unittest.TestCase):
-#
-#    """Make sure that building and stringing a table with no fieldnames works fine"""
-#
-#    def setUp(self):
-#        self.x = PrettyTable()
-#        self.x.add_row(["Adelaide",1295, 1158259, 600.5])
-#        self.x.add_row(["Brisbane",5905, 1857594, 1146.4])
-#        self.x.add_row(["Darwin", 112, 120900, 1714.7])
-#        self.x.add_row(["Hobart", 1357, 205556, 619.5])
-#        self.x.add_row(["Sydney", 2058, 4336374, 1214.8])
-#        self.x.add_row(["Melbourne", 1566, 3806092, 646.9])
-#        self.x.add_row(["Perth", 5386, 1554769, 869.4])
-#
-#    def testCanStringASCII(self):
-#        self.x.get_string()
-#
-#    def testCanStringHTML(self):
-#        self.x.get_html_string()
-#
-#    def testAddFieldnamesLater(self):
-#        self.x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
-#        self.x.get_string()
+class FieldnamelessTableTest(unittest.TestCase):
+
+    """Make sure that building and stringing a table with no fieldnames works fine"""
+
+    def setUp(self):
+        self.x = PrettyTable()
+        self.x.add_row(["Adelaide", 1295, 1158259, 600.5])
+        self.x.add_row(["Brisbane", 5905, 1857594, 1146.4])
+        self.x.add_row(["Darwin", 112, 120900, 1714.7])
+        self.x.add_row(["Hobart", 1357, 205556, 619.5])
+        self.x.add_row(["Sydney", 2058, 4336374, 1214.8])
+        self.x.add_row(["Melbourne", 1566, 3806092, 646.9])
+        self.x.add_row(["Perth", 5386, 1554769, 869.4])
+
+    def testCanStringASCII(self):
+        output = self.x.get_string()
+        assert "|  Field 1  | Field 2 | Field 3 | Field 4 |" in output
+        assert "|  Adelaide |   1295  | 1158259 |  600.5  |" in output
+
+    def testCanStringHTML(self):
+        output = self.x.get_html_string()
+        assert "<th>Field 1</th>" in output
+        assert "<td>Adelaide</td>" in output
+
+    def testAddFieldNamesLater(self):
+        self.x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
+        assert "City name | Area | Population | Annual Rainfall" in self.x.get_string()
 
 
 class CityDataTest(unittest.TestCase):
@@ -854,7 +858,3 @@ class PrintEmojiTest(unittest.TestCase):
     def testPrint(self):
         print()
         print(self.x)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/prettytable_test.py
+++ b/prettytable_test.py
@@ -5,6 +5,8 @@ import sys
 import unittest
 from math import e, pi, sqrt
 
+import pytest
+
 from prettytable import (
     ALL,
     MARKDOWN,
@@ -90,19 +92,19 @@ class BuildEquivalenceTest(unittest.TestCase):
 
     def testRowColEquivalenceASCII(self):
 
-        self.assertEqual(self.row.get_string(), self.col.get_string())
+        assert self.row.get_string() == self.col.get_string()
 
     def testRowMixEquivalenceASCII(self):
 
-        self.assertEqual(self.row.get_string(), self.mix.get_string())
+        assert self.row.get_string() == self.mix.get_string()
 
     def testRowColEquivalenceHTML(self):
 
-        self.assertEqual(self.row.get_html_string(), self.col.get_html_string())
+        assert self.row.get_html_string() == self.col.get_html_string()
 
     def testRowMixEquivalenceHTML(self):
 
-        self.assertEqual(self.row.get_html_string(), self.mix.get_html_string())
+        assert self.row.get_html_string() == self.mix.get_html_string()
 
 
 class DeleteColumnTest(unittest.TestCase):
@@ -117,13 +119,13 @@ class DeleteColumnTest(unittest.TestCase):
         without_row.add_column("City name", ["Adelaide", "Brisbane", "Darwin"])
         without_row.add_column("Population", [1158259, 1857594, 120900])
 
-        self.assertEqual(with_del.get_string(), without_row.get_string())
+        assert with_del.get_string() == without_row.get_string()
 
     def testDeleteIllegalColumnRaisesException(self):
         table = PrettyTable()
         table.add_column("City name", ["Adelaide", "Brisbane", "Darwin"])
 
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             table.del_column("City not-a-name")
 
 
@@ -175,23 +177,23 @@ class OptionOverrideTests(CityDataTest):
     def testBorder(self):
         default = self.x.get_string()
         override = self.x.get_string(border=False)
-        self.assertNotEqual(default, override)
+        assert default != override
 
     def testHeader(self):
         default = self.x.get_string()
         override = self.x.get_string(header=False)
-        self.assertNotEqual(default, override)
+        assert default != override
 
     def testHrulesAll(self):
         default = self.x.get_string()
         override = self.x.get_string(hrules=ALL)
-        self.assertNotEqual(default, override)
+        assert default != override
 
     def testHrulesNone(self):
 
         default = self.x.get_string()
         override = self.x.get_string(hrules=NONE)
-        self.assertNotEqual(default, override)
+        assert default != override
 
 
 class OptionAttributeTests(CityDataTest):
@@ -241,7 +243,7 @@ class BasicTests(CityDataTest):
 
         string = self.x.get_string()
         lines = string.split("\n")
-        self.assertNotIn("", lines)
+        assert "" not in lines
 
     def testAllLengthsEqual(self):
 
@@ -251,7 +253,7 @@ class BasicTests(CityDataTest):
         lines = string.split("\n")
         lengths = [len(line) for line in lines]
         lengths = set(lengths)
-        self.assertEqual(len(lengths), 1)
+        assert len(lengths) == 1
 
 
 class TitleBasicTests(BasicTests):
@@ -724,18 +726,16 @@ class CsvOutputTests(unittest.TestCase):
         t.add_row(["value 1", "value2", "value3"])
         t.add_row(["value 4", "value5", "value6"])
         t.add_row(["value 7", "value8", "value9"])
-        self.assertEqual(
-            t.get_csv_string(delimiter="\t", header=False),
+        assert t.get_csv_string(delimiter="\t", header=False) == (
             "value 1\tvalue2\tvalue3\r\n"
             "value 4\tvalue5\tvalue6\r\n"
-            "value 7\tvalue8\tvalue9\r\n",
+            "value 7\tvalue8\tvalue9\r\n"
         )
-        self.assertEqual(
-            t.get_csv_string(),
+        assert t.get_csv_string() == (
             "Field 1,Field 2,Field 3\r\n"
             "value 1,value2,value3\r\n"
             "value 4,value5,value6\r\n"
-            "value 7,value8,value9\r\n",
+            "value 7,value8,value9\r\n"
         )
 
 
@@ -801,7 +801,8 @@ class HtmlConstructorTest(CityDataTest):
     def testHtmlOneFailOnMany(self):
         html_string = self.x.get_html_string()
         html_string += self.x.get_html_string()
-        self.assertRaises(Exception, from_html_one, html_string)
+        with pytest.raises(Exception):
+            from_html_one(html_string)
 
 
 class PrintEnglishTest(CityDataTest):

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,23 @@
 [tox]
 envlist =
     lint
-    py{27, 35, 36, 37, 38, 39}
+    py{39, 38, 37, 36, 35, 27}
 
 [testenv]
-extras = tests
+extras =
+    tests
 commands =
-    {envpython} -m pytest --cov prettytable --cov prettytable_test --cov-report xml {posargs}
+    {envpython} -m pytest \
+      --cov prettytable \
+      --cov prettytable_test \
+      --cov-report xml {posargs}
     coverage report
 
 [testenv:lint]
-deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
+passenv =
+    PRE_COMMIT_COLOR
 skip_install = true
-passenv = PRE_COMMIT_COLOR
+deps =
+    pre-commit
+commands =
+    pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
* Add tests for `paginate` and `set_style`
* Uncomment passing tests for no field names and add asserts
* Convert tests to pytest with unittest2pytest (more updates possible later)
* Stop testing Python EOL 2.7 and 3.5 (ahead of https://github.com/jazzband/prettytable/issues/36)
* Format with Prettier
* README cleanup
