### PR TITLE
Use concrete built-in exceptions instead of Exception base class

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -312,7 +312,7 @@ class PrettyTable:
         elif isinstance(index, int):
             new.add_row(self._rows[index])
         else:
-            raise Exception(f"Index {index} is invalid, must be an integer or slice")
+            raise IndexError(f"Index {index} is invalid, must be an integer or slice")
         return new
 
     def __str__(self):
@@ -411,7 +411,7 @@ class PrettyTable:
             try:
                 assert len(val) == len(self._field_names)
             except AssertionError:
-                raise Exception(
+                raise ValueError(
                     "Field name list has incorrect number of values, "
                     f"(actual) {len(val)}!={len(self._field_names)} (expected)"
                 )
@@ -419,7 +419,7 @@ class PrettyTable:
             try:
                 assert len(val) == len(self._rows[0])
             except AssertionError:
-                raise Exception(
+                raise ValueError(
                     "Field name list has incorrect number of values, "
                     f"(actual) {len(val)}!={len(self._rows[0])} (expected)"
                 )
@@ -427,14 +427,14 @@ class PrettyTable:
         try:
             assert len(val) == len(set(val))
         except AssertionError:
-            raise Exception("Field names must be unique")
+            raise ValueError("Field names must be unique")
 
     def _validate_none_format(self, val):
         try:
             if val is not None:
                 assert isinstance(val, str)
         except AssertionError:
-            raise Exception(
+            raise TypeError(
                 "Replacement for None value must be a string if being supplied."
             )
 
@@ -442,7 +442,7 @@ class PrettyTable:
         try:
             assert val in ("cap", "title", "upper", "lower", None)
         except AssertionError:
-            raise Exception(
+            raise ValueError(
                 "Invalid header style, use cap, title, upper, lower or None"
             )
 
@@ -450,25 +450,25 @@ class PrettyTable:
         try:
             assert val in ["l", "c", "r"]
         except AssertionError:
-            raise Exception(f"Alignment {val} is invalid, use l, c or r")
+            raise ValueError(f"Alignment {val} is invalid, use l, c or r")
 
     def _validate_valign(self, val):
         try:
             assert val in ["t", "m", "b", None]
         except AssertionError:
-            raise Exception(f"Alignment {val} is invalid, use t, m, b or None")
+            raise ValueError(f"Alignment {val} is invalid, use t, m, b or None")
 
     def _validate_nonnegative_int(self, name, val):
         try:
             assert int(val) >= 0
         except AssertionError:
-            raise Exception(f"Invalid value for {name}: {val}")
+            raise ValueError(f"Invalid value for {name}: {val}")
 
     def _validate_true_or_false(self, name, val):
         try:
             assert val in (True, False)
         except AssertionError:
-            raise Exception(f"Invalid value for {name}. Must be True or False.")
+            raise ValueError(f"Invalid value for {name}. Must be True or False.")
 
     def _validate_int_format(self, name, val):
         if val == "":
@@ -477,7 +477,7 @@ class PrettyTable:
             assert isinstance(val, str)
             assert val.isdigit()
         except AssertionError:
-            raise Exception(
+            raise ValueError(
                 f"Invalid value for {name}. Must be an integer format string."
             )
 
@@ -496,19 +496,21 @@ class PrettyTable:
                 or (bits[1][-1] == "f" and bits[1].rstrip("f").isdigit())
             )
         except AssertionError:
-            raise Exception(f"Invalid value for {name}. Must be a float format string.")
+            raise ValueError(
+                f"Invalid value for {name}. Must be a float format string."
+            )
 
     def _validate_function(self, name, val):
         try:
             assert hasattr(val, "__call__")
         except AssertionError:
-            raise Exception(f"Invalid value for {name}. Must be a function.")
+            raise ValueError(f"Invalid value for {name}. Must be a function.")
 
     def _validate_hrules(self, name, val):
         try:
             assert val in (ALL, FRAME, HEADER, NONE)
         except AssertionError:
-            raise Exception(
+            raise ValueError(
                 f"Invalid value for {name}. Must be ALL, FRAME, HEADER or NONE."
             )
 
@@ -516,32 +518,32 @@ class PrettyTable:
         try:
             assert val in (ALL, FRAME, NONE)
         except AssertionError:
-            raise Exception(f"Invalid value for {name}. Must be ALL, FRAME, or NONE.")
+            raise ValueError(f"Invalid value for {name}. Must be ALL, FRAME, or NONE.")
 
     def _validate_field_name(self, name, val):
         try:
             assert (val in self._field_names) or (val is None)
         except AssertionError:
-            raise Exception(f"Invalid field name: {val}")
+            raise ValueError(f"Invalid field name: {val}")
 
     def _validate_all_field_names(self, name, val):
         try:
             for x in val:
                 self._validate_field_name(name, x)
         except AssertionError:
-            raise Exception("Fields must be a sequence of field names")
+            raise ValueError("Fields must be a sequence of field names")
 
     def _validate_single_char(self, name, val):
         try:
             assert _str_block_width(val) == 1
         except AssertionError:
-            raise Exception(f"Invalid value for {name}. Must be a string of length 1.")
+            raise ValueError(f"Invalid value for {name}. Must be a string of length 1.")
 
     def _validate_attributes(self, name, val):
         try:
             assert isinstance(val, dict)
         except AssertionError:
-            raise Exception("Attributes must be a dictionary of name/value pairs")
+            raise TypeError("Attributes must be a dictionary of name/value pairs")
 
     ##############################
     # ATTRIBUTE MANAGEMENT       #
@@ -923,7 +925,7 @@ class PrettyTable:
             for field in self._field_names:
                 self._custom_format[field] = val
         else:
-            raise Exception(
+            raise TypeError(
                 "The custom_format property need to be a dictionary or callable"
             )
 
@@ -1250,7 +1252,7 @@ class PrettyTable:
         elif style == RANDOM:
             self._set_random_style()
         else:
-            raise Exception("Invalid pre-set style")
+            raise ValueError("Invalid pre-set style")
 
     def _set_orgmode_style(self):
         self._set_default_style()
@@ -1371,7 +1373,7 @@ class PrettyTable:
         has fields"""
 
         if self._field_names and len(row) != len(self._field_names):
-            raise Exception(
+            raise ValueError(
                 "Row has incorrect number of values, "
                 f"(actual) {len(row)}!={len(self._field_names)} (expected)"
             )
@@ -1388,7 +1390,7 @@ class PrettyTable:
         row_index - The index of the row you want to delete.  Indexing starts at 0."""
 
         if row_index > len(self._rows) - 1:
-            raise Exception(
+            raise IndexError(
                 f"Can't delete row at index {row_index}, "
                 f"table only has {len(self._rows)} rows"
             )
@@ -1419,7 +1421,7 @@ class PrettyTable:
                     self._rows.append([])
                 self._rows[i].append(column[i])
         else:
-            raise Exception(
+            raise ValueError(
                 f"Column length {len(column)} does not match number of rows "
                 f"{len(self._rows)}"
             )
@@ -1443,7 +1445,7 @@ class PrettyTable:
         fieldname - The field name of the column you want to delete."""
 
         if fieldname not in self._field_names:
-            raise Exception(
+            raise ValueError(
                 "Can't delete column %r which is not a field name of this table."
                 " Field names are: %s"
                 % (fieldname, ", ".join(map(repr, self._field_names)))
@@ -2434,7 +2436,7 @@ def from_html_one(html_code, **kwargs):
     try:
         assert len(tables) == 1
     except AssertionError:
-        raise Exception(
+        raise ValueError(
             "More than one <table> in provided HTML code. Use from_html instead."
         )
     return tables[0]

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -99,7 +99,7 @@ class TestNoneOption:
         PrettyTable(["Field 1", "Field 2", "Field 3"], none_format="")
 
     def test_none_char_invalid_option(self):
-        with pytest.raises(Exception) as exc:
+        with pytest.raises(TypeError) as exc:
             PrettyTable(["Field 1", "Field 2", "Field 3"], none_format=2)
             assert "must be a string." in exc.value
 
@@ -229,11 +229,11 @@ class TestDeleteColumn:
 
         assert with_del.get_string() == without_row.get_string()
 
-    def test_delete_illegal_column_raises_exception(self):
+    def test_delete_illegal_column_raises_error(self):
         table = PrettyTable()
         table.add_column("City name", ["Adelaide", "Brisbane", "Darwin"])
 
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             table.del_column("City not-a-name")
 
 
@@ -1298,7 +1298,7 @@ value 7         value8         value9
 
         # Act / Assert
         # This is an hrule style, not a table style
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             t.set_style(ALL)
 
     @pytest.mark.parametrize(
@@ -1456,7 +1456,7 @@ class TestHtmlConstructor:
     def test_HtmlOneFailOnMany(self, city_data_prettytable: PrettyTable):
         html_string = city_data_prettytable.get_html_string()
         html_string += city_data_prettytable.get_html_string()
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             from_html_one(html_string)
 
 
@@ -1693,7 +1693,7 @@ class TestCustomFormatter:
         assert len(pt.custom_format) == 1
 
     def test_init_custom_format_throw_error_is_not_callable(self):
-        with pytest.raises(Exception) as e:
+        with pytest.raises(ValueError) as e:
             PrettyTable(custom_format={"col1": "{:.2}"})
 
         assert "Invalid value for custom_format.col1. Must be a function." in str(
@@ -1713,7 +1713,7 @@ class TestCustomFormatter:
 
     def test_set_custom_format_invalid_type_throw_error(self):
         pt = PrettyTable()
-        with pytest.raises(Exception) as e:
+        with pytest.raises(TypeError) as e:
             pt.custom_format = "Some String"
         assert "The custom_format property need to be a dictionary or callable" in str(
             e.value


### PR DESCRIPTION
Fixes https://github.com/jazzband/prettytable/issues/168.

Instead of using the `Exception` base class, use concrete built-in `IndexError`, `TypeError` and `ValueError` instead.

https://docs.python.org/3/library/exceptions.html

Allows more targeted exception catching.