### PR TITLE
CI: Set permissions for Release Drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
     if: github.repository == 'jazzband/prettytable'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Release Drafter stopped working (but the check still "passed"):

```
jazzband/prettytable: Creating new release
{ name: 'event', id: '911531067' }
Error: Resource not accessible by integration
{
  name: 'HttpError',
  id: '911531067',
  status: 403,
```

Checking the permissions (under "Set up job"):

```
GITHUB_TOKEN Permissions
  Contents: read
  Metadata: read
```

https://github.com/jazzband/prettytable/runs/2757517845?check_suite_focus=true

For the last good run two months ago, the permissions were:

```
GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Issues: write
  Metadata: read
  Packages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write
```

https://github.com/jazzband/prettytable/runs/2370488676?check_suite_focus=true#step:1:1

This will be due to the changes documented in https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and especially:

> Any permission that is absent from the list will be set to `none`.

So let's add the permissions mentioned in https://github.com/release-drafter/release-drafter/issues/869#issuecomment-844355468.
