### PR TITLE
Fix to `min_table_width` parameter

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1583,16 +1583,18 @@ class PrettyTable:
                 title_width = 0
             min_table_width = self.min_table_width or 0
             min_width = max(title_width, min_table_width)
-            if options['border']:
+            if options["border"]:
                 borders = len(widths) + 1
             else:
-                if options['preserve_internal_border']:
+                if options["preserve_internal_border"]:
                     borders = len(widths) - 1
                 else:
                     borders = 0
 
             # substract padding for each column and borders
-            min_width -= (sum([sum(self._get_padding_widths(options)) for _ in widths]) + borders)
+            min_width -= (
+                sum([sum(self._get_padding_widths(options)) for _ in widths]) + borders
+            )
             # what is being scaled is content so we sum column widths
             content_width = sum(widths) or 1
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1583,14 +1583,25 @@ class PrettyTable:
                 title_width = 0
             min_table_width = self.min_table_width or 0
             min_width = max(title_width, min_table_width)
-            table_width = self._compute_table_width(options)
-            if table_width < min_width:
-                # To make enough space for the title, all columns have to
-                # grow enough that their combined widths (and the borders
-                # between them) are equal to the length of the title.
-                border_char_count = 3 * (len(widths) - 1)
-                scale = 1.0 * (len(options["title"]) - border_char_count) / sum(widths)
-                widths = [int(math.ceil(w * scale)) for w in widths]
+            if options['border']:
+                borders = len(widths) + 1
+            else:
+                if options['preserve_internal_border']:
+                    borders = len(widths) - 1
+                else:
+                    borders = 0
+
+            # substract padding for each column and borders
+            min_width -= (sum([sum(self._get_padding_widths(options)) for _ in widths]) + borders)
+            # what is being scaled is content so we sum column widths
+            content_width = sum(widths) or 1
+
+            if content_width < min_width:
+                # Grow widths in proportion
+                scale = 1.0 * min_width / content_width
+                widths = [int(math.floor(w * scale)) for w in widths]
+                if sum(widths) < min_width:
+                    widths[-1] += min_width - sum(widths)
                 self._widths = widths
 
     def _get_padding_widths(self, options):

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1587,13 +1587,13 @@ class PrettyTable:
                 borders = len(widths) + 1
             else:
                 if options['preserve_internal_border']:
-                    borders = len(widths) - 1
+                    borders = len(widths)
                 else:
                     borders = 0
 
-            # substract padding for each column and borders
+            # Subtract padding for each column and borders
             min_width -= (sum([sum(self._get_padding_widths(options)) for _ in widths]) + borders)
-            # what is being scaled is content so we sum column widths
+            # What is being scaled is content so we sum column widths
             content_width = sum(widths) or 1
 
             if content_width < min_width:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1585,11 +1585,10 @@ class PrettyTable:
             min_width = max(title_width, min_table_width)
             if options["border"]:
                 borders = len(widths) + 1
+            elif options["preserve_internal_border"]:
+                borders = len(widths)
             else:
