### PR TITLE
Add type hints from typeshed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: [--add-import=from __future__ import annotations]
 
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 

--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .prettytable import (
     ALL,
     DEFAULT,

--- a/src/prettytable/colortable.py
+++ b/src/prettytable/colortable.py
@@ -1,4 +1,8 @@
 from .prettytable import PrettyTable
+from _typeshed import Incomplete
+from collections.abc import Callable
+from typing import ClassVar
+from .prettytable import PrettyTable
 
 try:
     from colorama import init
@@ -68,7 +72,7 @@ class ColorTable(PrettyTable):
         self._theme = value
         self.update_theme()
 
-    def update_theme(self):
+    def update_theme(self) -> None:
         theme = self._theme
 
         self._vertical_char = (
@@ -92,5 +96,5 @@ class ColorTable(PrettyTable):
             + theme.default_color
         )
 
-    def get_string(self, **kwargs):
+    def get_string(self, **kwargs) -> str:
         return super().get_string(**kwargs) + RESET_CODE

--- a/src/prettytable/colortable.py
+++ b/src/prettytable/colortable.py
@@ -1,10 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import ClassVar
-
-from _typeshed import Incomplete
-
 from .prettytable import PrettyTable
 
 try:

--- a/src/prettytable/colortable.py
+++ b/src/prettytable/colortable.py
@@ -1,7 +1,10 @@
-from .prettytable import PrettyTable
-from _typeshed import Incomplete
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import ClassVar
+
+from _typeshed import Incomplete
+
 from .prettytable import PrettyTable
 
 try:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -46,7 +46,6 @@ from html.parser import HTMLParser
 from typing import Any
 
 import wcwidth
-from _typeshed import Incomplete
 
 # hrule styles
 FRAME = 0

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -31,6 +31,8 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from __future__ import annotations
+
 import copy
 import csv
 import io
@@ -41,10 +43,10 @@ import re
 import textwrap
 from html import escape
 from html.parser import HTMLParser
+from typing import Any
 
 import wcwidth
 from _typeshed import Incomplete
-from typing import Any
 
 # hrule styles
 FRAME = 0
@@ -1431,7 +1433,9 @@ class PrettyTable:
             )
         del self._rows[row_index]
 
-    def add_column(self, fieldname, column, align: str="c", valign: str="t") -> None:
+    def add_column(
+        self, fieldname, column, align: str = "c", valign: str = "t"
+    ) -> None:
 
         """Add a column to the table.
 
@@ -1461,7 +1465,7 @@ class PrettyTable:
                 f"{len(self._rows)}"
             )
 
-    def add_autoindex(self, fieldname: str="Index"):
+    def add_autoindex(self, fieldname: str = "Index"):
         """Add an auto-incrementing index column to the table.
         Arguments:
         fieldname - name of the field to contain the new column of data"""
@@ -1969,7 +1973,7 @@ class PrettyTable:
 
         return "\n".join(bits)
 
-    def paginate(self, page_length: int=58, line_break: str="\f", **kwargs):
+    def paginate(self, page_length: int = 58, line_break: str = "\f", **kwargs):
 
         pages = []
         kwargs["start"] = kwargs.get("start", 0)
@@ -2361,7 +2365,7 @@ def _str_block_width(val):
 ##############################
 
 
-def from_csv(fp, field_names: Any | None=None, **kwargs):
+def from_csv(fp, field_names: Any | None = None, **kwargs):
     fmtparams = {}
     for param in [
         "delimiter",

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -43,6 +43,8 @@ from html import escape
 from html.parser import HTMLParser
 
 import wcwidth
+from _typeshed import Incomplete
+from typing import Any
 
 # hrule styles
 FRAME = 0
@@ -558,11 +560,11 @@ class PrettyTable:
     # ATTRIBUTE MANAGEMENT       #
     ##############################
     @property
-    def rows(self):
+    def rows(self) -> list[Incomplete]:
         return self._rows[:]
 
     @property
-    def xhtml(self):
+    def xhtml(self) -> bool:
         """Print <br/> tags if True, <br> tags if False"""
         return self._xhtml
 
@@ -1265,7 +1267,7 @@ class PrettyTable:
     # PRESET STYLE LOGIC         #
     ##############################
 
-    def set_style(self, style):
+    def set_style(self, style) -> None:
 
         if style == DEFAULT:
             self._set_default_style()
@@ -1385,7 +1387,7 @@ class PrettyTable:
     # DATA INPUT METHODS         #
     ##############################
 
-    def add_rows(self, rows):
+    def add_rows(self, rows) -> None:
 
         """Add rows to the table
 
@@ -1396,7 +1398,7 @@ class PrettyTable:
         for row in rows:
             self.add_row(row)
 
-    def add_row(self, row):
+    def add_row(self, row) -> None:
 
         """Add a row to the table
 
@@ -1414,7 +1416,7 @@ class PrettyTable:
             self.field_names = [f"Field {n + 1}" for n in range(0, len(row))]
         self._rows.append(list(row))
 
-    def del_row(self, row_index):
+    def del_row(self, row_index) -> None:
 
         """Delete a row from the table
 
@@ -1429,7 +1431,7 @@ class PrettyTable:
             )
         del self._rows[row_index]
 
-    def add_column(self, fieldname, column, align="c", valign="t"):
+    def add_column(self, fieldname, column, align: str="c", valign: str="t") -> None:
 
         """Add a column to the table.
 
@@ -1459,7 +1461,7 @@ class PrettyTable:
                 f"{len(self._rows)}"
             )
 
-    def add_autoindex(self, fieldname="Index"):
+    def add_autoindex(self, fieldname: str="Index"):
         """Add an auto-incrementing index column to the table.
         Arguments:
         fieldname - name of the field to contain the new column of data"""
@@ -1469,7 +1471,7 @@ class PrettyTable:
         for i, row in enumerate(self._rows):
             row.insert(0, i + 1)
 
-    def del_column(self, fieldname):
+    def del_column(self, fieldname) -> None:
 
         """Delete a column from the table
 
