### PR TITLE
Widen tables with long titles

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1585,11 +1585,11 @@ class PrettyTable:
             min_width = max(title_width, min_table_width)
             table_width = self._compute_table_width(options)
             if table_width < min_width:
-                # To make enough space for the title, all columns have to 
-                # grow enough that their combined widths (and the borders 
+                # To make enough space for the title, all columns have to
+                # grow enough that their combined widths (and the borders
                 # between them) are equal to the length of the title.
-                border_char_count = 3 * (len(widths) - 1) 
-                scale = 1.0 * (len(options['title']) - border_char_count) / sum(widths)
+                border_char_count = 3 * (len(widths) - 1)
+                scale = 1.0 * (len(options["title"]) - border_char_count) / sum(widths)
                 widths = [int(math.ceil(w * scale)) for w in widths]
                 self._widths = widths
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1585,8 +1585,11 @@ class PrettyTable:
             min_width = max(title_width, min_table_width)
             table_width = self._compute_table_width(options)
             if table_width < min_width:
-                # Grow widths in proportion
-                scale = 1.0 * min_width / table_width
+                # To make enough space for the title, all columns have to 
+                # grow enough that their combined widths (and the borders 
+                # between them) are equal to the length of the title.
+                border_char_count = 3 * (len(widths) - 1) 
+                scale = 1.0 * (len(options['title']) - border_char_count) / sum(widths)
                 widths = [int(math.ceil(w * scale)) for w in widths]
                 self._widths = widths
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -555,10 +555,12 @@ class TestBasic:
         city_data_prettytable.title = "My table"
         self._test_all_length_equal(city_data_prettytable)
 
-    def test_all_lengths_equal_with_long_title(self, city_data_prettytable: PrettyTable):
+    def test_all_lengths_equal_with_long_title(
+        self, city_data_prettytable: PrettyTable
+    ):
         """All lines in a table should be of the same length, even with a long title."""
-        city_data_prettytable.title = "My table (75 characters wide) " + "="*45
-        self._test_all_length_equal(city_data_prettytable)        
+        city_data_prettytable.title = "My table (75 characters wide) " + "=" * 45
+        self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_without_border(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -555,6 +555,11 @@ class TestBasic:
         city_data_prettytable.title = "My table"
         self._test_all_length_equal(city_data_prettytable)
 
+    def test_all_lengths_equal_with_long_title(self, city_data_prettytable: PrettyTable):
+        """All lines in a table should be of the same length, even with a long title."""
+        city_data_prettytable.title = "My table (75 characters wide) " + "="*45
+        self._test_all_length_equal(city_data_prettytable)        
+
     def test_no_blank_lines_without_border(self, city_data_prettytable: PrettyTable):
         """No table should ever have blank lines in it."""
         city_data_prettytable.border = False


### PR DESCRIPTION
Recalculated this to scale the table correctly.

- Added `test_prettytable.test_all_lengths_equal_with_long_title()` to capture this this error as well.

**Original behavior:**
```

Without title:
+---------+---------+
| field a | field b |
+---------+---------+
|    a1   |    b1   |
|    a2   |    b2   |
+---------+---------+

With title:
+-----------------------------------------------------------------+
| === 80 char str ================================================================ |
+--------------------------------+--------------------------------+
|            field a             |            field b             |
+--------------------------------+--------------------------------+
|               a1               |               b1               |
|               a2               |               b2               |
+--------------------------------+--------------------------------+
```

**New behavior:**
``` 
With title:
+-----------------------------------------------------------------------------------+
|  === 80 char str ================================================================ |
+-----------------------------------------+-----------------------------------------+
|                 field a                 |                 field b                 |
+-----------------------------------------+-----------------------------------------+
|                    a1                   |                    b1                   |
|                    a2                   |                    b2                   |
+-----------------------------------------+-----------------------------------------+
```