### PR TITLE
Add option to specify line break character used in pagination

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2004,7 +2004,7 @@ class PrettyTable:
 
         return "\n".join(bits)
 
-    def paginate(self, page_length=58, **kwargs):
+    def paginate(self, page_length=58, line_break="\f", **kwargs):
 
         pages = []
         kwargs["start"] = kwargs.get("start", 0)
@@ -2015,7 +2015,7 @@ class PrettyTable:
             if kwargs["end"] == true_end:
                 break
             kwargs["start"] += page_length
-        return "\f".join(pages)
+        return line_break.join(pages)
 
     ##############################
     # CSV STRING METHODS         #

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1735,6 +1735,9 @@ def test_paginate():
     assert paginated.startswith(expected_page_1)
     assert "\f" in paginated
     assert paginated.endswith(expected_page_2)
+    paginated = t.paginate(page_length=4, line_break="\n")
+    assert "\f" not in paginated
+    assert "\n" in paginated
 
 
 def test_add_rows():

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1735,7 +1735,11 @@ def test_paginate():
     assert paginated.startswith(expected_page_1)
     assert "\f" in paginated
     assert paginated.endswith(expected_page_2)
+
+    # Act
     paginated = t.paginate(page_length=4, line_break="\n")
+
+    # Assert
     assert "\f" not in paginated
     assert "\n" in paginated
 


### PR DESCRIPTION
In some cases when getting multiple pages of table data it's preferable to have the pages divided by breaks other than form feed. This allows users to separate pages by whatever they'd like.