-                if options["preserve_internal_border"]:
-                    borders = len(widths)
-                else:
-                    borders = 0
+                borders = 0
 
             # Subtract padding for each column and borders
             min_width -= (

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1913,43 +1913,57 @@ class TestRepr:
 
 
 class TestMinTableWidth:
-    @pytest.mark.parametrize("loops, fields, desired_width, border, internal_border", 
-    [
-        (15, ["Test table"], 20, True, False),
-        (16, ["Test table"], 21, True, False),
-        (18, ["Test table", "Test table 2"], 40, True, False),
-        (19, ["Test table", "Test table 2"], 41, True, False),
-        (21, ["Test table", "Test col 2", "Test col 3"], 50, True, False),
-        (22, ["Test table", "Test col 2", "Test col 3"], 51, True, False),
-        (19, ["Test table"], 20, False, False),
-        (20, ["Test table"], 21, False, False),
-        (25, ["Test table", "Test table 2"], 40, False, False),
-        (26, ["Test table", "Test table 2"], 41, False, False),
-        (25, ["Test table", "Test col 2", "Test col 3"], 50, False, False),
-        (26, ["Test table", "Test col 2", "Test col 3"], 51, False, False),
-        (18, ["Test table"], 20, False, True),
-        (19, ["Test table"], 21, False, True),
-        (23, ["Test table", "Test table 2"], 40, False, True),
-        (24, ["Test table", "Test table 2"], 41, False, True),
-        (22, ["Test table", "Test col 2", "Test col 3"], 50, False, True),
-        (23, ["Test table", "Test col 2", "Test col 3"], 51, False, True),
-    ])
-    def test_min_table_width(self, loops, fields, desired_width, border, internal_border):
-        for col_width  in range(loops):
+    @pytest.mark.parametrize(
+        "loops, fields, desired_width, border, internal_border",
+        [
+            (15, ["Test table"], 20, True, False),
+            (16, ["Test table"], 21, True, False),
+            (18, ["Test table", "Test table 2"], 40, True, False),
+            (19, ["Test table", "Test table 2"], 41, True, False),
+            (21, ["Test table", "Test col 2", "Test col 3"], 50, True, False),
+            (22, ["Test table", "Test col 2", "Test col 3"], 51, True, False),
+            (19, ["Test table"], 20, False, False),
+            (20, ["Test table"], 21, False, False),
+            (25, ["Test table", "Test table 2"], 40, False, False),
+            (26, ["Test table", "Test table 2"], 41, False, False),
+            (25, ["Test table", "Test col 2", "Test col 3"], 50, False, False),
+            (26, ["Test table", "Test col 2", "Test col 3"], 51, False, False),
+            (18, ["Test table"], 20, False, True),
+            (19, ["Test table"], 21, False, True),
+            (23, ["Test table", "Test table 2"], 40, False, True),
+            (24, ["Test table", "Test table 2"], 41, False, True),
+            (22, ["Test table", "Test col 2", "Test col 3"], 50, False, True),
+            (23, ["Test table", "Test col 2", "Test col 3"], 51, False, True),
+        ],
+    )
+    def test_min_table_width(
+        self, loops, fields, desired_width, border, internal_border
+    ):
+        for col_width in range(loops):
             x = prettytable.PrettyTable()
             x.border = border
             x.preserve_internal_border = internal_border
             x.field_names = fields
-            x.add_row(['X'*col_width] + ['' for _ in range(len(fields)-1)])
+            x.add_row(["X" * col_width] + ["" for _ in range(len(fields) - 1)])
             x.min_table_width = desired_width
             t = x.get_string()
             if border == False and internal_border == False:
-                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width])
+                assert [len(x) for x in t.split("\n")] == [desired_width, desired_width]
             elif border == False and internal_border == True:
-                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width - 1, desired_width])
+                assert [len(x) for x in t.split("\n")] == [
+                    desired_width,
+                    desired_width - 1,
+                    desired_width,
+                ]
             else:
-                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    
+                assert [len(x) for x in t.split("\n")] == [
+                    desired_width,
+                    desired_width,
+                    desired_width,
+                    desired_width,
+                    desired_width,
+                ]
+
 
 class TestMaxTableWidth:
     def test_max_table_width(self):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1911,64 +1911,106 @@ class TestRepr:
     def test_jupyter_repr(self, row_prettytable: PrettyTable):
         assert row_prettytable._repr_html_() == row_prettytable.get_html_string()
 
+
 class TestMinTableWidth:
     def test_even_min_table_width_one_column(self):
         for i in range(15):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table"]
-            x.add_row(['X'*i])
+            x.add_row(["X" * i])
             desired_width = 20
             x.min_table_width = desired_width
             t = x.get_string()
             print(t)
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
     def test_odd_min_table_width_one_column(self):
         for i in range(16):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table"]
-            x.add_row(['X'*i])
+            x.add_row(["X" * i])
             desired_width = 21
             x.min_table_width = desired_width
             t = x.get_string()
             print(t)
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
     def test_even_min_table_width_two_column(self):
         for i in range(18):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table", "Test table 2"]
