### PR TITLE
Revert "Add header alignment attribute"

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,20 +295,6 @@ gives:
 +-----------+------+------------+-----------------+
 ```
 
-##### Other alignment
-
-You can also change the alignment of the headers of the columns using the `header_align`
-attribute in the same way as the `align` attribute.
-
-```python
-x.header_align["City name"] = "l"
-print(x)
-```
-
-The `valign` attribute works in the same way as the other align attributes for
-controlling vertical alignment. It accepts the values `"t"`, `"m"` and `"b"` for top,
-middle, and bottom respectively.
-
 ##### Sorting your table by a field
 
 You can make sure that your ASCII tables are produced with the data sorted by one

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -135,7 +135,6 @@ class PrettyTable:
         self._rows = []
         self.align = {}
         self.valign = {}
-        self.header_align = {}
         self.max_width = {}
         self.min_width = {}
         self.int_format = {}
@@ -190,7 +189,6 @@ class PrettyTable:
             "bottom_left_junction_char",
             "align",
             "valign",
-            "header_align",
             "max_width",
             "min_width",
             "none_format",
@@ -233,7 +231,6 @@ class PrettyTable:
         # Column specific arguments, use property.setters
         self.align = kwargs["align"] or {}
         self.valign = kwargs["valign"] or {}
-        self.header_align = kwargs["header_align"] or {}
         self.max_width = kwargs["max_width"] or {}
         self.min_width = kwargs["min_width"] or {}
         self.int_format = kwargs["int_format"] or {}
@@ -618,15 +615,6 @@ class PrettyTable:
                 self._align[field_name] = self._align[BASE_ALIGN_VALUE]
         else:
             self.align = "c"
-        if self._header_align and old_names:
-            for old_name, new_name in zip(old_names, val):
-                self._header_align[new_name] = self._header_align[old_name]
-            for old_name in old_names:
-                if old_name in self._header_align and old_name not in val:
-                    self._header_align.pop(old_name)
-        elif self._header_align:
-            for field_name in self._field_names:
-                self._header_align[field_name] = self._header_align[BASE_ALIGN_VALUE]
         if self._valign and old_names:
             for old_name, new_name in zip(old_names, val):
                 self._valign[new_name] = self._valign[old_name]
@@ -659,30 +647,6 @@ class PrettyTable:
             else:
                 for field in self._field_names:
                     self._align[field] = val
-
-    @property
-    def header_align(self):
-        """Controls alignment of header fields
-        Arguments:
-
-        header_align - header alignment, one of "l", "c", or "r" """
-        return self._header_align
-
-    @header_align.setter
-    def header_align(self, val):
-        if val is None or (isinstance(val, dict) and len(val) == 0):
-            if not self._field_names:
-                self._header_align = {BASE_ALIGN_VALUE: "c"}
-            else:
-                for field in self._field_names:
-                    self._header_align[field] = "c"
-        else:
-            self._validate_align(val)
-            if not self._field_names:
-                self._header_align = {BASE_ALIGN_VALUE: val}
-            else:
-                for field in self._field_names:
-                    self._header_align[field] = val
 
     @property
     def valign(self):
@@ -1465,7 +1429,7 @@ class PrettyTable:
             )
         del self._rows[row_index]
 
-    def add_column(self, fieldname, column, align="c", valign="t", header_align="c"):
+    def add_column(self, fieldname, column, align="c", valign="t"):
 
         """Add a column to the table.
 
@@ -1481,12 +1445,10 @@ class PrettyTable:
 
         if len(self._rows) in (0, len(column)):
             self._validate_align(align)
-            self._validate_align(header_align)
             self._validate_valign(valign)
             self._field_names.append(fieldname)
             self._align[fieldname] = align
             self._valign[fieldname] = valign
-            self._header_align[fieldname] = header_align
             for i in range(0, len(column)):
                 if len(self._rows) < i + 1:
                     self._rows.append([])
@@ -1504,7 +1466,6 @@ class PrettyTable:
         self._field_names.insert(0, fieldname)
         self._align[fieldname] = self.align
         self._valign[fieldname] = self.valign
-        self._header_align[fieldname] = self.header_align
         for i, row in enumerate(self._rows):
             row.insert(0, i + 1)
 
@@ -1890,7 +1851,7 @@ class PrettyTable:
                 fieldname = fieldname[:width]
             bits.append(
                 " " * lpad
-                + self._justify(fieldname, width, self._header_align[field])
+                + self._justify(fieldname, width, self._align[field])
                 + " " * rpad
             )
             if options["border"] or options["preserve_internal_border"]:
@@ -1898,6 +1859,7 @@ class PrettyTable:
                     bits.append(options["vertical_char"])
                 else:
                     bits.append(" ")
+
         # If only preserve_internal_border is true, then we just appended
         # a vertical character at the end when we wanted a space
         if not options["border"] and options["preserve_internal_border"]:
@@ -2217,15 +2179,8 @@ class PrettyTable:
                 if options["fields"] and field not in options["fields"]:
                     continue
                 lines.append(
-                    '            <th style="padding-left: %dem; padding-right: %dem; text-align: %s">%s</th>'  # noqa: E501
-                    % (
-                        lpad,
-                        rpad,
-                        {"l": "left", "r": "right", "c": "center"}[
-                            self._header_align[field]
-                        ],
-                        escape(field).replace("\n", linebreak),
-                    )  # noqa: E501
+                    '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
+                    % (lpad, rpad, escape(field).replace("\n", linebreak))
                 )
             lines.append("        </tr>")
             lines.append("    </thead>")

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -331,7 +331,6 @@ class TestFieldNameLessTable:
 def aligned_before_table():
     x = PrettyTable()
     x.align = "r"
-    x.header_align = "r"
     x.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
     x.add_row(["Adelaide", 1295, 1158259, 600.5])
     x.add_row(["Brisbane", 5905, 1857594, 1146.4])
@@ -355,7 +354,6 @@ def aligned_after_table():
     x.add_row(["Melbourne", 1566, 3806092, 646.9])
     x.add_row(["Perth", 5386, 1554769, 869.4])
     x.align = "r"
-    x.header_align = "r"
     return x
 
 
@@ -1432,41 +1430,6 @@ class TestStyle:
         t.align["Align left"] = "l"
         t.align["Align centre"] = "c"
         t.align["Align right"] = "r"
-
-        # Assert
-        result = t.get_string()
-        assert result.strip() == expected.strip()
-
-    @pytest.mark.parametrize(
-        "style, expected",
-        [
-            pytest.param(
-                DEFAULT,
-                """
-+---------+--------+--------+
-| L       |   C    |      R |
-+---------+--------+--------+
-| value 1 | value2 | value3 |
-| value 4 | value5 | value6 |
-| value 7 | value8 | value9 |
-+---------+--------+--------+
-""",
-                id="MARKDOWN",
-            ),
-        ],
-    )
-    def test_style_header_align(self, style, expected):
-        # Arrange
-        t = helper_table()
-        t.field_names = ["L", "C", "R"]
-
-        assert t.header_align["L"] == "c"
-
-        # Act
-        t.set_style(style)
-        t.header_align["L"] = "l"
-        t.header_align["C"] = "c"
-        t.header_align["R"] = "r"
 
         # Assert
         result = t.get_string()


### PR DESCRIPTION
Reverts jazzband/prettytable#183

As detailed at https://github.com/jazzband/prettytable/pull/183#issuecomment-1231418583, if there's no `header_align` value, it still changes the header alignment and ignores the `align` value:

> In 3.3.0, the data _and_ header were left-aligned.
>
> In 3.4.0, only the data was left-aligned, the header was centre-aligned.

So let's revert and jazzband/prettytable#183 can be resubmitted with a more robust fix.

