### PR TITLE
Support formatting options in get_json_string()

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1555,17 +1555,26 @@ class PrettyTable:
 
         """Return string representation of JSON formatted table in the current state
 
-        Arguments:
-
-        none yet"""
+        Keyword arguments are first interpreted as table formatting options, and
+        then any unused keyword arguments are passed to json.dumps(). For
+        example, get_json_string(header=False, indent=2) would use header as
+        a PrettyTable formatting option (skip the header row) and indent as a
+        json.dumps keyword argument.
+        """
 
         options = self._get_options(kwargs)
+        json_options = dict(indent=4, separators=(",", ": "), sort_keys=True)
+        json_options.update(
+            {key: value for key, value in kwargs.items() if key not in options}
+        )
+        objects = []
 
-        objects = [self.field_names]
+        if options.get("header"):
+            objects.append(self.field_names)
         for row in self._get_rows(options):
             objects.append(dict(zip(self._field_names, row)))
 
-        return json.dumps(objects, indent=4, separators=(",", ": "), sort_keys=True)
+        return json.dumps(objects, **json_options)
 
     ##############################
     # HTML STRING METHODS        #

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -601,6 +601,16 @@ class JSONOutputTests(unittest.TestCase):
 ]""".strip()
         )
 
+    def testJSONOutputOptions(self):
+        t = helper_table()
+        result = t.get_json_string(header=False, indent=None, separators=(",", ":"))
+        assert (
+            result
+            == """[{"Field 1":"value 1","Field 2":"value2","Field 3":"value3"},"""
+            """{"Field 1":"value 4","Field 2":"value5","Field 3":"value6"},"""
+            """{"Field 1":"value 7","Field 2":"value8","Field 3":"value9"}]"""
+        )
+
 
 class HtmlOutputTests(unittest.TestCase):
     def testHtmlOutput(self):


### PR DESCRIPTION
This change passes through keyword arguments to json.dumps() in a
similar manner to get_csv_string(). Additionally, it respects the
'header' table option.