### PR TITLE
Docs: Remove reference to Python 2.x print statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,16 +161,8 @@ You can print tables like this to `stdout` or get string representations of them
 To print a table in ASCII form, you can just do this:
 
 ```python
-print x
-```
-
-in Python 2.x or:
-
-```python
 print(x)
 ```
-
-in Python 3.x.
 
 The old `x.printt()` method from versions 0.5 and earlier has been removed.
 


### PR DESCRIPTION
As this project only supports Python 3.6+, remove reference to Python 2.x `print` statement to make README simpler.