### PR TITLE
Refactor old %-formatting to use format() builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,10 +412,10 @@ The options are these:
   `prettytable` module so make sure you import them or use `prettytable.FRAME` etc.
 - `vrules` - Controls printing of vertical rules between columns. Allowed values:
   `FRAME`, `ALL`, `NONE`.
-- `int_format` - A string which controls the way integer data is printed. This works
-  like: `print("%<int_format>d" % data)`
-- `float_format` - A string which controls the way floating point data is printed. This
-  works like: `print("%<float_format>f" % data)`
+- `int_format` - A string which controls the way integer values are printed. This works
+  like: `format(value, int_format)`
+- `float_format` - A string which controls the way floating point values are printed.
+  This works like: `format(value, float_format)`
 - `custom_format` - A Dictionary of field and callable. This allows you to set any
   format you want `pf.custom_format["my_col_int"] = ()lambda f, v: f"{v:,}"`. The type
   of the callable if `callable[[str, Any], str]`

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -488,9 +488,9 @@ class PrettyTable:
         try:
             assert isinstance(val, str)
             if not val[-1].isalpha():
-                val = f"{val}d"
+                val += "d"
             format(1, val)  # format an example int
-        except AssertionError:
+        except (AssertionError, ValueError):
             raise ValueError(
                 f"Invalid value for {name}. Must be an integer format string."
             )
@@ -501,7 +501,7 @@ class PrettyTable:
         try:
             assert isinstance(val, str)
             if not val[-1].isalpha():
-                val = f"{val}f"
+                val += "f"
             format(1.2, val)  # format an example float
         except (AssertionError, ValueError):
             raise ValueError(

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -487,7 +487,9 @@ class PrettyTable:
             return
         try:
             assert isinstance(val, str)
-            assert val.isdigit()
+            if not val[-1].isalpha():
+                val = f"{val}d"
+            format(1, val)  # format an example int
         except AssertionError:
             raise ValueError(
                 f"Invalid value for {name}. Must be an integer format string."
@@ -498,16 +500,10 @@ class PrettyTable:
             return
         try:
             assert isinstance(val, str)
-            assert "." in val
-            bits = val.split(".")
-            assert len(bits) <= 2
-            assert bits[0] == "" or bits[0].isdigit()
-            assert (
-                bits[1] == ""
-                or bits[1].isdigit()
-                or (bits[1][-1] == "f" and bits[1].rstrip("f").isdigit())
-            )
-        except AssertionError:
+            if not val[-1].isalpha():
+                val = f"{val}f"
+            format(1.2, val)  # format an example float
+        except (AssertionError, ValueError):
             raise ValueError(
                 f"Invalid value for {name}. Must be a float format string."
             )
@@ -1484,9 +1480,9 @@ class PrettyTable:
 
         if fieldname not in self._field_names:
             raise ValueError(
-                "Can't delete column %r which is not a field name of this table."
-                " Field names are: %s"
-                % (fieldname, ", ".join(map(repr, self._field_names)))
+                f"Can't delete column {fieldname!r} which is not a field name "
+                "of this table. Field names are: "
+                + ", ".join(map(repr, self._field_names))
             )
 
         col_index = self._field_names.index(fieldname)
@@ -1522,9 +1518,15 @@ class PrettyTable:
 
     def _format_value(self, field, value):
         if isinstance(value, int) and field in self._int_format:
-            return ("%%%sd" % self._int_format[field]) % value
+            int_format = self._int_format.get(field, "")
+            if not int_format[-1:].isalpha():
+                int_format += "d"
+            return format(value, int_format)
         elif isinstance(value, float) and field in self._float_format:
-            return ("%%%sf" % self._float_format[field]) % value
+            float_format = self._float_format.get(field, "")
+            if not float_format[-1:].isalpha():
+                float_format += "f"
+            return format(value, float_format)
 
         formatter = self._custom_format.get(field, (lambda f, v: str(v)))
         return formatter(field, value)
@@ -2129,9 +2131,8 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    "            <th>%s</th>" % escape(field).replace("\n", linebreak)
-                )
+                field = escape(field).replace("\n", linebreak)
+                lines.append(f"            <th>{field}</th>")
             lines.append("        </tr>")
             lines.append("    </thead>")
 
@@ -2144,9 +2145,8 @@ class PrettyTable:
             for field, datum in zip(self._field_names, row):
                 if options["fields"] and field not in options["fields"]:
                     continue
-                lines.append(
-                    "            <td>%s</td>" % escape(datum).replace("\n", linebreak)
-                )
+                datum = escape(datum).replace("\n", linebreak)
+                lines.append(f"            <td>{datum}</td>")
             lines.append("        </tr>")
         lines.append("    </tbody>")
         lines.append("</table>")
@@ -2198,9 +2198,10 @@ class PrettyTable:
             for field in self._field_names:
                 if options["fields"] and field not in options["fields"]:
                     continue
+                field = escape(field).replace("\n", linebreak)
                 lines.append(
-                    '            <th style="padding-left: %dem; padding-right: %dem; text-align: center">%s</th>'  # noqa: E501
-                    % (lpad, rpad, escape(field).replace("\n", linebreak))
+                    f'            <th style="padding-left: {lpad}em; '
+                    f'padding-right: {rpad}em; text-align: center">{field}</th>'
                 )
             lines.append("        </tr>")
             lines.append("    </thead>")
@@ -2225,15 +2226,11 @@ class PrettyTable:
             ):
                 if options["fields"] and field not in options["fields"]:
                     continue
