### PR TITLE
Resolve "KeyError" issue on `_stringify_row`

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1830,7 +1830,7 @@ class PrettyTable:
             lines = value.split("\n")
             new_lines = []
             for line in lines:
-                if line == "None" and self.none_format[field] is not None:
+                if line == "None" and self.none_format.get(field) is not None:
                     line = self.none_format[field]
                 if _str_block_width(line) > width:
                     line = textwrap.fill(line, width)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1234,9 +1234,9 @@ class TestStyle:
             pytest.param(
                 PLAIN_COLUMNS,
                 """
-Field 1        Field 2        Field 3
-value 1         value2         value3
-value 4         value5         value6
+Field 1        Field 2        Field 3        
+value 1         value2         value3        
+value 4         value5         value6        
 value 7         value8         value9
 """,  # noqa: W291
                 id="PLAIN_COLUMNS",

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -117,6 +117,20 @@ class TestNoneOption:
 """.strip()
         )
 
+    def test_no_value_replace_none_string(self):
+        t = PrettyTable()
+        t.add_row(["value 1", "None", "value 2"])
+        assert (
+            t.get_string().strip()
+            == """
++---------+---------+---------+
+| Field 1 | Field 2 | Field 3 |
++---------+---------+---------+
+| value 1 |   None  | value 2 |
++---------+---------+---------+
+""".strip()
+        )
+
     def test_replace_none_all(self):
         t = PrettyTable(["Field 1", "Field 2", "Field 3"], none_format="N/A")
         t.add_row(["value 1", None, "None"])
@@ -1220,9 +1234,9 @@ class TestStyle:
             pytest.param(
                 PLAIN_COLUMNS,
                 """
-Field 1        Field 2        Field 3        
-value 1         value2         value3        
-value 4         value5         value6        
+Field 1        Field 2        Field 3
+value 1         value2         value3
+value 4         value5         value6
 value 7         value8         value9
 """,  # noqa: W291
                 id="PLAIN_COLUMNS",

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -117,7 +117,7 @@ class TestNoneOption:
 """.strip()
         )
 
-    def test_no_value_replace_none_string(self):
+    def test_no_value_replace_none_with_default_field_names(self):
         t = PrettyTable()
         t.add_row(["value 1", "None", "value 2"])
         assert (


### PR DESCRIPTION
If PrettyTable class instance is initialized without field_names
calling `get_string` function raises "KeyError" exception if there is any
"None" line.

resolves #166