### PR TITLE
Set the length of each column

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,12 +354,12 @@ relevant row, in the column specified by the `sort_by` argument. The remaining n
 elements are the data in each of the table's columns, in order, including a repeated
 instance of the data in the `sort_by` column.
 
-##### Setting the minimum columns lengths
+##### Setting columns' minimum widths
 
 You can set the minimum width of each column using the property `columns_min_widths`:
 
 ```python
-x.columns_min_widths = [30, 15, 20, None]
+x.columns_min_widths = [30, 15, 20, 0]
 print(x)
 ```
 
@@ -379,7 +379,8 @@ to get:
 +--------------------------------+-----------------+----------------------+-----------------+
 ```
 
-If the argument `None` is passed, then the minimum width is automatically selected
+If `0` is given for a column, then the minimum width is calculated based on the column's
+data.
 
 ### Changing the appearance of your table - the easy way
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,9 @@ elements are the data in each of the table's columns, in order, including a repe
 instance of the data in the `sort_by` column.
 
 ##### Setting the minimum columns lengths
+
 You can set the minimum width of each column using the property `columns_min_widths`:
+
 ```python
 x.columns_min_widths = [30, 15, 20, None]
 print(x)
@@ -376,6 +378,7 @@ to get:
 |             Perth              |       5386      |       1554769        |      869.4      |
 +--------------------------------+-----------------+----------------------+-----------------+
 ```
+
 If the argument `None` is passed, then the minimum width is automatically selected
 
 ### Changing the appearance of your table - the easy way

--- a/README.md
+++ b/README.md
@@ -354,6 +354,30 @@ relevant row, in the column specified by the `sort_by` argument. The remaining n
 elements are the data in each of the table's columns, in order, including a repeated
 instance of the data in the `sort_by` column.
 
+##### Setting the minimum columns lengths
+You can set the minimum width of each column using the property `columns_min_widths`:
+```python
+x.columns_min_widths = [30, 15, 20, None]
+print(x)
+```
+
+to get:
+
+```
++--------------------------------+-----------------+----------------------+-----------------+
+|           City name            |       Area      |      Population      | Annual Rainfall |
++--------------------------------+-----------------+----------------------+-----------------+
+|            Adelaide            |       1295      |       1158259        |      600.5      |
+|            Brisbane            |       5905      |       1857594        |      1146.4     |
+|             Darwin             |       112       |        120900        |      1714.7     |
+|             Hobart             |       1357      |        205556        |      619.5      |
+|             Sydney             |       2058      |       4336374        |      1214.8     |
+|           Melbourne            |       1566      |       3806092        |      646.9      |
+|             Perth              |       5386      |       1554769        |      869.4      |
++--------------------------------+-----------------+----------------------+-----------------+
+```
+If the argument `None` is passed, then the minimum width is automatically selected
+
 ### Changing the appearance of your table - the easy way
 
 By default, PrettyTable produces ASCII tables that look like the ones used in SQL

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -529,30 +529,6 @@ class PrettyTable:
         except AssertionError:
             raise Exception("Attributes must be a dictionary of name/value pairs")
 
-    def _get_column_name_wight(self, field):
-        width, name = None, str()
-        split_field = field.split("'")
-        if len(split_field) > 1:
-            try:
-                width = int(split_field[-1])
-                name = "'".join(split_field[0:-1])
-            except ValueError:
-                name = field
-        else:
-            name = field
-        return name, width
-
-    def _get_column_name_and_set_wight(self, val):
-        if isinstance(val, str):
-            temp_val, temp_width = self._get_column_name_wight(val)
-            self._user_column_widths.append(temp_width)
-        else:
-            temp_val = []
-            for v in val:
-                temp_name, temp_width = self._get_column_name_wight(v)
-                temp_val.append(temp_name)
-                self._user_column_widths.append(temp_width)
-        return temp_val
     ##############################
     # ATTRIBUTE MANAGEMENT       #
     ##############################

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1351,6 +1351,7 @@ class PrettyTable:
         Arguments:
         fieldname - name of the field to contain the new column of data"""
         self._field_names.insert(0, fieldname)
+        self._columns_min_widths.insert(0, 0)
         self._align[fieldname] = self.align
         self._valign[fieldname] = self.valign
         for i, row in enumerate(self._rows):
@@ -1638,9 +1639,7 @@ class PrettyTable:
             bits.append(options[where + "right_junction_char"])
             return "".join(bits)
         for field, width, min_widths in zip(
-                self._field_names,
-                self._widths,
-                self._columns_min_widths
+            self._field_names, self._widths, self._columns_min_widths
         ):
             if options["fields"] and field not in options["fields"]:
                 continue
@@ -1702,9 +1701,9 @@ class PrettyTable:
             else:
                 bits.append(" ")
         for (field, width, min_widths) in zip(
-                self._field_names,
-                self._widths,
-                self._columns_min_widths,
+            self._field_names,
+            self._widths,
+            self._columns_min_widths,
         ):
             if options["fields"] and field not in options["fields"]:
                 continue
@@ -1772,10 +1771,10 @@ class PrettyTable:
                     bits[y].append(" ")
 
         for (field, value, width, min_widths) in zip(
-                self._field_names,
-                row,
-                self._widths,
-                self._columns_min_widths,
+            self._field_names,
+            row,
+            self._widths,
+            self._columns_min_widths,
         ):
             valign = self._valign[field]
             lines = value.split("\n")

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1346,12 +1346,12 @@ class PrettyTable:
                 f"{len(self._rows)}"
             )
 
-    def add_autoindex(self, fieldname="Index"):
+    def add_autoindex(self, fieldname="Index", min_width=0):
         """Add an auto-incrementing index column to the table.
         Arguments:
         fieldname - name of the field to contain the new column of data"""
         self._field_names.insert(0, fieldname)
-        self._columns_min_widths.insert(0, 0)
+        self._columns_min_widths.insert(0, min_width)
         self._align[fieldname] = self.align
         self._valign[fieldname] = self.valign
         for i, row in enumerate(self._rows):

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -392,7 +392,7 @@ class PrettyTable:
                     len(self._field_names) if self._field_names else len(self._rows[0])
                 )
                 raise Exception(
-                    "Columns minimum widths list has incorrect number of values, "
+                    "Columns' minimum widths list has incorrect number of values, "
                     f"(actual) {len(val)}!={field_len} (expected)"
                 )
 
@@ -535,7 +535,7 @@ class PrettyTable:
 
     @columns_min_widths.setter
     def columns_min_widths(self, val):
-        val = [int(x) if x else 0 for x in val]
+        val = [int(x) for x in val]
         self._validate_option("columns_min_widths", val)
         self._columns_min_widths = val
 
@@ -1634,12 +1634,12 @@ class PrettyTable:
         if not self._field_names:
             bits.append(options[where + "right_junction_char"])
             return "".join(bits)
-        for field, width, min_widths in zip(
+        for field, width, min_width in zip(
             self._field_names, self._widths, self._columns_min_widths
         ):
             if options["fields"] and field not in options["fields"]:
                 continue
-            temp_width = width if width > min_widths else min_widths
+            temp_width = max(width, min_width)
             bits.append((temp_width + lpad + rpad) * options["horizontal_char"])
             if options["vrules"] == ALL:
                 bits.append(options[where + "junction_char"])
@@ -1696,7 +1696,7 @@ class PrettyTable:
                 bits.append(options["vertical_char"])
             else:
                 bits.append(" ")
-        for (field, width, min_widths) in zip(
+        for (field, width, min_width) in zip(
             self._field_names,
             self._widths,
             self._columns_min_widths,
@@ -1713,7 +1713,7 @@ class PrettyTable:
                 fieldname = field.lower()
             else:
                 fieldname = field
-            temp_width = width if width > min_widths else min_widths
+            temp_width = max(width, min_width)
             bits.append(
                 " " * lpad
                 + self._justify(fieldname, temp_width, self._align[field])
@@ -1766,7 +1766,7 @@ class PrettyTable:
                 else:
                     bits[y].append(" ")
 
-        for (field, value, width, min_widths) in zip(
+        for (field, value, width, min_width) in zip(
             self._field_names,
             row,
             self._widths,
@@ -1791,7 +1791,7 @@ class PrettyTable:
             for line in lines:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                temp_width = width if width > min_widths else min_widths
+                temp_width = max(width, min_width)
                 bits[y].append(
                     " " * lpad
                     + self._justify(line, temp_width, self._align[field])

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -383,21 +383,17 @@ class PrettyTable:
 
     def _validate_columns_min_widths(self, val):
         # Check for appropriate length
-        if self._field_names:
+        if self._field_names or self._rows:
             try:
                 assert len(val) == len(self._field_names)
-            except AssertionError:
-                raise Exception(
-                    "Columns minimum widths list has incorrect number of values, "
-                    f"(actual) {len(val)}!={len(self._field_names)} (expected)"
-                )
-        if self._rows:
-            try:
                 assert len(val) == len(self._rows[0])
             except AssertionError:
+                field_len = (
+                    len(self._field_names) if self._field_names else len(self._rows[0])
+                )
                 raise Exception(
                     "Columns minimum widths list has incorrect number of values, "
-                    f"(actual) {len(val)}!={len(self._rows[0])} (expected)"
+                    f"(actual) {len(val)}!={field_len} (expected)"
                 )
 
     def _validate_field_names(self, val):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1211,6 +1211,18 @@ class ColumnsMinWidthsTest(unittest.TestCase):
         self.y.add_row(["Brisbane", 5905, 1857594])
         self.y.add_row(["Darwin", 112, 120900])
 
+        self.auto_index_table = PrettyTable()
+        self.auto_index_table.field_names = ["City name", "Area", "Population"]
+        self.auto_index_table.add_row(["Adelaide", 1295, 1158259])
+        self.auto_index_table.add_row(["Brisbane", 5905, 1857594])
+        self.auto_index_table.add_row(["Darwin", 112, 120900])
+
+        self.add_column_table = PrettyTable()
+        self.add_column_table.field_names = ["City name", "Area", "Population"]
+        self.add_column_table.add_row(["Adelaide", 1295, 1158259])
+        self.add_column_table.add_row(["Brisbane", 5905, 1857594])
+        self.add_column_table.add_row(["Darwin", 112, 120900])
+
     def testColumnsMinWidths(self):
         tables = [
             dict(
@@ -1266,3 +1278,19 @@ class ColumnsMinWidthsTest(unittest.TestCase):
             self.y.columns_min_widths = [20, 30]
         with self.assertRaises(Exception):
             self.y.columns_min_widths = [20, 30, 40, 50]
+
+    def testAutoIndex(self):
+        self.auto_index_table.add_autoindex(fieldname="Test")
+        self.assertEqual(self.auto_index_table.columns_min_widths, [0, 0, 0, 0])
+
+        self.auto_index_table.add_autoindex(fieldname="Test", min_width=30)
+        self.assertEqual(self.auto_index_table.columns_min_widths, [30, 0, 0, 0, 0])
+
+    def testAddColumn(self):
+        self.add_column_table.add_column("Starts with A", [True, False, False])
+        self.assertEqual(self.add_column_table.columns_min_widths, [0, 0, 0, 0])
+
+        self.add_column_table.add_column(
+            "Starts with B", [False, True, False], min_width=30
+        )
+        self.assertEqual(self.add_column_table.columns_min_widths, [0, 0, 0, 0, 30])

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1223,6 +1223,16 @@ class ColumnsMinWidthsTest(unittest.TestCase):
         self.add_column_table.add_row(["Brisbane", 5905, 1857594])
         self.add_column_table.add_row(["Darwin", 112, 120900])
 
+        self.min_width_table = PrettyTable()
+        self.min_width_table.field_names = ["City name", "Area", "Population"]
+        self.min_width_table.add_row(["Adelaide", 1295, 1158259])
+        self.min_width_table.add_row(["Brisbane", 5905, 1857594])
+
+        self.max_width_table = PrettyTable()
+        self.max_width_table.field_names = ["City name", "Area", "Population"]
+        self.max_width_table.add_row(["Adelaide", 1295, 1158259])
+        self.max_width_table.add_row(["Brisbane", 5905, 18575943432423434242342])
+
     def testColumnsMinWidths(self):
         tables = [
             dict(
@@ -1294,3 +1304,31 @@ class ColumnsMinWidthsTest(unittest.TestCase):
             "Starts with B", [False, True, False], min_width=30
         )
         assert self.add_column_table.columns_min_widths == [0, 0, 0, 0, 30]
+
+    def testMinWidth(self):
+        self.min_width_table.columns_min_widths = [15, 15, 30]
+        self.min_width_table.min_width["Area"] = 30
+        self.min_width_table.min_width["Population"] = 15
+        result = """
++-----------------+--------------------------------+--------------------------------+
+|    City name    |              Area              |           Population           |
++-----------------+--------------------------------+--------------------------------+
+|     Adelaide    |              1295              |            1158259             |
+|     Brisbane    |              5905              |            1857594             |
++-----------------+--------------------------------+--------------------------------+
+        """.strip()
+        assert self.min_width_table.get_string() == result
+
+    def testMaxWidth(self):
+        self.max_width_table.columns_min_widths = [10, 30, 10]
+        self.max_width_table.max_width["Area"] = 15
+        self.max_width_table.max_width["Population"] = 30
+        result = """
++------------+--------------------------------+-------------------------+
+| City name  |              Area              |        Population       |
++------------+--------------------------------+-------------------------+
+|  Adelaide  |              1295              |         1158259         |
+|  Brisbane  |              5905              | 18575943432423434242342 |
++------------+--------------------------------+-------------------------+
+                """.strip()
+        assert self.max_width_table.get_string() == result

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1206,6 +1206,11 @@ class ColumnsMinWidthsTest(unittest.TestCase):
         self.x.add_row(["Brisbane", 5905, 1857594])
         self.x.add_row(["Darwin", 112, 120900])
 
+        self.y = PrettyTable()
+        self.y.add_row(["Adelaide", 1295, 1158259])
+        self.y.add_row(["Brisbane", 5905, 1857594])
+        self.y.add_row(["Darwin", 112, 120900])
+
     def testColumnsMinWidths(self):
         tables = [
             dict(
@@ -1217,7 +1222,7 @@ class ColumnsMinWidthsTest(unittest.TestCase):
 |  Brisbane | 5905 |  1857594   |
 |   Darwin  | 112  |   120900   |
 +-----------+------+------------+
-                    """,
+""",
                 min_widths=[None, None, None],
             ),
             dict(
@@ -1228,8 +1233,8 @@ class ColumnsMinWidthsTest(unittest.TestCase):
 |       Adelaide       |              1295              |  1158259   |
 |       Brisbane       |              5905              |  1857594   |
 |        Darwin        |              112               |   120900   |
-+----------------------+--------------------------------+------------+           
-            """,
++----------------------+--------------------------------+------------+
+""",
                 min_widths=[20, 30, None],
             ),
             dict(
@@ -1240,12 +1245,24 @@ class ColumnsMinWidthsTest(unittest.TestCase):
 |  Adelaide |              1295              |  1158259   |
 |  Brisbane |              5905              |  1857594   |
 |   Darwin  |              112               |   120900   |
-+-----------+--------------------------------+------------+           
-                    """,
++-----------+--------------------------------+------------+
+""",
                 min_widths=[2, 30, 3],
             ),
         ]
         for table in tables:
             self.x.columns_min_widths = table["min_widths"]
             result = self.x.get_string()
-            assert result.strip() == table["result"].strip()
+            self.assertEqual(result.strip(), table["result"].strip())
+
+    def testExceptionsWithFieldNames(self):
+        with self.assertRaises(Exception):
+            self.x.columns_min_widths = [20, 30]
+        with self.assertRaises(Exception):
+            self.x.columns_min_widths = [20, 30, 40, 50]
+
+    def testExceptionsWithoutFieldNames(self):
+        with self.assertRaises(Exception):
+            self.y.columns_min_widths = [20, 30]
+        with self.assertRaises(Exception):
+            self.y.columns_min_widths = [20, 30, 40, 50]

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1201,51 +1201,51 @@ g..
 class ColumnsMinWidthsTest(unittest.TestCase):
     def setUp(self):
         self.x = PrettyTable()
-        self.x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
-        self.x.add_row(["Adelaide", 1295, 1158259, 600.5])
-        self.x.add_row(["Brisbane", 5905, 1857594, 1146.4])
-        self.x.add_row(["Darwin", 112, 120900, 1714.7])
+        self.x.field_names = ["City name", "Area", "Population"]
+        self.x.add_row(["Adelaide", 1295, 1158259])
+        self.x.add_row(["Brisbane", 5905, 1857594])
+        self.x.add_row(["Darwin", 112, 120900])
 
     def testColumnsMinWidths(self):
         tables = [
             dict(
                 result="""
-+-----------+------+------------+-----------------+
-| City name | Area | Population | Annual Rainfall |
-+-----------+------+------------+-----------------+
-|  Adelaide | 1295 |  1158259   |      600.5      |
-|  Brisbane | 5905 |  1857594   |      1146.4     |
-|   Darwin  | 112  |   120900   |      1714.7     |
-+-----------+------+------------+-----------------+
-                    """.strip(),
-                min_widths=[None, None, None, None],
++-----------+------+------------+
+| City name | Area | Population |
++-----------+------+------------+
+|  Adelaide | 1295 |  1158259   |
+|  Brisbane | 5905 |  1857594   |
+|   Darwin  | 112  |   120900   |
++-----------+------+------------+
+                    """,
+                min_widths=[None, None, None],
             ),
             dict(
                 result="""
-+----------------------+--------------------------------+---------------------------+-----------------+
-|      City name       |              Area              |         Population        | Annual Rainfall |
-+----------------------+--------------------------------+---------------------------+-----------------+
-|       Adelaide       |              1295              |          1158259          |      600.5      |
-|       Brisbane       |              5905              |          1857594          |      1146.4     |
-|        Darwin        |              112               |           120900          |      1714.7     |
-+----------------------+--------------------------------+---------------------------+-----------------+            
-            """.strip(),
-                min_widths=[20, 30, 25, None],
++----------------------+--------------------------------+------------+
+|      City name       |              Area              | Population |
++----------------------+--------------------------------+------------+
+|       Adelaide       |              1295              |  1158259   |
+|       Brisbane       |              5905              |  1857594   |
+|        Darwin        |              112               |   120900   |
++----------------------+--------------------------------+------------+           
+            """,
+                min_widths=[20, 30, None],
             ),
             dict(
                 result="""
-+-----------+--------------------------------+------------+-----------------+
-| City name |              Area              | Population | Annual Rainfall |
-+-----------+--------------------------------+------------+-----------------+
-|  Adelaide |              1295              |  1158259   |      600.5      |
-|  Brisbane |              5905              |  1857594   |      1146.4     |
-|   Darwin  |              112               |   120900   |      1714.7     |
-+-----------+--------------------------------+------------+-----------------+            
-                    """.strip(),
-                min_widths=[2, 30, 3, 10],
++-----------+--------------------------------+------------+
+| City name |              Area              | Population |
++-----------+--------------------------------+------------+
+|  Adelaide |              1295              |  1158259   |
+|  Brisbane |              5905              |  1857594   |
+|   Darwin  |              112               |   120900   |
++-----------+--------------------------------+------------+           
+                    """,
+                min_widths=[2, 30, 3],
             ),
         ]
         for table in tables:
             self.x.columns_min_widths = table['min_widths']
             result = self.x.get_string()
-            assert result == table['result']
+            assert result.strip() == table['result'].strip()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1235,7 +1235,7 @@ class ColumnsMinWidthsTest(unittest.TestCase):
 |   Darwin  | 112  |   120900   |
 +-----------+------+------------+
 """,
-                min_widths=[None, None, None],
+                min_widths=[0, 0, 0],
             ),
             dict(
                 result="""
@@ -1247,7 +1247,7 @@ class ColumnsMinWidthsTest(unittest.TestCase):
 |        Darwin        |              112               |   120900   |
 +----------------------+--------------------------------+------------+
 """,
-                min_widths=[20, 30, None],
+                min_widths=[20, 30, 0],
             ),
             dict(
                 result="""
@@ -1265,32 +1265,32 @@ class ColumnsMinWidthsTest(unittest.TestCase):
         for table in tables:
             self.x.columns_min_widths = table["min_widths"]
             result = self.x.get_string()
-            self.assertEqual(result.strip(), table["result"].strip())
+            assert result.strip() == table["result"].strip()
 
     def testExceptionsWithFieldNames(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.x.columns_min_widths = [20, 30]
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.x.columns_min_widths = [20, 30, 40, 50]
 
     def testExceptionsWithoutFieldNames(self):
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.y.columns_min_widths = [20, 30]
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             self.y.columns_min_widths = [20, 30, 40, 50]
 
     def testAutoIndex(self):
         self.auto_index_table.add_autoindex(fieldname="Test")
-        self.assertEqual(self.auto_index_table.columns_min_widths, [0, 0, 0, 0])
+        assert self.auto_index_table.columns_min_widths == [0, 0, 0, 0]
 
         self.auto_index_table.add_autoindex(fieldname="Test", min_width=30)
-        self.assertEqual(self.auto_index_table.columns_min_widths, [30, 0, 0, 0, 0])
+        assert self.auto_index_table.columns_min_widths == [30, 0, 0, 0, 0]
 
     def testAddColumn(self):
         self.add_column_table.add_column("Starts with A", [True, False, False])
-        self.assertEqual(self.add_column_table.columns_min_widths, [0, 0, 0, 0])
+        assert self.add_column_table.columns_min_widths == [0, 0, 0, 0]
 
         self.add_column_table.add_column(
             "Starts with B", [False, True, False], min_width=30
         )
-        self.assertEqual(self.add_column_table.columns_min_widths, [0, 0, 0, 0, 30])
+        assert self.add_column_table.columns_min_widths == [0, 0, 0, 0, 30]

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1246,6 +1246,6 @@ class ColumnsMinWidthsTest(unittest.TestCase):
             ),
         ]
         for table in tables:
-            self.x.columns_min_widths = table['min_widths']
+            self.x.columns_min_widths = table["min_widths"]
             result = self.x.get_string()
-            assert result.strip() == table['result'].strip()
+            assert result.strip() == table["result"].strip()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1246,6 +1246,6 @@ class ColumnsMinWidthsTest(unittest.TestCase):
             ),
         ]
         for table in tables:
-            self.x = table['min_widths']
+            self.x.columns_min_widths = table['min_widths']
             result = self.x.get_string()
             assert result == table['result']

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1196,3 +1196,56 @@ g..
 +-+-+-+
 """
         assert result.strip() == expected.strip()
+
+
+class ColumnsMinWidthsTest(unittest.TestCase):
+    def setUp(self):
+        self.x = PrettyTable()
+        self.x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
+        self.x.add_row(["Adelaide", 1295, 1158259, 600.5])
+        self.x.add_row(["Brisbane", 5905, 1857594, 1146.4])
+        self.x.add_row(["Darwin", 112, 120900, 1714.7])
+
+    def testColumnsMinWidths(self):
+        tables = [
+            dict(
+                result="""
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+|   Darwin  | 112  |   120900   |      1714.7     |
++-----------+------+------------+-----------------+
+                    """.strip(),
+                min_widths=[None, None, None, None],
+            ),
+            dict(
+                result="""
++----------------------+--------------------------------+---------------------------+-----------------+
+|      City name       |              Area              |         Population        | Annual Rainfall |
++----------------------+--------------------------------+---------------------------+-----------------+
+|       Adelaide       |              1295              |          1158259          |      600.5      |
+|       Brisbane       |              5905              |          1857594          |      1146.4     |
+|        Darwin        |              112               |           120900          |      1714.7     |
++----------------------+--------------------------------+---------------------------+-----------------+            
+            """.strip(),
+                min_widths=[20, 30, 25, None],
+            ),
+            dict(
+                result="""
++-----------+--------------------------------+------------+-----------------+
+| City name |              Area              | Population | Annual Rainfall |
++-----------+--------------------------------+------------+-----------------+
+|  Adelaide |              1295              |  1158259   |      600.5      |
+|  Brisbane |              5905              |  1857594   |      1146.4     |
+|   Darwin  |              112               |   120900   |      1714.7     |
++-----------+--------------------------------+------------+-----------------+            
+                    """.strip(),
+                min_widths=[2, 30, 3, 10],
+            ),
+        ]
+        for table in tables:
+            self.x = table['min_widths']
+            result = self.x.get_string()
+            assert result == table['result']


### PR DESCRIPTION
Set the length of each column with a separator `'`. For example:
```python
x = PrettyTable()
x.field_names = ["Country'50", "Capital", "is_russia", "that's mine"]
x.add_row(["Russia", "Moscow", True, True])
x.add_rows([["Argentina", "Buenos Aires", False, False], ["Jamaica", "Kingston", False, False]])
x.add_column("Starts with A'77", [False, True, False])
x.add_column("Can't do this'30", [False, True, False])

print(x)
```