+                datum = escape(datum).replace("\n", linebreak)
                 lines.append(
-                    '            <td style="padding-left: %dem; padding-right: %dem; text-align: %s; vertical-align: %s">%s</td>'  # noqa: E501
-                    % (
-                        lpad,
-                        rpad,
-                        align,
-                        valign,
-                        escape(datum).replace("\n", linebreak),
-                    )
+                    f'            <td style="padding-left: {lpad}em; '
+                    f"padding-right: {rpad}em; text-align: {align}; "
+                    f'vertical-align: {valign}">{datum}</td>'
                 )
             lines.append("        </tr>")
         lines.append("    </tbody>")
@@ -2290,7 +2287,7 @@ class PrettyTable:
 
         alignments = "".join([self._align[field] for field in wanted_fields])
 
-        begin_cmd = "\\begin{tabular}{%s}" % alignments
+        begin_cmd = f"\\begin{{tabular}}{{{alignments}}}"
         lines.append(begin_cmd)
 
         # Headers
@@ -2332,7 +2329,7 @@ class PrettyTable:
         if options["border"] and options["vrules"] in [ALL, FRAME]:
             alignment_str = "|" + alignment_str + "|"
 
-        begin_cmd = "\\begin{tabular}{%s}" % alignment_str
+        begin_cmd = f"\\begin{{tabular}}{{{alignment_str}}}"
         lines.append(begin_cmd)
         if options["border"] and options["hrules"] in [ALL, FRAME]:
             lines.append("\\hline")

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -634,6 +634,14 @@ class TestBasic:
         city_data_prettytable.int_format = int_format
         self._test_all_length_equal(city_data_prettytable)
 
+    @pytest.mark.parametrize("int_format", [4, "04i", "5s"])
+    def test_invalid_int_format(
+        self, city_data_prettytable: PrettyTable, int_format: str
+    ):
+        """Ensure ValueError is raised for invalid formats."""
+        with pytest.raises(ValueError, match="Invalid value for int_format"):
+            city_data_prettytable.int_format = int_format
+
     @pytest.mark.parametrize("float_format", ["6.2", "6.2f", "7.4G", "8,.2"])
     def test_no_blank_lines_with_float_format(
         self, city_data_prettytable: PrettyTable, float_format: str
@@ -649,6 +657,14 @@ class TestBasic:
         """All lines in a table should be of the same length."""
         city_data_prettytable.float_format = float_format
         self._test_all_length_equal(city_data_prettytable)
+
+    @pytest.mark.parametrize("float_format", [4, "04d", "5s"])
+    def test_invalid_float_format(
+        self, city_data_prettytable: PrettyTable, float_format: str
+    ):
+        """Ensure ValueError is raised for invalid formats."""
+        with pytest.raises(ValueError, match="Invalid value for float_format"):
+            city_data_prettytable.float_format = float_format
 
     def test_no_blank_lines_from_csv(self, city_data_from_csv: PrettyTable):
         """No table should ever have blank lines in it."""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -618,28 +618,36 @@ class TestBasic:
         city_data_prettytable.set_style(MSWORD_FRIENDLY)
         self._test_all_length_equal(city_data_prettytable)
 
-    def test_no_blank_lines_with_int_format(self, city_data_prettytable: PrettyTable):
+    @pytest.mark.parametrize("int_format", ["04", "04d", "#06x", "5,"])
+    def test_no_blank_lines_with_int_format(
+        self, city_data_prettytable: PrettyTable, int_format: str
+    ):
         """No table should ever have blank lines in it."""
-        city_data_prettytable.int_format = "04"
+        city_data_prettytable.int_format = int_format
         self._test_no_blank_lines(city_data_prettytable)
 
+    @pytest.mark.parametrize("int_format", ["04", "04d", "#06x", "5,"])
     def test_all_lengths_equal_with_int_format(
-        self, city_data_prettytable: PrettyTable
+        self, city_data_prettytable: PrettyTable, int_format: str
     ):
         """All lines in a table should be of the same length."""
-        city_data_prettytable.int_format = "04"
+        city_data_prettytable.int_format = int_format
         self._test_all_length_equal(city_data_prettytable)
 
-    def test_no_blank_lines_with_float_format(self, city_data_prettytable: PrettyTable):
+    @pytest.mark.parametrize("float_format", ["6.2", "6.2f", "7.4G", "8,.2"])
+    def test_no_blank_lines_with_float_format(
+        self, city_data_prettytable: PrettyTable, float_format: str
+    ):
         """No table should ever have blank lines in it."""
-        city_data_prettytable.float_format = "6.2f"
+        city_data_prettytable.float_format = float_format
         self._test_no_blank_lines(city_data_prettytable)
 
+    @pytest.mark.parametrize("float_format", ["6.2", "6.2f", "7.4G", "8,.2"])
     def test_all_lengths_equal_with_float_format(
-        self, city_data_prettytable: PrettyTable
+        self, city_data_prettytable: PrettyTable, float_format: str
     ):
         """All lines in a table should be of the same length."""
-        city_data_prettytable.float_format = "6.2f"
+        city_data_prettytable.float_format = float_format
         self._test_all_length_equal(city_data_prettytable)
 
     def test_no_blank_lines_from_csv(self, city_data_from_csv: PrettyTable):


### PR DESCRIPTION
The old `%`-formatting is not ageing well in modern Python code, and has largely been superseded by [format strings](https://docs.python.org/3/library/string.html#format-string-syntax) driven by the [`format()`](https://docs.python.org/3/library/functions.html#format) built-in. This PR pivots away from the `%` operator when used for string operations.

One notable change is to the behaviour of `int_format` and `float_format`, which have been changed to optionally allowed to end with alpha char, e.g. `#08x` or `8.3G`. Previously, only `float_format` optionally ended with `f`.