### PR TITLE
Add custom format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ The options are these:
   like: `print("%<int_format>d" % data)`
 - `float_format` - A string which controls the way floating point data is printed. This
   works like: `print("%<float_format>f" % data)`
+- `custom_format` - A Dictionary of field and callable. This allow you to set any format you wnat
+: `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`
 - `padding_width` - Number of spaces on either side of column data (only used if left
   and right paddings are `None`).
 - `left_padding_width` - Number of spaces on left hand side of column data.

--- a/README.md
+++ b/README.md
@@ -415,9 +415,9 @@ The options are these:
   like: `print("%<int_format>d" % data)`
 - `float_format` - A string which controls the way floating point data is printed. This
   works like: `print("%<float_format>f" % data)`
-- `custom_format` - A Dictionary of field and callable. This allow you to set any format you wnat
-: `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type of the callable if 
-```callable[[str, Any], str]```
+- `custom_format` - A Dictionary of field and callable. This allow you to set any format
+  you want `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type of the
+  callable if `callable[[str, Any], str]`
 - `padding_width` - Number of spaces on either side of column data (only used if left
   and right paddings are `None`).
 - `left_padding_width` - Number of spaces on left hand side of column data.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ The options are these:
 - `float_format` - A string which controls the way floating point data is printed. This
   works like: `print("%<float_format>f" % data)`
 - `custom_format` - A Dictionary of field and callable. This allow you to set any format you wnat
