### PR TITLE
Markdown: Add colons to align the rendered output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ See GitHub Releases:
   correctly for tables with e.g. Japanese text.
 - Table contents can now be read in from a .csv file
 - Table contents can now be read in from a DB-API compatible cursor
-- Table contents can now be read in from a string containing a HTML table (thanks to
+- Table contents can now be read in from a string containing an HTML table (thanks to
   Christoph Robbert for submitting this patch!)
 - New `valign` attribute controls vertical alignment of text when some cells in a row
   have multiple lines of text and others don't. (thanks to Google Code user maartendb

--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ The options are these:
 - `vertical_char` - Single character string used to draw vertical lines. Default is `|`.
 - `horizontal_char` - Single character string used to draw horizontal lines. Default is
   `-`.
+- `_horizontal_align_char` - single character string used to indicate column alignment
+  in horizontal lines. Default is `:` for Markdown, otherwise `None`.
 - `junction_char` - Single character string used to draw line junctions. Default is `+`.
 - `top_junction_char` - single character string used to draw top line junctions. Default
   is `junction_char`.

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ instance of the data in the `sort_by` column.
 ### Changing the appearance of your table - the easy way
 
 By default, PrettyTable produces ASCII tables that look like the ones used in SQL
-database shells. But if can print them in a variety of other formats as well. If the
+database shells. But it can print them in a variety of other formats as well. If the
 format you want to use is common, PrettyTable makes this easy for you to do using the
 `set_style` method. If you want to produce an uncommon table, you'll have to do things
 slightly harder (see later).
@@ -374,8 +374,7 @@ x.set_style(MSWORD_FRIENDLY)
 print(x)
 ```
 
-In addition to `MSWORD_FRIENDLY` there are currently two other in-built styles you can
-use for your tables:
+In addition to `MSWORD_FRIENDLY` you can use these in-built styles for your tables:
 
 - `DEFAULT` - The default look, used to undo any style changes you may have made
 - `PLAIN_COLUMNS` - A borderless style that works well with command line programs for
@@ -402,10 +401,10 @@ whatever you prefer. The `set_style` method just does this automatically for you
 
 The options are these:
 
-- `border` - A boolean option (must be `True` or `False`). Controls whether or not a
-  border is drawn around the table.
-- `header` - A boolean option (must be `True` or `False`). Controls whether or not the
-  first row of the table is a header showing the names of all the fields.
+- `border` - A boolean option (must be `True` or `False`). Controls whether a border is
+  drawn around the table.
+- `header` - A boolean option (must be `True` or `False`). Controls whether the first
+  row of the table is a header showing the names of all the fields.
 - `hrules` - Controls printing of horizontal rules after rows. Allowed values: `FRAME`,
   `HEADER`, `ALL`, `NONE` - note that these are variables defined inside the
   `prettytable` module so make sure you import them or use `prettytable.FRAME` etc.
@@ -415,13 +414,13 @@ The options are these:
   like: `print("%<int_format>d" % data)`
 - `float_format` - A string which controls the way floating point data is printed. This
   works like: `print("%<float_format>f" % data)`
-- `custom_format` - A Dictionary of field and callable. This allow you to set any format
-  you want `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type of the
-  callable if `callable[[str, Any], str]`
+- `custom_format` - A Dictionary of field and callable. This allows you to set any
+  format you want `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type
+  of the callable if `callable[[str, Any], str]`
 - `padding_width` - Number of spaces on either side of column data (only used if left
   and right paddings are `None`).
-- `left_padding_width` - Number of spaces on left hand side of column data.
-- `right_padding_width` - Number of spaces on right hand side of column data.
+- `left_padding_width` - Number of spaces on left-hand side of column data.
+- `right_padding_width` - Number of spaces on right-hand side of column data.
 - `vertical_char` - Single character string used to draw vertical lines. Default is `|`.
 - `horizontal_char` - Single character string used to draw horizontal lines. Default is
   `-`.
@@ -554,7 +553,7 @@ x.format = True
 and the setting will persist until you turn it off.
 
 Just like with ASCII tables, if you want to change the table's style for just one
-`get_html_string` you can pass those methods keyword arguments - exactly like `print`
+`get_html_string` you can pass those methods' keyword arguments - exactly like `print`
 and `get_string`.
 
 #### Setting HTML attributes

--- a/README.md
+++ b/README.md
@@ -561,17 +561,17 @@ and `get_string`.
 
 You can provide a dictionary of HTML attribute name/value pairs to the `get_html_string`
 method using the `attributes` keyword argument. This lets you specify common HTML
-attributes like `name`, `id` and `class` that can be used for linking to your tables or
+attributes like `id` and `class` that can be used for linking to your tables or
 customising their appearance using CSS. For example:
 
 ```python
-print(x.get_html_string(attributes={"name":"my_table", "class":"red_table"}))
+print(x.get_html_string(attributes={"id":"my_table", "class":"red_table"}))
 ```
 
 will print:
 
 ```html
-<table name="my_table" class="red_table">
+<table id="my_table" class="red_table">
   <thead>
     <tr>
       <th>City name</th>

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2167,9 +2167,9 @@ class PrettyTable:
         else:
             wanted_fields = self._field_names
 
-        aligments = "".join([self._align[field] for field in wanted_fields])
+        alignments = "".join([self._align[field] for field in wanted_fields])
 
-        begin_cmd = "\\begin{tabular}{%s}" % aligments
+        begin_cmd = "\\begin{tabular}{%s}" % alignments
         lines.append(begin_cmd)
 
         # Headers
@@ -2200,16 +2200,16 @@ class PrettyTable:
         else:
             wanted_fields = self._field_names
 
-        wanted_aligments = [self._align[field] for field in wanted_fields]
+        wanted_alignments = [self._align[field] for field in wanted_fields]
         if options["border"] and options["vrules"] == ALL:
-            aligment_str = "|".join(wanted_aligments)
+            alignment_str = "|".join(wanted_alignments)
         else:
-            aligment_str = "".join(wanted_aligments)
+            alignment_str = "".join(wanted_alignments)
 
         if options["border"] and options["vrules"] in [ALL, FRAME]:
-            aligment_str = "|" + aligment_str + "|"
+            alignment_str = "|" + alignment_str + "|"
 
-        begin_cmd = "\\begin{tabular}{%s}" % aligment_str
+        begin_cmd = "\\begin{tabular}{%s}" % alignment_str
         lines.append(begin_cmd)
 
         if options["border"] and options["hrules"] in [ALL, FRAME]:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1982,9 +1982,7 @@ class PrettyTable:
         open_tag = ["<table"]
         if options["attributes"]:
             for attr_name in options["attributes"]:
-                open_tag.append(
-                    ' {}="{}"'.format(attr_name, options["attributes"][attr_name])
-                )
+                open_tag.append(f' {attr_name}="{options["attributes"][attr_name]}"')
         open_tag.append(">")
         lines.append("".join(open_tag))
 
@@ -2056,9 +2054,7 @@ class PrettyTable:
                 open_tag.append(' frame="vsides" rules="cols"')
         if options["attributes"]:
             for attr_name in options["attributes"]:
-                open_tag.append(
-                    ' {}="{}"'.format(attr_name, options["attributes"][attr_name])
-                )
+                open_tag.append(f' {attr_name}="{options["attributes"][attr_name]}"')
         open_tag.append(">")
         lines.append("".join(open_tag))
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -103,6 +103,7 @@ class PrettyTable:
         right_padding_width - number of spaces on right hand side of column data
         vertical_char - single character string used to draw vertical lines
         horizontal_char - single character string used to draw horizontal lines
+        horizontal_align_char - single character string used to indicate alignment
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
         bottom_junction_char -
@@ -167,6 +168,7 @@ class PrettyTable:
             "right_padding_width",
             "vertical_char",
             "horizontal_char",
+            "horizontal_align_char",
             "junction_char",
             "header_style",
             "valign",
@@ -236,6 +238,7 @@ class PrettyTable:
 
         self._vertical_char = kwargs["vertical_char"] or "|"
         self._horizontal_char = kwargs["horizontal_char"] or "-"
+        self._horizontal_align_char = kwargs["horizontal_align_char"]
         self._junction_char = kwargs["junction_char"] or "+"
         self._top_junction_char = kwargs["top_junction_char"]
         self._bottom_junction_char = kwargs["bottom_junction_char"]
@@ -382,6 +385,7 @@ class PrettyTable:
         elif option in (
             "vertical_char",
             "horizontal_char",
+            "horizontal_align_char",
             "junction_char",
             "top_junction_char",
             "bottom_junction_char",
@@ -966,6 +970,21 @@ class PrettyTable:
         self._horizontal_char = val
 
     @property
+    def horizontal_align_char(self):
+        """The character used to indicate column alignment in horizontal lines
+
+        Arguments:
+
+        horizontal_align_char - single character string used to indicate alignment"""
+        return self._bottom_left_junction_char or self.junction_char
+
+    @horizontal_align_char.setter
+    def horizontal_align_char(self, val):
+        val = str(val)
+        self._validate_option("horizontal_align_char", val)
+        self._horizontal_align_char = val
+
+    @property
     def junction_char(self):
         """The character used when printing table borders to draw line junctions
 
@@ -1214,6 +1233,7 @@ class PrettyTable:
         self.right_padding_width = 1
         self.vertical_char = "|"
         self.junction_char = "|"
+        self._horizontal_align_char = ":"
 
     def _set_default_style(self):
 
@@ -1226,6 +1246,7 @@ class PrettyTable:
         self.right_padding_width = 1
         self.vertical_char = "|"
         self.horizontal_char = "-"
+        self._horizontal_align_char = None
         self.junction_char = "+"
         self._top_junction_char = None
         self._bottom_junction_char = None
@@ -1560,6 +1581,7 @@ class PrettyTable:
         right_padding_width - number of spaces on right hand side of column data
         vertical_char - single character string used to draw vertical lines
         horizontal_char - single character string used to draw horizontal lines
+        horizontal_align_char - single character string used to indicate alignment
         junction_char - single character string used to draw line junctions
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
@@ -1655,7 +1677,17 @@ class PrettyTable:
         for field, width in zip(self._field_names, self._widths):
             if options["fields"] and field not in options["fields"]:
                 continue
-            bits.append((width + lpad + rpad) * options["horizontal_char"])
+
+            line = (width + lpad + rpad) * options["horizontal_char"]
+
+            # If necessary, add column alignment characters (e.g. ":" for Markdown)
+            if self._horizontal_align_char:
+                if self._align[field] in ("l", "c"):
+                    line = self._horizontal_align_char + line[1:]
+                if self._align[field] in ("c", "r"):
+                    line = line[:-1] + self._horizontal_align_char
+
+            bits.append(line)
             if options["vrules"] == ALL:
                 bits.append(options[where + "junction_char"])
             else:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -190,7 +190,7 @@ class TestFieldNameLessTable:
         assert "|  Field 1  | Field 2 | Field 3 | Field 4 |" in output
         assert "|  Adelaide |   1295  | 1158259 |  600.5  |" in output
 
-    def test_can_sring_HTML(self, field_name_less_table: prettytable):
+    def test_can_string_HTML(self, field_name_less_table: prettytable):
         output = field_name_less_table.get_html_string()
         assert "<th>Field 1</th>" in output
         assert "<td>Adelaide</td>" in output
@@ -354,7 +354,7 @@ class TestBasic:
         lines = string.split("\n")
         assert "" not in lines
 
-    def _test_all_lenght_equal(self, table: prettytable):
+    def _test_all_length_equal(self, table: prettytable):
         string = table.get_string()
         lines = string.split("\n")
         lengths = [len(line) for line in lines]
@@ -367,7 +367,7 @@ class TestBasic:
 
     def test_all_lengths_equal(self, city_data_prettytable):
         """All lines in a table should be of the same length."""
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_title(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -377,7 +377,7 @@ class TestBasic:
     def test_all_lengths_equal_with_title(self, city_data_prettytable: PrettyTable):
         """All lines in a table should be of the same length."""
         city_data_prettytable.title = "My table"
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_without_border(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -387,7 +387,7 @@ class TestBasic:
     def test_all_lengths_equal_without_border(self, city_data_prettytable: PrettyTable):
         """All lines in a table should be of the same length."""
         city_data_prettytable.border = False
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_without_header(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -397,7 +397,7 @@ class TestBasic:
     def test_all_lengths_equal_without_header(self, city_data_prettytable: PrettyTable):
         """All lines in a table should be of the same length."""
         city_data_prettytable.header = False
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_hrules_none(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -409,7 +409,7 @@ class TestBasic:
     ):
         """All lines in a table should be of the same length."""
         city_data_prettytable.hrules = NONE
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_hrules_all(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -421,7 +421,7 @@ class TestBasic:
     ):
         """All lines in a table should be of the same length."""
         city_data_prettytable.hrules = ALL
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_style_msword(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -433,7 +433,7 @@ class TestBasic:
     ):
         """All lines in a table should be of the same length."""
         city_data_prettytable.set_style(MSWORD_FRIENDLY)
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_int_format(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -445,7 +445,7 @@ class TestBasic:
     ):
         """All lines in a table should be of the same length."""
         city_data_prettytable.int_format = "04"
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_with_float_format(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -457,7 +457,7 @@ class TestBasic:
     ):
         """All lines in a table should be of the same length."""
         city_data_prettytable.float_format = "6.2f"
-        self._test_all_lenght_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_from_csv(self, city_data_from_csv: PrettyTable):
         """No table should ever have blank lines in it."""
@@ -465,7 +465,7 @@ class TestBasic:
 
     def test_all_lengths_equal_from_csv(self, city_data_from_csv: PrettyTable):
         """All lines in a table should be of the same length."""
-        self._test_all_lenght_equal(city_data_from_csv)
+        self._test_all_length_equal(city_data_from_csv)
 
     @pytest.mark.usefixtures("init_db")
     def test_no_blank_lines_from_db(self, db_cursor):
@@ -479,7 +479,7 @@ class TestBasic:
         """No table should ever have blank lines in it."""
         db_cursor.execute("SELECT * FROM cities")
         pt = from_db_cursor(db_cursor)
-        self._test_all_lenght_equal(pt)
+        self._test_all_length_equal(pt)
 
 
 class TestEmptyTable:
@@ -585,9 +585,9 @@ class TestSorting:
         x = PrettyTable(["Foo"])
         for i in range(20, 0, -1):
             x.add_row([i])
-        newstyle = x.get_string(sortby="Foo", end=10)
-        assert "10" in newstyle
-        assert "20" not in newstyle
+        new_style = x.get_string(sortby="Foo", end=10)
+        assert "10" in new_style
+        assert "20" not in new_style
         oldstyle = x.get_string(sortby="Foo", end=10, oldsortslice=True)
         assert "10" not in oldstyle
         assert "20" in oldstyle
@@ -1564,7 +1564,7 @@ class TestCustomFormatter:
             e.value
         )
 
-    def test_use_custom_formater_for_int(self, city_data_prettytable: PrettyTable):
+    def test_use_custom_formatter_for_int(self, city_data_prettytable: PrettyTable):
         city_data_prettytable.custom_format["Annual Rainfall"] = lambda n, v: f"{v:.2f}"
         assert (
             city_data_prettytable.get_string().strip()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1058,7 +1058,7 @@ class TestStyle:
                 MARKDOWN,
                 """
 | Field 1 | Field 2 | Field 3 |
-|---------|---------|---------|
+|:-------:|:-------:|:-------:|
 | value 1 |  value2 |  value3 |
 | value 4 |  value5 |  value6 |
 | value 7 |  value8 |  value9 |
@@ -1145,6 +1145,37 @@ value 7         value8         value9
         # This is an hrule style, not a table style
         with pytest.raises(Exception):
             t.set_style(ALL)
+
+    @pytest.mark.parametrize(
+        "style, expected",
+        [
+            pytest.param(
+                MARKDOWN,
+                """
+| Align left | Align centre | Align right |
+|:-----------|:------------:|------------:|
+| value 1    |    value2    |      value3 |
+| value 4    |    value5    |      value6 |
+| value 7    |    value8    |      value9 |
+""",
+                id="MARKDOWN",
+            ),
+        ],
+    )
+    def test_style_align(self, style, expected):
+        # Arrange
+        t = helper_table()
+        t.field_names = ["Align left", "Align centre", "Align right"]
+
+        # Act
+        t.set_style(style)
+        t.align["Align left"] = "l"
+        t.align["Align centre"] = "c"
+        t.align["Align right"] = "r"
+
+        # Assert
+        result = t.get_string()
+        assert result.strip() == expected.strip()
 
 
 class TestCsvOutput:


### PR DESCRIPTION
Fixes https://github.com/jazzband/prettytable/issues/149.

Plus fix some typos, replace invalid HTML5 `name` attribute in an example, and use f-strings.