### PR TITLE
Add add_rows to add several rows at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ x.add_row(["Melbourne", 1566, 3806092, 646.9])
 x.add_row(["Perth", 5386, 1554769, 869.4])
 ```
 
+#### All rows at once
+
+When you have a list of rows, you can add them in one go with `add_rows`:
+
+```python
+x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
+x.add_rows(
+    [
+        ["Adelaide", 1295, 1158259, 600.5],
+        ["Brisbane", 5905, 1857594, 1146.4],
+        ["Darwin", 112, 120900, 1714.7],
+        ["Hobart", 1357, 205556, 619.5],
+        ["Sydney", 2058, 4336374, 1214.8],
+        ["Melbourne", 1566, 3806092, 646.9],
+        ["Perth", 5386, 1554769, 869.4],
+    ]
+)
+```
+
 #### Column by column
 
 You can add data one column at a time as well. To do this you use the `add_column`

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1007,6 +1007,17 @@ class PrettyTable:
     # DATA INPUT METHODS         #
     ##############################
 
+    def add_rows(self, rows):
+
+        """Add rows to the table
+
+        Arguments:
+
+        rows - rows of data, should be an iterable of lists, each list with as many
+        elements as the table has fields"""
+        for row in rows:
+            self.add_row(row)
+
     def add_row(self, row):
 
         """Add a row to the table

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -925,3 +925,24 @@ def test_paginate():
     assert paginated.startswith(expected_page_1)
     assert "\f" in paginated
     assert paginated.endswith(expected_page_2)
+
+
+def test_add_rows():
+    """A table created with multiple add_row calls
+    is the same as one created with a single add_rows
+    """
+    # Arrange
+    t1 = PrettyTable(["A", "B", "C"])
+    t2 = PrettyTable(["A", "B", "C"])
+    t1.add_row([1, 2, 3])
+    t1.add_row([4, 5, 6])
+    rows = [
+        [1, 2, 3],
+        [4, 5, 6],
+    ]
+
+    # Act
+    t2.add_rows(rows)
+
+    # Assert
+    assert str(t1) == str(t2)


### PR DESCRIPTION
When you have a list of rows, you can add them in one go with `add_rows`:

```python
from prettytable import PrettyTable

x = PrettyTable()
x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
x.add_rows(
    [
        ["Adelaide", 1295, 1158259, 600.5],
        ["Brisbane", 5905, 1857594, 1146.4],
        ["Darwin", 112, 120900, 1714.7],
        ["Hobart", 1357, 205556, 619.5],
        ["Sydney", 2058, 4336374, 1214.8],
        ["Melbourne", 1566, 3806092, 646.9],
        ["Perth", 5386, 1554769, 869.4],
    ]
)

print(x)
```
```
+-----------+------+------------+-----------------+
| City name | Area | Population | Annual Rainfall |
+-----------+------+------------+-----------------+
|  Adelaide | 1295 |  1158259   |      600.5      |
|  Brisbane | 5905 |  1857594   |      1146.4     |
|   Darwin  | 112  |   120900   |      1714.7     |
|   Hobart  | 1357 |   205556   |      619.5      |
|   Sydney  | 2058 |  4336374   |      1214.8     |
| Melbourne | 1566 |  3806092   |      646.9      |
|   Perth   | 5386 |  1554769   |      869.4      |
+-----------+------+------------+-----------------+
```