-: `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`
+: `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type of the callable if 
+```callable[[str, Any], str]```
 - `padding_width` - Number of spaces on either side of column data (only used if left
   and right paddings are `None`).
 - `left_padding_width` - Number of spaces on left hand side of column data.

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -92,6 +92,7 @@ class PrettyTable:
             Allowed values: FRAME, ALL, NONE
         int_format - controls formatting of integer data
         float_format - controls formatting of floating point data
+        custom_format - controls formatting of any column using callable
         min_table_width - minimum desired table width, in characters
         max_table_width - maximum desired table width, in characters
         min_width - minimum desired field width, in characters
@@ -366,8 +367,8 @@ class PrettyTable:
         elif option == "float_format":
             self._validate_float_format(option, val)
         elif option == "custom_format":
-            for formatter in val.values():
-                self._validate_function(option, formatter)
+            for k, formatter in val.items():
+                self._validate_function(f"{option}.{k}", formatter)
         elif option in (
             "vertical_char",
             "horizontal_char",
@@ -853,6 +854,27 @@ class PrettyTable:
             self._validate_option("float_format", val)
             for field in self._field_names:
                 self._float_format[field] = val
+
+    @property
+    def custom_format(self):
+        """Controls formatting of any column using callable
+        Arguments:
+
+        custom_format - Dictionary of field_name and callable"""
+        return self._custom_format
+
+    @custom_format.setter
+    def custom_format(self, val):
+        if val is None:
+            self._custom_format = {}
+        elif isinstance(val, dict):
+            for k, v in val.items():
+                self._validate_function(f"custom_value.{k}", v)
+            self._custom_format = val
+        else:
+            raise Exception(
+                "The custom_format property need to be a dictionary or callable"
+            )
 
     @property
     def padding_width(self):
@@ -1377,10 +1399,12 @@ class PrettyTable:
 
     def _format_value(self, field, value):
         if isinstance(value, int) and field in self._int_format:
-            value = ("%%%sd" % self._int_format[field]) % value
+            return ("%%%sd" % self._int_format[field]) % value
         elif isinstance(value, float) and field in self._float_format:
-            value = ("%%%sf" % self._float_format[field]) % value
-        return str(value)
+            return ("%%%sf" % self._float_format[field]) % value
+
+        formatter = self._custom_format.get(field, (lambda f, v: str(v)))
+        return formatter(field, value)
 
     def _compute_table_width(self, options):
         table_width = 2 if options["vrules"] in (FRAME, ALL) else 0
@@ -1512,6 +1536,7 @@ class PrettyTable:
             Allowed values: FRAME, ALL, NONE
         int_format - controls formatting of integer data
         float_format - controls formatting of floating point data
+        custom_format - controls formatting of any column using callable
         padding_width - number of spaces on either side of column data (only used if
             left and right paddings are None)
         left_padding_width - number of spaces on left hand side of column data
@@ -1875,6 +1900,7 @@ class PrettyTable:
             Allowed values: FRAME, ALL, NONE
         int_format - controls formatting of integer data
         float_format - controls formatting of floating point data
+        custom_format - controls formatting of any column using callable
         padding_width - number of spaces on either side of column data (only used if
             left and right paddings are None)
         left_padding_width - number of spaces on left hand side of column data

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -134,6 +134,8 @@ class PrettyTable:
         self.min_width = {}
         self.int_format = {}
         self.float_format = {}
+        self.custom_format = {}
+
         if field_names:
             self.field_names = field_names
         else:
@@ -156,6 +158,7 @@ class PrettyTable:
             "vrules",
             "int_format",
             "float_format",
+            "custom_format",
             "min_table_width",
             "max_table_width",
             "padding_width",
@@ -219,6 +222,7 @@ class PrettyTable:
         self.min_width = kwargs["min_width"] or {}
         self.int_format = kwargs["int_format"] or {}
         self.float_format = kwargs["float_format"] or {}
+        self.custom_format = kwargs["custom_format"] or {}
 
         self._min_table_width = kwargs["min_table_width"] or None
         self._max_table_width = kwargs["max_table_width"] or None
@@ -361,6 +365,9 @@ class PrettyTable:
             self._validate_int_format(option, val)
         elif option == "float_format":
             self._validate_float_format(option, val)
+        elif option == "custom_format":
+            for formatter in val.values():
+                self._validate_function(option, formatter)
         elif option in (
             "vertical_char",
             "horizontal_char",

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -872,7 +872,7 @@ class PrettyTable:
                 self._validate_function(f"custom_value.{k}", v)
             self._custom_format = val
         elif hasattr(val, "__call__"):
-            self._validate_function(f"custom_value", val)
+            self._validate_function("custom_value", val)
             for field in self._field_names:
                 self._custom_format[field] = val
         else:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -871,6 +871,10 @@ class PrettyTable:
             for k, v in val.items():
                 self._validate_function(f"custom_value.{k}", v)
             self._custom_format = val
+        elif hasattr(val, "__call__"):
+            self._validate_function(f"custom_value", val)
+            for field in self._field_names:
+                self._custom_format[field] = val
         else:
             raise Exception(
                 "The custom_format property need to be a dictionary or callable"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1387,3 +1387,19 @@ g..
 +-+-+-+
 """
         assert result.strip() == expected.strip()
+
+
+class TestCustomFormatter:
+    def test_init_custom_format_is_empty(self):
+        pt = PrettyTable()
+        assert pt.custom_format == {}
+
+    def test_init_custom_format_set_value(self):
+        pt = PrettyTable(custom_format = {"col1": (lambda col_name, value: f"{value:.2}")})
+        assert len(pt.custom_format) == 1
+
+    def test_init_custom_format_throw_error_is_not_callable(self):
+        with pytest.raises(Exception) as e:
+            pt = PrettyTable(custom_format = {"col1": "{:.2}"})
+        
+        assert "Invalid value for custom_format. Must be a function."  in str(e.value)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1465,3 +1465,30 @@ class TestCustomFormatter:
 +-------------+----------+-----------+------------+
 """.strip()
         )
+
+    def test_custom_format_multi_type_using_on_function(self):
+        pt = PrettyTable(["col_date", "col_str", "col_float", "col_int"])
+        pt.add_row([date(2021, 1, 1), "January", 12345.12345, 12345678])
+        pt.add_row([date(2021, 2, 1), "February", 54321.12345, 87654321])
+
+        def my_format(col: str, value: Any) -> str:
+            if col == "col_date":
+                return value.strftime("%d %b %Y")
+            if col == "col_float":
+                return f"{value:.3f}"
+            if col == "col_int":
+                return f"{value:,}"
+            return str(value)
+
+        pt.custom_format = my_format
+        assert (
+            pt.get_string().strip()
+            == """
++-------------+----------+-----------+------------+
+|   col_date  | col_str  | col_float |  col_int   |
++-------------+----------+-----------+------------+
+| 01 Jan 2021 | January  | 12345.123 | 12,345,678 |
+| 01 Feb 2021 | February | 54321.123 | 87,654,321 |
++-------------+----------+-----------+------------+
+""".strip()
+        )

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,6 +1,7 @@
 import io
 import random
 import sqlite3
+from datetime import date
 from math import e, pi, sqrt
 from typing import Any, List
 
@@ -1395,11 +1396,72 @@ class TestCustomFormatter:
         assert pt.custom_format == {}
 
     def test_init_custom_format_set_value(self):
-        pt = PrettyTable(custom_format = {"col1": (lambda col_name, value: f"{value:.2}")})
+        pt = PrettyTable(
+            custom_format={"col1": (lambda col_name, value: f"{value:.2}")}
+        )
         assert len(pt.custom_format) == 1
 
     def test_init_custom_format_throw_error_is_not_callable(self):
         with pytest.raises(Exception) as e:
-            pt = PrettyTable(custom_format = {"col1": "{:.2}"})
-        
-        assert "Invalid value for custom_format. Must be a function."  in str(e.value)
+            PrettyTable(custom_format={"col1": "{:.2}"})
+
+        assert "Invalid value for custom_format.col1. Must be a function." in str(
+            e.value
+        )
+
+    def test_can_set_custom_format_from_property_setter(self):
+        pt = PrettyTable()
+        pt.custom_format = {"col1": (lambda col_name, value: f"{value:.2}")}
+        assert len(pt.custom_format) == 1
+
+    def test_set_custom_format_to_none_set_empty_dict(self):
+        pt = PrettyTable()
+        pt.custom_format = None
+        assert len(pt.custom_format) == 0
+        assert isinstance(pt.custom_format, dict)
+
+    def test_set_custom_format_invalid_type_throw_error(self):
+        pt = PrettyTable()
+        with pytest.raises(Exception) as e:
+            pt.custom_format = "Some String"
+        assert "The custom_format property need to be a dictionary or callable" in str(
+            e.value
+        )
+
+    def test_use_custom_formater_for_int(self, city_data_prettytable: PrettyTable):
+        city_data_prettytable.custom_format["Annual Rainfall"] = lambda n, v: f"{v:.2f}"
+        assert (
+            city_data_prettytable.get_string().strip()
+            == """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.50     |
+|  Brisbane | 5905 |  1857594   |     1146.40     |
+|   Darwin  | 112  |   120900   |     1714.70     |
+|   Hobart  | 1357 |   205556   |      619.50     |
+|   Sydney  | 2058 |  4336374   |     1214.80     |
+| Melbourne | 1566 |  3806092   |      646.90     |
+|   Perth   | 5386 |  1554769   |      869.40     |
++-----------+------+------------+-----------------+
+""".strip()
+        )
+
+    def test_custom_format_multi_type(self):
+        pt = PrettyTable(["col_date", "col_str", "col_float", "col_int"])
+        pt.add_row([date(2021, 1, 1), "January", 12345.12345, 12345678])
+        pt.add_row([date(2021, 2, 1), "February", 54321.12345, 87654321])
+        pt.custom_format["col_date"] = lambda f, v: v.strftime("%d %b %Y")
+        pt.custom_format["col_float"] = lambda f, v: f"{v:.3f}"
+        pt.custom_format["col_int"] = lambda f, v: f"{v:,}"
+        assert (
+            pt.get_string().strip()
+            == """
++-------------+----------+-----------+------------+
+|   col_date  | col_str  | col_float |  col_int   |
++-------------+----------+-----------+------------+
+| 01 Jan 2021 | January  | 12345.123 | 12,345,678 |
+| 01 Feb 2021 | February | 54321.123 | 87,654,321 |
++-------------+----------+-----------+------------+
+""".strip()
+        )

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,7 +1,7 @@
+import datetime as dt
 import io
 import random
 import sqlite3
-from datetime import date
 from math import e, pi, sqrt
 from typing import Any, List
 
@@ -1449,8 +1449,8 @@ class TestCustomFormatter:
 
     def test_custom_format_multi_type(self):
         pt = PrettyTable(["col_date", "col_str", "col_float", "col_int"])
-        pt.add_row([date(2021, 1, 1), "January", 12345.12345, 12345678])
-        pt.add_row([date(2021, 2, 1), "February", 54321.12345, 87654321])
+        pt.add_row([dt.date(2021, 1, 1), "January", 12345.12345, 12345678])
+        pt.add_row([dt.date(2021, 2, 1), "February", 54321.12345, 87654321])
         pt.custom_format["col_date"] = lambda f, v: v.strftime("%d %b %Y")
         pt.custom_format["col_float"] = lambda f, v: f"{v:.3f}"
         pt.custom_format["col_int"] = lambda f, v: f"{v:,}"
@@ -1468,8 +1468,8 @@ class TestCustomFormatter:
 
     def test_custom_format_multi_type_using_on_function(self):
         pt = PrettyTable(["col_date", "col_str", "col_float", "col_int"])
-        pt.add_row([date(2021, 1, 1), "January", 12345.12345, 12345678])
-        pt.add_row([date(2021, 2, 1), "February", 54321.12345, 87654321])
+        pt.add_row([dt.date(2021, 1, 1), "January", 12345.12345, 12345678])
+        pt.add_row([dt.date(2021, 2, 1), "February", 54321.12345, 87654321])
 
         def my_format(col: str, value: Any) -> str:
             if col == "col_date":


### PR DESCRIPTION
* Fixes https://github.com/jazzband/prettytable/issues/105.
* Fixes https://github.com/jazzband/prettytable/issues/92.
* Fixes https://github.com/jazzband/prettytable/issues/99.

This change should be able to address all the following issues.
It add the capability to set custom formatter for any column as callable. You can set as well
``` python
        pt = PrettyTable(["col_date", "col_str", "col_float", "col_int"])
        pt.add_row([date(2021, 1, 1), "January", 12345.12345, 12345678])
        pt.add_row([date(2021, 2, 1), "February", 54321.12345, 87654321])
        pt.custom_format["col_date"] = lambda f, v: v.strftime("%d %b %Y")
        pt.custom_format["col_float"] = lambda f, v: f"{v:.3f}"
        pt.custom_format["col_int"] = lambda f, v: f"{v:,}"
```

would generate a table like that

```
+-------------+----------+-----------+------------+
|   col_date  | col_str  | col_float |  col_int   |
+-------------+----------+-----------+------------+
| 01 Jan 2021 | January  | 12345.123 | 12,345,678 |
| 01 Feb 2021 | February | 54321.123 | 87,654,321 |
+-------------+----------+-----------+------------+
```
This PR should help with all below issues:
- https://github.com/jazzband/prettytable/issues/105
- https://github.com/jazzband/prettytable/issues/92
- https://github.com/jazzband/prettytable/issues/99