### PR TITLE
Add `py.typed` and update `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Text Processing
+    Typing :: Typed
 project_urls =
     Source=https://github.com/jazzband/prettytable
 


### PR DESCRIPTION
As mentioned here: https://github.com/jazzband/prettytable/issues/203#issuecomment-1295330801

Created `py.typed` in `src/prettytable` as a marker file in order to indicate that the package supports typing.
Also added `Typing :: Typed` to `setup.cfg` as a `Trove classifier` in the `classifiers` list in order to help find and classify things on PyPI.

