### PR TITLE
Highlight the project goal at top of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 [![codecov](https://codecov.io/gh/jazzband/prettytable/branch/master/graph/badge.svg)](https://codecov.io/gh/jazzband/prettytable)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-PrettyTable's main goal is to let you print tables in an attractive ASCII form, like
-this:
+PrettyTable lets you print tables in an attractive ASCII form:
 
 ```
 +-----------+------+------------+-----------------+

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@
 [![codecov](https://codecov.io/gh/jazzband/prettytable/branch/master/graph/badge.svg)](https://codecov.io/gh/jazzband/prettytable)
 [![Code style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
+PrettyTable's main goal is to let you print tables in an attractive ASCII form, like
+this:
+
+```
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+| Adelaide  | 1295 |  1158259   |      600.5      |
+| Brisbane  | 5905 |  1857594   |      1146.4     |
+| Darwin    | 112  |   120900   |      1714.7     |
+| Hobart    | 1357 |   205556   |      619.5      |
+| Melbourne | 1566 |  3806092   |      646.9      |
+| Perth     | 5386 |  1554769   |      869.4      |
+| Sydney    | 2058 |  4336374   |      1214.8     |
++-----------+------+------------+-----------------+
+```
+
+You can print tables like this to `stdout` or get string representations of them.
+
 ## Installation
 
 Install via pip:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ this:
 +-----------+------+------------+-----------------+
 ```
 
-You can print tables like this to `stdout` or get string representations of them.
-
 ## Installation
 
 Install via pip:


### PR DESCRIPTION
Rather than talking directly about installation, add a short section that talks about the main purpose of the project. Show a quick example of what users can get using PrettyTable.