### PR TITLE
`None` `annotation` for `__init__` constructors/functions

### DIFF
--- a/src/prettytable/colortable.py
+++ b/src/prettytable/colortable.py
@@ -23,7 +23,7 @@ class Theme:
         horizontal_color: str = "",
         junction_char: str = "+",
         junction_color: str = "",
-    ):
+    ) -> None:
         self.default_color = Theme.format_code(default_color)
         self.vertical_char = vertical_char
         self.vertical_color = Theme.format_code(vertical_color)
@@ -53,7 +53,7 @@ class Themes:
 
 
 class ColorTable(PrettyTable):
-    def __init__(self, field_names=None, **kwargs):
+    def __init__(self, field_names=None, **kwargs) -> None:
         super().__init__(field_names=field_names, **kwargs)
         # TODO: Validate option
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -72,7 +72,7 @@ def _get_size(text):
 
 
 class PrettyTable:
-    def __init__(self, field_names=None, **kwargs):
+    def __init__(self, field_names=None, **kwargs) -> None:
         """Return a new PrettyTable instance
 
         Arguments:
@@ -2456,7 +2456,7 @@ def from_json(json_string, **kwargs):
 
 
 class TableHandler(HTMLParser):
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         HTMLParser.__init__(self)
         self.kwargs = kwargs
         self.tables = []


### PR DESCRIPTION
Everywhere there was a class declaration and a __init__ function
defined for that class, I added `None` as an `annotation` to it.
```python
class ...:
    def __init__(..) -> None:
```

[Reason](https://peps.python.org/pep-0484/#the-meaning-of-annotations)