### PR TITLE
Added requirements.txt to clarify installation requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+wcwidth
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 wcwidth
-


### PR DESCRIPTION
While packaging the prettytable module in spack, the installation errored out due to the lack of the depencency wcwidth. I've PR'd this requirements.txt so that people packaging or installing this module in the future are aware of this dependency. 