### PR TITLE
Test Python 3.12 pre-releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["pypy-3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    py{py3, 311, 310, 39, 38, 37}
+    py{py3, 312, 311, 310, 39, 38, 37}
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
Currently in [alpha](https://discuss.python.org/t/python-3-12-0-alpha-2-released/21087?u=hugovk), full release due [October 2023](https://peps.python.org/pep-0693/).

Let's make sure PrettyTable is ready and at the same time help test CPython itself.