### PR TITLE
Consider US G0 Character Set ANSI-escape code as 0-width (like colors)

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -59,7 +59,7 @@ ORGMODE = 14
 DOUBLE_BORDER = 15
 RANDOM = 20
 
-_re = re.compile(r"\033\[[0-9;]*m")
+_re = re.compile(r"\033\[[0-9;]*m|\033\(B")
 
 
 def _get_size(text):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -580,6 +580,44 @@ class BreakLineTests(unittest.TestCase):
         )
 
 
+class AnsiWidthTest(unittest.TestCase):
+    colored = "\033[31mC\033[32mO\033[31mL\033[32mO\033[31mR\033[32mE\033[31mD\033[0m"
+
+    def testColor(self):
+        t = PrettyTable(["Field 1", "Field 2"])
+        t.add_row([self.colored, self.colored])
+        t.add_row(["nothing", "neither"])
+        result = t.get_string()
+        assert (
+            result.strip()
+            == f"""
++---------+---------+
+| Field 1 | Field 2 |
++---------+---------+
+| {self.colored} | {self.colored} |
+| nothing | neither |
++---------+---------+
+""".strip()
+        )
+
+    def testReset(self):
+        t = PrettyTable(["Field 1", "Field 2"])
+        t.add_row(["abc def\033(B", "\033[31mabc def\033[m"])
+        t.add_row(["nothing", "neither"])
+        result = t.get_string()
+        assert (
+            result.strip()
+            == """
++---------+---------+
+| Field 1 | Field 2 |
++---------+---------+
+| abc def\033(B | \033[31mabc def\033[m |
+| nothing | neither |
++---------+---------+
+""".strip()
+        )
+
+
 class JSONOutputTests(unittest.TestCase):
     def testJSONOutput(self):
         t = helper_table()


### PR DESCRIPTION
The ANSI escape code "^[(B" is used in terminal for changing the
character set, and is output by some terminal-coloring libraries as part
of color-resetting code (for example, by blessed). It's also present in
"sgr0" code of terminfo from some terminals.

The bug was that prettytable didn't interpret it as 0-width
non-printable sequence but as the sequence of individual characters,
breaking the width of the column.
Like colors codes, it should be ignored when computing the width of a
cell.

Closes #129.