-            x.add_row(['X'*i, ''])
+            x.add_row(["X" * i, ""])
             desired_width = 40
             x.min_table_width = desired_width
             t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
     def test_odd_min_table_width_two_column(self):
         for i in range(19):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table", "Test table 2"]
-            x.add_row(['X'*i, ''])
+            x.add_row(["X" * i, ""])
             desired_width = 41
             x.min_table_width = desired_width
             t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
     def test_even_min_table_width_three_column(self):
         for i in range(15):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table", "Test col 2", "Test col 3"]
-            x.add_row(['X'*i, '', ''])
+            x.add_row(["X" * i, "", ""])
             desired_width = 50
             x.min_table_width = desired_width
             t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
     def test_odd_min_table_width_three_column(self):
         for i in range(15):
             x = prettytable.PrettyTable()
             x.field_names = ["Test table", "Test col 2", "Test col 3"]
-            x.add_row(['X'*i, '', ''])
+            x.add_row(["X" * i, "", ""])
             desired_width = 51
             x.min_table_width = desired_width
             t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            assert [len(x) for x in t.split("\n")] == [
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+                desired_width,
+            ]
+
 
 class TestMaxTableWidth:
     def test_max_table_width(self):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1947,9 +1947,9 @@ class TestMinTableWidth:
             x.add_row(["X" * col_width] + ["" for _ in range(len(fields) - 1)])
             x.min_table_width = desired_width
             t = x.get_string()
-            if border == False and internal_border == False:
+            if border is False and internal_border is False:
                 assert [len(x) for x in t.split("\n")] == [desired_width, desired_width]
-            elif border == False and internal_border == True:
+            elif border is False and internal_border is True:
                 assert [len(x) for x in t.split("\n")] == [
                     desired_width,
                     desired_width - 1,

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1912,63 +1912,43 @@ class TestRepr:
         assert row_prettytable._repr_html_() == row_prettytable.get_html_string()
 
 class TestMinTableWidth:
-    def test_even_min_table_width_one_column(self):
-        for i in range(15):
+    @pytest.mark.parametrize("loops, fields, desired_width, border, internal_border", 
+    [
+        (15, ["Test table"], 20, True, False),
+        (16, ["Test table"], 21, True, False),
+        (18, ["Test table", "Test table 2"], 40, True, False),
+        (19, ["Test table", "Test table 2"], 41, True, False),
+        (21, ["Test table", "Test col 2", "Test col 3"], 50, True, False),
+        (22, ["Test table", "Test col 2", "Test col 3"], 51, True, False),
+        (19, ["Test table"], 20, False, False),
+        (20, ["Test table"], 21, False, False),
+        (25, ["Test table", "Test table 2"], 40, False, False),
+        (26, ["Test table", "Test table 2"], 41, False, False),
+        (25, ["Test table", "Test col 2", "Test col 3"], 50, False, False),
+        (26, ["Test table", "Test col 2", "Test col 3"], 51, False, False),
+        (18, ["Test table"], 20, False, True),
+        (19, ["Test table"], 21, False, True),
+        (23, ["Test table", "Test table 2"], 40, False, True),
+        (24, ["Test table", "Test table 2"], 41, False, True),
+        (22, ["Test table", "Test col 2", "Test col 3"], 50, False, True),
+        (23, ["Test table", "Test col 2", "Test col 3"], 51, False, True),
+    ])
+    def test_min_table_width(self, loops, fields, desired_width, border, internal_border):
+        for col_width  in range(loops):
             x = prettytable.PrettyTable()
-            x.field_names = ["Test table"]
-            x.add_row(['X'*i])
-            desired_width = 20
+            x.border = border
+            x.preserve_internal_border = internal_border
+            x.field_names = fields
+            x.add_row(['X'*col_width] + ['' for _ in range(len(fields)-1)])
             x.min_table_width = desired_width
             t = x.get_string()
-            print(t)
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+            if border == False and internal_border == False:
+                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width])
+            elif border == False and internal_border == True:
+                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width - 1, desired_width])
+            else:
+                assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
     