@@ -1489,13 +1491,13 @@ class PrettyTable:
         for row in self._rows:
             del row[col_index]
 
-    def clear_rows(self):
+    def clear_rows(self) -> None:
 
         """Delete all rows from the table but keep the current field names"""
 
         self._rows = []
 
-    def clear(self):
+    def clear(self) -> None:
 
         """Delete all rows and field names from the table, maintaining nothing but
         styling options"""
@@ -1639,7 +1641,7 @@ class PrettyTable:
     # PLAIN TEXT STRING METHODS  #
     ##############################
 
-    def get_string(self, **kwargs):
+    def get_string(self, **kwargs) -> str:
 
         """Return string representation of table in current state.
 
@@ -1967,7 +1969,7 @@ class PrettyTable:
 
         return "\n".join(bits)
 
-    def paginate(self, page_length=58, line_break="\f", **kwargs):
+    def paginate(self, page_length: int=58, line_break: str="\f", **kwargs):
 
         pages = []
         kwargs["start"] = kwargs.get("start", 0)
@@ -1983,7 +1985,7 @@ class PrettyTable:
     ##############################
     # CSV STRING METHODS         #
     ##############################
-    def get_csv_string(self, **kwargs):
+    def get_csv_string(self, **kwargs) -> str:
 
         """Return string representation of CSV formatted table in the current state
 
@@ -2011,7 +2013,7 @@ class PrettyTable:
     ##############################
     # JSON STRING METHODS        #
     ##############################
-    def get_json_string(self, **kwargs):
+    def get_json_string(self, **kwargs) -> str:
 
         """Return string representation of JSON formatted table in the current state
 
@@ -2040,7 +2042,7 @@ class PrettyTable:
     # HTML STRING METHODS        #
     ##############################
 
-    def get_html_string(self, **kwargs):
+    def get_html_string(self, **kwargs) -> str:
         """Return string representation of HTML formatted version of table in current
         state.
 
@@ -2225,7 +2227,7 @@ class PrettyTable:
     # LATEX STRING METHODS       #
     ##############################
 
-    def get_latex_string(self, **kwargs):
+    def get_latex_string(self, **kwargs) -> str:
         """Return string representation of LaTex formatted version of table in current
         state.
 
@@ -2359,7 +2361,7 @@ def _str_block_width(val):
 ##############################
 
 
-def from_csv(fp, field_names=None, **kwargs):
+def from_csv(fp, field_names: Any | None=None, **kwargs):
     fmtparams = {}
     for param in [
         "delimiter",
@@ -2424,7 +2426,7 @@ class TableHandler(HTMLParser):
         self.is_last_row_header = False
         self.colspan = 0
 
-    def handle_starttag(self, tag, attrs):
+    def handle_starttag(self, tag, attrs) -> None:
         self.active = tag
         if tag == "th":
             self.is_last_row_header = True
@@ -2432,7 +2434,7 @@ class TableHandler(HTMLParser):
             if key == "colspan":
                 self.colspan = int(value)
 
-    def handle_endtag(self, tag):
+    def handle_endtag(self, tag) -> None:
         if tag in ["th", "td"]:
             stripped_content = self.last_content.strip()
             self.last_row.append(stripped_content)
@@ -2453,7 +2455,7 @@ class TableHandler(HTMLParser):
         self.last_content = " "
         self.active = None
 
-    def handle_data(self, data):
+    def handle_data(self, data) -> None:
         self.last_content += data
 
     def generate_table(self, rows):
@@ -2474,7 +2476,7 @@ class TableHandler(HTMLParser):
                 table.add_row(row[0])
         return table
 
-    def make_fields_unique(self, fields):
+    def make_fields_unique(self, fields) -> None:
         """
         iterates over the row and make each field unique
         """

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -561,7 +561,7 @@ class PrettyTable:
     # ATTRIBUTE MANAGEMENT       #
     ##############################
     @property
-    def rows(self) -> list[Incomplete]:
+    def rows(self) -> list[Any]:
         return self._rows[:]
 
     @property

--- a/tests/test_colortable.py
+++ b/tests/test_colortable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from prettytable import PrettyTable

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime as dt
 import io
 import random

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -863,7 +863,7 @@ class TestBreakLine:
         ],
     )
     def test_break_line_ASCII(
-        self, rows: List[List[Any]], hrule: int, expected_result: str
+        self, rows: list[list[Any]], hrule: int, expected_result: str
     ):
         t = PrettyTable(["Field 1", "Field 2"])
         for row in rows:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -5,7 +5,7 @@ import io
 import random
 import sqlite3
 from math import e, pi, sqrt
-from typing import Any, List
+from typing import Any
 
 import pytest
 


### PR DESCRIPTION
Issue: https://github.com/jazzband/prettytable/issues/203

I didn't do the third part yet...
**Add mypy via pre-commit and make mypy pass (can be follow-up PR if there's much to do)**
...as I'm newer to contributing and didn't want to get overwhelmed. I can open a new issue so that it doesn't get forgotten and work on that next.

Used merge_pyi to integrate the type annotations and added appropriate args to .pre-commit-config.yaml in order for pre-commit to add the import to Python files so that newer typing syntax can be used on older Python 3.7 (as described in the issue).

Note: Did not use Black to format as it was deleting spaces in the docstrings which presumably are supposed to be there; can use Black and then add the spaces again after if that's better.