### PR TITLE
Update GitHub Actions and pre-commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload packages to Jazzband
         if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: jazzband
           password: ${{ secrets.JAZZBAND_RELEASE_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -17,7 +17,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
@@ -34,10 +34,10 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.1
+    rev: v2.0.0
     hooks:
       - id: setup-cfg-fmt
-        args: [--max-py-version=3.11]
+        args: [--max-py-version=3.11, --include-version-classifiers]
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
     rev: 0.5.2
@@ -45,7 +45,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.7.1
+    rev: v3.0.0-alpha.0
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1162,7 +1162,8 @@ class PrettyTable:
 
     @property
     def top_right_junction_char(self):
-        """The character used when printing table borders to draw top-right line junctions
+        """
+        The character used when printing table borders to draw top-right line junctions
 
         Arguments:
 


### PR DESCRIPTION
* Upgrade pypa/gh-action-pypi-publish from deprecated `master` to `release/v1`
  * https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-
* Upgrade other actions
* Upgrade asottile/setup-cfg-fmt and include new required `--include-version-classifiers` 
  * https://github.com/asottile/setup-cfg-fmt#adds-python-version-classifiers
* Upgrade other pre-commit including a Flake8 fix