-    def test_odd_min_table_width_one_column(self):
-        for i in range(16):
-            x = prettytable.PrettyTable()
-            x.field_names = ["Test table"]
-            x.add_row(['X'*i])
-            desired_width = 21
-            x.min_table_width = desired_width
-            t = x.get_string()
-            print(t)
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    def test_even_min_table_width_two_column(self):
-        for i in range(18):
-            x = prettytable.PrettyTable()
-            x.field_names = ["Test table", "Test table 2"]
-            x.add_row(['X'*i, ''])
-            desired_width = 40
-            x.min_table_width = desired_width
-            t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    def test_odd_min_table_width_two_column(self):
-        for i in range(19):
-            x = prettytable.PrettyTable()
-            x.field_names = ["Test table", "Test table 2"]
-            x.add_row(['X'*i, ''])
-            desired_width = 41
-            x.min_table_width = desired_width
-            t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    def test_even_min_table_width_three_column(self):
-        for i in range(15):
-            x = prettytable.PrettyTable()
-            x.field_names = ["Test table", "Test col 2", "Test col 3"]
-            x.add_row(['X'*i, '', ''])
-            desired_width = 50
-            x.min_table_width = desired_width
-            t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
-    def test_odd_min_table_width_three_column(self):
-        for i in range(15):
-            x = prettytable.PrettyTable()
-            x.field_names = ["Test table", "Test col 2", "Test col 3"]
-            x.add_row(['X'*i, '', ''])
-            desired_width = 51
-            x.min_table_width = desired_width
-            t = x.get_string()
-            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
 
 class TestMaxTableWidth:
     def test_max_table_width(self):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1911,6 +1911,64 @@ class TestRepr:
     def test_jupyter_repr(self, row_prettytable: PrettyTable):
         assert row_prettytable._repr_html_() == row_prettytable.get_html_string()
 
+class TestMinTableWidth:
+    def test_even_min_table_width_one_column(self):
+        for i in range(15):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table"]
+            x.add_row(['X'*i])
+            desired_width = 20
+            x.min_table_width = desired_width
+            t = x.get_string()
+            print(t)
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+    
+    def test_odd_min_table_width_one_column(self):
+        for i in range(16):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table"]
+            x.add_row(['X'*i])
+            desired_width = 21
+            x.min_table_width = desired_width
+            t = x.get_string()
+            print(t)
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+    def test_even_min_table_width_two_column(self):
+        for i in range(18):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table", "Test table 2"]
+            x.add_row(['X'*i, ''])
+            desired_width = 40
+            x.min_table_width = desired_width
+            t = x.get_string()
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+    def test_odd_min_table_width_two_column(self):
+        for i in range(19):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table", "Test table 2"]
+            x.add_row(['X'*i, ''])
+            desired_width = 41
+            x.min_table_width = desired_width
+            t = x.get_string()
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+    def test_even_min_table_width_three_column(self):
+        for i in range(15):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table", "Test col 2", "Test col 3"]
+            x.add_row(['X'*i, '', ''])
+            desired_width = 50
+            x.min_table_width = desired_width
+            t = x.get_string()
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
+    def test_odd_min_table_width_three_column(self):
+        for i in range(15):
+            x = prettytable.PrettyTable()
+            x.field_names = ["Test table", "Test col 2", "Test col 3"]
+            x.add_row(['X'*i, '', ''])
+            desired_width = 51
+            x.min_table_width = desired_width
+            t = x.get_string()
+            assert ([len(x) for x in t.split('\n')] == [desired_width, desired_width, desired_width, desired_width, desired_width])
 
 class TestMaxTableWidth:
     def test_max_table_width(self):


### PR DESCRIPTION
Before the change specifying **min_table_width** parameter changed the width of the table but the width value seemed random.

After the change width is exactly the parameter value when the content is not wide enough. At the same time this pull request fixes / preserves behavior from #216 (Long title doesn't break table layout)

Added tests for odd and even **min_table_width** for one, two, three columns tables.

min_table_width=50
```
+--------------+------------------+--------------+
|      F1      |        F2        |      F3      |
+--------------+------------------+--------------+
|     v 1      |       None       |     v 2      |
+--------------+------------------+--------------+
```