### PR TITLE
Fix padding_width = 0

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -176,7 +176,10 @@ class PrettyTable:
 
         self._min_table_width = kwargs["min_table_width"] or None
         self._max_table_width = kwargs["max_table_width"] or None
-        self._padding_width = kwargs["padding_width"] or 1
+        if kwargs["padding_width"] is None:
+            self._padding_width = 1
+        else:
+            self._padding_width = kwargs["padding_width"]
         self._left_padding_width = kwargs["left_padding_width"] or None
         self._right_padding_width = kwargs["right_padding_width"] or None
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -946,3 +946,33 @@ def test_add_rows():
 
     # Assert
     assert str(t1) == str(t2)
+
+
+class UnpaddedTableTest(unittest.TestCase):
+    def setUp(self):
+        self.x = PrettyTable(header=False, padding_width=0)
+        self.x.add_row("abc")
+        self.x.add_row("def")
+        self.x.add_row("g..")
+
+    def testUnbordered(self):
+        self.x.border = False
+        result = self.x.get_string()
+        expected = """
+abc
+def
+g..
+"""
+        assert result.strip() == expected.strip()
+
+    def testBordered(self):
+        self.x.border = True
+        result = self.x.get_string()
+        expected = """
++-+-+-+
+|a|b|c|
+|d|e|f|
+|g|.|.|
++-+-+-+
+"""
+        assert result.strip() == expected.strip()


### PR DESCRIPTION
Based on https://github.com/kxxoling/PTable/pull/2 from the PTable fork.

Thanks to @Sebelino for the original PR:

> Fixes a bug where setting padding_width to 0 has the same effect as setting it to 1. This makes it possible to create compact tables like these:
> 
> ```
> +-+-+-+
> |a|b|c|
> |d|e|f|
> |g|.|.|
> +-+-+-+
> 
> abc
> def
> g..
> ```

