### PR TITLE
Fix width for custom `none_format`

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1510,6 +1510,9 @@ class PrettyTable:
         for row in rows:
             for index, value in enumerate(row):
                 fieldname = self.field_names[index]
+                if self.none_format.get(fieldname) is not None:
+                    if value == 'None' or value is None:
+                        value = self.none_format.get(fieldname)
                 if fieldname in self.max_width:
                     widths[index] = max(
                         widths[index],
@@ -1836,6 +1839,8 @@ class PrettyTable:
             for line in lines:
                 if line == "None" and self.none_format.get(field) is not None:
                     line = self.none_format[field]
+                    if len(line) > width:
+                        width = len(line)
                 if _str_block_width(line) > width:
                     line = textwrap.fill(line, width)
                 new_lines.append(line)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1839,8 +1839,6 @@ class PrettyTable:
             for line in lines:
                 if line == "None" and self.none_format.get(field) is not None:
                     line = self.none_format[field]
-                    if len(line) > width:
-                        width = len(line)
                 if _str_block_width(line) > width:
                     line = textwrap.fill(line, width)
                 new_lines.append(line)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1511,7 +1511,7 @@ class PrettyTable:
             for index, value in enumerate(row):
                 fieldname = self.field_names[index]
                 if self.none_format.get(fieldname) is not None:
-                    if value == 'None' or value is None:
+                    if value == "None" or value is None:
                         value = self.none_format.get(fieldname)
                 if fieldname in self.max_width:
                     widths[index] = max(

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -164,7 +164,7 @@ class TestNoneOption:
     def test_replace_none_recompute_width(self):
         t = PrettyTable()
         t.add_row([None])
-        t.none_format = '0123456789'
+        t.none_format = "0123456789"
         assert (
             t.get_string().strip()
             == """
@@ -178,8 +178,8 @@ class TestNoneOption:
 
     def test_replace_none_maintain_width_on_recompute(self):
         t = PrettyTable()
-        t.add_row(['Hello'])
-        t.none_format = '0123456789'
+        t.add_row(["Hello"])
+        t.none_format = "0123456789"
         assert (
             t.get_string().strip()
             == """
@@ -193,11 +193,11 @@ class TestNoneOption:
 
     def test_replace_none_recompute_width_multi_column(self):
         t = PrettyTable()
-        t.add_row(['Hello', None, 'World'])
-        t.none_format = '0123456789'
+        t.add_row(["Hello", None, "World"])
+        t.none_format = "0123456789"
         assert (
-                t.get_string().strip()
-                == """
+            t.get_string().strip()
+            == """
 +---------+------------+---------+
 | Field 1 |  Field 2   | Field 3 |
 +---------+------------+---------+
@@ -205,6 +205,7 @@ class TestNoneOption:
 +---------+------------+---------+
 """.strip()
         )
+
 
 class TestBuildEquivalence:
     """Make sure that building a table row-by-row and column-by-column yield the same

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -161,6 +161,50 @@ class TestNoneOption:
 """.strip()
         )
 
+    def test_replace_none_recompute_width(self):
+        t = PrettyTable()
+        t.add_row([None])
+        t.none_format = '0123456789'
+        assert (
+            t.get_string().strip()
+            == """
++------------+
+|  Field 1   |
++------------+
+| 0123456789 |
++------------+
+""".strip()
+        )
+
+    def test_replace_none_maintain_width_on_recompute(self):
+        t = PrettyTable()
+        t.add_row(['Hello'])
+        t.none_format = '0123456789'
+        assert (
+            t.get_string().strip()
+            == """
++---------+
+| Field 1 |
++---------+
+|  Hello  |
++---------+
+""".strip()
+        )
+
+    def test_replace_none_recompute_width_multi_column(self):
+        t = PrettyTable()
+        t.add_row(['Hello', None, 'World'])
+        t.none_format = '0123456789'
+        assert (
+                t.get_string().strip()
+                == """
++---------+------------+---------+
+| Field 1 |  Field 2   | Field 3 |
++---------+------------+---------+
+|  Hello  | 0123456789 |  World  |
++---------+------------+---------+
+""".strip()
+        )
 
 class TestBuildEquivalence:
     """Make sure that building a table row-by-row and column-by-column yield the same


### PR DESCRIPTION
Resolves issue #172 by checking for existence of a `None` value when widths are being computed inside of `_compute_widths`. 