### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: v1.17.0
     hooks:
       - id: setup-cfg-fmt
+        args: ["--max-py-version=3.10"]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 0.5.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.1
+    rev: v2.24.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
 
   - repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 21.7b0
     hooks:
       - id: black
         args: ["--target-version", "py36"]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.8.0
+    rev: 5.9.3
     hooks:
       - id: isort
 
@@ -23,7 +23,7 @@ repos:
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.8.0
+    rev: v1.9.0
     hooks:
       - id: python-check-blanket-noqa
 
@@ -39,12 +39,12 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 0.5.0
+    rev: 0.5.1
     hooks:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.3.1
+    rev: v2.3.2
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing


### PR DESCRIPTION
Python 3.10.0 final is out in October, and the release candidate is out now. We've been testing 3.10-dev for some time, let's declare support.