### PR TITLE
Add Escaping Options to HTML Tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,16 @@ will print:
 </table>
 ```
 
+#### Setting HTML Escaping
+
+By default, PrettyTable will escape the data contained in the header and data fields when 
+sending output to html. This can be disabled by setting the 'escape_header' and 'escape_data'
+to false. For example:
+
+```python
+print(x.get_html_string(escape_header=False, escape_data=False))
+```
+
 ### Miscellaneous things
 
 #### Copying a table

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -138,7 +138,8 @@ class PrettyTable:
             "vertical_char horizontal_char junction_char header_style valign xhtml "
             "print_empty oldsortslice".split()
         )
-        self._options.extend("align valign max_width min_width".split())
+        self._options.extend(
+            "align valign max_width min_width header_escape data_escape".split())
         for option in self._options:
             if option in kwargs:
                 self._validate_option(option, kwargs[option])
@@ -154,7 +155,15 @@ class PrettyTable:
             self._header = kwargs["header"]
         else:
             self._header = True
+        if kwargs["header_escape"] in (True, False):
+            self._header_escape = kwargs["header_escape"]
+        else:
+            self._header_escape = True
         self._header_style = kwargs["header_style"] or None
+        if kwargs["data_escape"] in (True, False):
+            self._data_escape = kwargs["data_escape"]
+        else:
+            self._data_escape = True
         if kwargs["border"] in (True, False):
             self._border = kwargs["border"]
         else:
@@ -302,6 +311,8 @@ class PrettyTable:
             "xhtml",
             "print_empty",
             "oldsortslice",
+            "header_escape",
+            "data_escape",
         ):
             self._validate_true_or_false(option, val)
         elif option == "header_style":
@@ -1594,6 +1605,7 @@ class PrettyTable:
         end - index of last data row to include in output PLUS ONE (list slice style)
         fields - names of fields (columns) to include
         header - print a header showing field names (True or False)
+        header_escape - escapes the text within a header (True or False)
         border - print a border around the table (True or False)
         hrules - controls printing of horizontal rules after rows.
             Allowed values: ALL, FRAME, HEADER, NONE
@@ -1611,6 +1623,7 @@ class PrettyTable:
             <table> tag
         format - Controls whether or not HTML tables are formatted to match
             styling options (True or False)
+        data_escape - escapes the text within a data field (True or False)
         xhtml - print <br/> tags if True, <br> tags if false"""
 
         options = self._get_options(kwargs)
@@ -1656,9 +1669,14 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    "            <th>%s</th>" % escape(field).replace("\n", linebreak)
-                )
+                if options["header_escape"]:
+                    lines.append(
+                        "            <th>%s</th>" % escape(field).replace("\n", linebreak)
+                    )
+                else:
+                    lines.append(
+                        "            <th>%s</th>" % field.replace("\n", linebreak)
+                        )
             lines.append("        </tr>")
             lines.append("    </thead>")
 
@@ -1671,9 +1689,14 @@ class PrettyTable:
             for field, datum in zip(self._field_names, row):
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    "            <td>%s</td>" % escape(datum).replace("\n", linebreak)
-                )
+                if options["data_escape"]:
+                    lines.append(
+                        "            <td>%s</td>" % escape(datum).replace("\n", linebreak)
+                    )
+                else:
+                    lines.append(
+                        "            <td>%s</td>" % datum.replace("\n", linebreak)
+                    )                    
             lines.append("        </tr>")
         lines.append("    </tbody>")
         lines.append("</table>")
@@ -1730,10 +1753,16 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
-                    % (lpad, rpad, escape(field).replace("\n", linebreak))
-                )
+                if options["header_escape"]:
+                    lines.append(
+                        '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
+                        % (lpad, rpad, escape(field).replace("\n", linebreak))
+                    )
+                else:
+                    lines.append(
+                        '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
+                        % (lpad, rpad, field.replace("\n", linebreak))
+                    )
             lines.append("        </tr>")
             lines.append("    </thead>")
 
@@ -1757,16 +1786,28 @@ class PrettyTable:
             ):
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    '            <td style="padding-left: %dem; padding-right: %dem; text-align: %s; vertical-align: %s">%s</td>'  # noqa: E501
-                    % (
-                        lpad,
-                        rpad,
-                        align,
-                        valign,
-                        escape(datum).replace("\n", linebreak),
+                if options["data_escape"]:
+                    lines.append(
+                        '            <td style="padding-left: %dem; padding-right: %dem; text-align: %s; vertical-align: %s">%s</td>'  # noqa: E501
+                        % (
+                            lpad,
+                            rpad,
+                            align,
+                            valign,
+                            escape(datum).replace("\n", linebreak),
+                        )
                     )
-                )
+                else:
+                    lines.append(
+                        '            <td style="padding-left: %dem; padding-right: %dem; text-align: %s; vertical-align: %s">%s</td>'  # noqa: E501
+                        % (
+                            lpad,
+                            rpad,
+                            align,
+                            valign,
+                            datum.replace("\n", linebreak),
+                        )
+                    )                    
             lines.append("        </tr>")
         lines.append("    </tbody>")
         lines.append("</table>")

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -139,7 +139,7 @@ class PrettyTable:
             "print_empty oldsortslice".split()
         )
         self._options.extend(
-            "align valign max_width min_width header_escape data_escape".split())
+            "align valign max_width min_width escape_header escape_data".split())
         for option in self._options:
             if option in kwargs:
                 self._validate_option(option, kwargs[option])
@@ -155,15 +155,15 @@ class PrettyTable:
             self._header = kwargs["header"]
         else:
             self._header = True
-        if kwargs["header_escape"] in (True, False):
-            self._header_escape = kwargs["header_escape"]
+        if kwargs["escape_header"] in (True, False):
+            self._escape_header = kwargs["escape_header"]
         else:
-            self._header_escape = True
+            self._escape_header = True
         self._header_style = kwargs["header_style"] or None
-        if kwargs["data_escape"] in (True, False):
-            self._data_escape = kwargs["data_escape"]
+        if kwargs["escape_data"] in (True, False):
+            self._escape_data = kwargs["escape_data"]
         else:
-            self._data_escape = True
+            self._escape_data = True
         if kwargs["border"] in (True, False):
             self._border = kwargs["border"]
         else:
@@ -311,8 +311,8 @@ class PrettyTable:
             "xhtml",
             "print_empty",
             "oldsortslice",
-            "header_escape",
-            "data_escape",
+            "escape_header",
+            "escape_data",
         ):
             self._validate_true_or_false(option, val)
         elif option == "header_style":
@@ -1605,7 +1605,7 @@ class PrettyTable:
         end - index of last data row to include in output PLUS ONE (list slice style)
         fields - names of fields (columns) to include
         header - print a header showing field names (True or False)
-        header_escape - escapes the text within a header (True or False)
+        escape_header - escapes the text within a header (True or False)
         border - print a border around the table (True or False)
         hrules - controls printing of horizontal rules after rows.
             Allowed values: ALL, FRAME, HEADER, NONE
@@ -1623,7 +1623,7 @@ class PrettyTable:
             <table> tag
         format - Controls whether or not HTML tables are formatted to match
             styling options (True or False)
-        data_escape - escapes the text within a data field (True or False)
+        escape_data - escapes the text within a data field (True or False)
         xhtml - print <br/> tags if True, <br> tags if false"""
 
         options = self._get_options(kwargs)
@@ -1669,7 +1669,7 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                if options["header_escape"]:
+                if options["escape_header"]:
                     lines.append(
                         "            <th>%s</th>" % escape(field).replace("\n", linebreak)
                     )
@@ -1689,7 +1689,7 @@ class PrettyTable:
             for field, datum in zip(self._field_names, row):
                 if options["fields"] and field not in options["fields"]:
                     continue
-                if options["data_escape"]:
+                if options["escape_data"]:
                     lines.append(
                         "            <td>%s</td>" % escape(datum).replace("\n", linebreak)
                     )
@@ -1753,7 +1753,7 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                if options["header_escape"]:
+                if options["escape_header"]:
                     lines.append(
                         '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
                         % (lpad, rpad, escape(field).replace("\n", linebreak))
@@ -1786,7 +1786,7 @@ class PrettyTable:
             ):
                 if options["fields"] and field not in options["fields"]:
                     continue
-                if options["data_escape"]:
+                if options["escape_data"]:
                     lines.append(
                         '            <td style="padding-left: %dem; padding-right: %dem; text-align: %s; vertical-align: %s">%s</td>'  # noqa: E501
                         % (

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -888,6 +888,60 @@ class PrintJapaneseTest(unittest.TestCase):
         print()
         print(self.x)
 
+class PrintHTMLEscapingTest(unittest.TestCase):
+    def setUp(self):
+
+        self.x = PrettyTable(['<a href="https://google.com">Field 1</a>', 'Field 2'])
+        self.x.add_row(['value 1', 'value 2'])
+        self.x.add_row(['<a href="https://google.com">value 3</a>', 'value 4'])
+
+
+    def testNoFormatEscape(self):
+        result = self.x.get_html_string(header_escape=False, data_escape=False)
+        print(result)
+        assert result.strip() == """
+<table>
+    <thead>
+        <tr>
+            <th><a href="https://google.com">Field 1</a></th>
+            <th>Field 2</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>value 1</td>
+            <td>value 2</td>
+        </tr>
+        <tr>
+            <td><a href="https://google.com">value 3</a></td>
+            <td>value 4</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+    
+    def testFormatEscape(self):
+        result = self.x.get_html_string(header_escape=False, data_escape=False, format=True)
+        assert result.strip() == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"><a href="https://google.com">Field 1</a></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 2</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><a href="https://google.com">value 3</a></td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
 
 class PrintEmojiTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -888,6 +888,7 @@ class PrintJapaneseTest(unittest.TestCase):
         print()
         print(self.x)
 
+
 class PrintHTMLEscapingTest(unittest.TestCase):
     def setUp(self):
 
@@ -895,9 +896,8 @@ class PrintHTMLEscapingTest(unittest.TestCase):
         self.x.add_row(['value 1', 'value 2'])
         self.x.add_row(['<a href="https://google.com">value 3</a>', 'value 4'])
 
-
     def testNoFormatEscape(self):
-        result = self.x.get_html_string(header_escape=False, data_escape=False)
+        result = self.x.get_html_string(escape_header=False, escape_data=False)
         print(result)
         assert result.strip() == """
 <table>
@@ -919,9 +919,11 @@ class PrintHTMLEscapingTest(unittest.TestCase):
     </tbody>
 </table>
 """.strip()
-    
+
     def testFormatEscape(self):
-        result = self.x.get_html_string(header_escape=False, data_escape=False, format=True)
+        result = self.x.get_html_string(escape_header=False,
+                                        escape_data=False,
+                                        format=True)
         assert result.strip() == """
 <table frame="box" rules="cols">
     <thead>
@@ -941,7 +943,8 @@ class PrintHTMLEscapingTest(unittest.TestCase):
         </tr>
     </tbody>
 </table>
-""".strip()
+""".strip()  # noqa: E501
+
 
 class PrintEmojiTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes #40. 

Add Escaping Options to HTML Tables

This will allow tables to contain active links and other html code allowing prettytables to more easily be used for dynamic site building.

Example includes allowing a header to be a link.

`x.get_html_string(header_escape=False, data_escape=False)`

```html
<table>
    <thead>
        <tr>
            <th><a href="https://google.com">Field 1</a></th>
            <th>Field 2</th>
        </tr>
    </thead>
        <tr>
            <td>value 1</td>
            <td>value 2</td>
        </tr>
        <tr>
            <td><a href="https://google.com">value 3</a></td>
            <td>value 4</td>
        </tr>
    </tbody>
</table>
```

instead of
`x.get_html_string()`

```html
<table>
    <thead>
        <tr>
            <th>&lt;a href=&quot;https://google.com&quot;&gt;Field 1&lt;/a&gt;</th>
            <th>Field 2</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td>value 1</td>
            <td>value 2</td>
        </tr>
        <tr>
            <td>&lt;a href=&quot;https://google.com&quot;&gt;value 3&lt;/a&gt;</td>
            <td>value 4</td>
        </tr>
    </tbody>
</table>
```

