### PR TITLE
Add `get_formatted_string()` convenience function

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ your table to a file or insert it into a GUI.
 
 The table can be displayed in several different formats using `get_formatted_string`
 just by changing the `out_format=<text|html|json|csv|latex>`. This function passes
-through arguments to the functions that render the table, so additional arguments
-can be given. The provides an easy means to let a user choose the output formatting.
+through arguments to the functions that render the table, so additional arguments can be
+given. The provides an easy means to let a user choose the output formatting.
 
 ```python
 def my_cli_function(table_format: str = 'text'):

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ your table to a file or insert it into a GUI.
 The table can be displayed in several different formats using `get_formatted_string` by
 changing the `out_format=<text|html|json|csv|latex>`. This function passes through
 arguments to the functions that render the table, so additional arguments can be given.
-The provides an easy means to let a user choose the output formatting.
+This provides a way to let a user choose the output formatting.
 
 ```python
 def my_cli_function(table_format: str = 'text'):

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ This string is guaranteed to look exactly the same as what would be printed by d
 `print(x)`. You can now do all the usual things you can do with a string, like write
 your table to a file or insert it into a GUI.
 
+The table can be displayed in several different formats using `get_formatted_string`
+just by changing the `out_format=<text|html|json|csv|latex>`. This function passes
+through arguments to the functions that render the table, so additional arguments
+can be given. The provides an easy means to let a user choose the output formatting.
+
+```python
+def my_cli_function(table_format: str = 'text'):
+  ...
+  print(x.get_formatted_string(table_format))
+```
+
 #### Controlling which data gets displayed
 
 If you like, you can restrict the output of `print(x)` or `x.get_string` to only the

--- a/README.md
+++ b/README.md
@@ -203,10 +203,10 @@ This string is guaranteed to look exactly the same as what would be printed by d
 `print(x)`. You can now do all the usual things you can do with a string, like write
 your table to a file or insert it into a GUI.
 
-The table can be displayed in several different formats using `get_formatted_string`
-by changing the `out_format=<text|html|json|csv|latex>`. This function passes
-through arguments to the functions that render the table, so additional arguments can be
-given. The provides an easy means to let a user choose the output formatting.
+The table can be displayed in several different formats using `get_formatted_string` by
+changing the `out_format=<text|html|json|csv|latex>`. This function passes through
+arguments to the functions that render the table, so additional arguments can be given.
+The provides an easy means to let a user choose the output formatting.
 
 ```python
 def my_cli_function(table_format: str = 'text'):

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ This string is guaranteed to look exactly the same as what would be printed by d
 your table to a file or insert it into a GUI.
 
 The table can be displayed in several different formats using `get_formatted_string`
-just by changing the `out_format=<text|html|json|csv|latex>`. This function passes
+by changing the `out_format=<text|html|json|csv|latex>`. This function passes
 through arguments to the functions that render the table, so additional arguments can be
 given. The provides an easy means to let a user choose the output formatting.
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1511,25 +1511,25 @@ class PrettyTable:
     def copy(self):
         return copy.deepcopy(self)
 
-    def get_output(self, format: str = "text", **kwargs) -> str:
+    def get_output(self, out_format: str = "text", **kwargs) -> str:
         """Return string representation of specified format of table in current state.
 
         Arguments:
-        format - resulting table format
+        out_format - resulting table format
         kwargs - passed through to function that performs formatting
         """
-        if format == "text":
+        if out_format == "text":
             return self.get_string(**kwargs)
-        if format == "html":
+        if out_format == "html":
             return self.get_html_string(**kwargs)
-        if format == "json":
+        if out_format == "json":
             return self.get_json_string(**kwargs)
-        if format == "csv":
+        if out_format == "csv":
             return self.get_csv_string(**kwargs)
-        if format == "latex":
+        if out_format == "latex":
             return self.get_latex_string(**kwargs)
         raise ValueError(
-            f"Invalid format {format}. Must be one of: text, html, json, csv, or latex"
+            f"Invalid format {out_format}. Must be one of: text, html, json, csv, or latex"
         )
 
     ##############################

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1529,7 +1529,8 @@ class PrettyTable:
         if out_format == "latex":
             return self.get_latex_string(**kwargs)
         raise ValueError(
-            f"Invalid format {out_format}. Must be one of: text, html, json, csv, or latex"
+            f"Invalid format {out_format}. "
+            "Must be one of: text, html, json, csv, or latex"
         )
 
     ##############################

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1511,6 +1511,27 @@ class PrettyTable:
     def copy(self):
         return copy.deepcopy(self)
 
+    def get_output(self, format: str = "text", **kwargs) -> str:
+        """Return string representation of specified format of table in current state.
+
+        Arguments:
+        format - resulting table format
+        kwargs - passed through to function that performs formatting
+        """
+        if format == "text":
+            return self.get_string(**kwargs)
+        if format == "html":
+            return self.get_html_string(**kwargs)
+        if format == "json":
+            return self.get_json_string(**kwargs)
+        if format == "csv":
+            return self.get_csv_string(**kwargs)
+        if format == "latex":
+            return self.get_latex_string(**kwargs)
+        raise ValueError(
+            f"Invalid format {format}. Must be one of: text, html, json, csv, or latex"
+        )
+
     ##############################
     # MISC PRIVATE METHODS       #
     ##############################

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1511,7 +1511,7 @@ class PrettyTable:
     def copy(self):
         return copy.deepcopy(self)
 
-    def get_output(self, out_format: str = "text", **kwargs) -> str:
+    def get_formatted_string(self, out_format: str = "text", **kwargs) -> str:
         """Return string representation of specified format of table in current state.
 
         Arguments:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2095,3 +2095,42 @@ class TestPreservingInternalBorders:
 </table>
 """.strip()  # noqa: E501
         )
+
+
+class TestGeneralOutput:
+    def test_text(self):
+        t = helper_table()
+        assert t.get_output("text") == t.get_string()
+        # test with default arg, too
+        assert t.get_output() == t.get_string()
+        # args passed through
+        assert t.get_output(border=False) == t.get_string(border=False)
+
+    def test_csv(self):
+        t = helper_table()
+        assert t.get_output("csv") == t.get_csv_string()
+        # args passed through
+        assert t.get_output("csv", border=False) == t.get_csv_string(border=False)
+
+    def test_json(self):
+        t = helper_table()
+        assert t.get_output("json") == t.get_json_string()
+        # args passed through
+        assert t.get_output("json", border=False) == t.get_json_string(border=False)
+
+    def test_html(self):
+        t = helper_table()
+        assert t.get_output("html") == t.get_html_string()
+        # args passed through
+        assert t.get_output("html", border=False) == t.get_html_string(border=False)
+
+    def test_latex(self):
+        t = helper_table()
+        assert t.get_output("latex") == t.get_latex_string()
+        # args passed through
+        assert t.get_output("latex", border=False) == t.get_latex_string(border=False)
+
+    def test_invalid(self):
+        t = helper_table()
+        with pytest.raises(ValueError):
+            t.get_output("pdf")

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2100,37 +2100,37 @@ class TestPreservingInternalBorders:
 class TestGeneralOutput:
     def test_text(self):
         t = helper_table()
-        assert t.get_output("text") == t.get_string()
+        assert t.get_formatted_string("text") == t.get_string()
         # test with default arg, too
-        assert t.get_output() == t.get_string()
+        assert t.get_formatted_string() == t.get_string()
         # args passed through
-        assert t.get_output(border=False) == t.get_string(border=False)
+        assert t.get_formatted_string(border=False) == t.get_string(border=False)
 
     def test_csv(self):
         t = helper_table()
-        assert t.get_output("csv") == t.get_csv_string()
+        assert t.get_formatted_string("csv") == t.get_csv_string()
         # args passed through
-        assert t.get_output("csv", border=False) == t.get_csv_string(border=False)
+        assert t.get_formatted_string("csv", border=False) == t.get_csv_string(border=False)
 
     def test_json(self):
         t = helper_table()
-        assert t.get_output("json") == t.get_json_string()
+        assert t.get_formatted_string("json") == t.get_json_string()
         # args passed through
-        assert t.get_output("json", border=False) == t.get_json_string(border=False)
+        assert t.get_formatted_string("json", border=False) == t.get_json_string(border=False)
 
     def test_html(self):
         t = helper_table()
-        assert t.get_output("html") == t.get_html_string()
+        assert t.get_formatted_string("html") == t.get_html_string()
         # args passed through
-        assert t.get_output("html", border=False) == t.get_html_string(border=False)
+        assert t.get_formatted_string("html", border=False) == t.get_html_string(border=False)
 
     def test_latex(self):
         t = helper_table()
-        assert t.get_output("latex") == t.get_latex_string()
+        assert t.get_formatted_string("latex") == t.get_latex_string()
         # args passed through
-        assert t.get_output("latex", border=False) == t.get_latex_string(border=False)
+        assert t.get_formatted_string("latex", border=False) == t.get_latex_string(border=False)
 
     def test_invalid(self):
         t = helper_table()
         with pytest.raises(ValueError):
-            t.get_output("pdf")
+            t.get_formatted_string("pdf")

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2110,25 +2110,33 @@ class TestGeneralOutput:
         t = helper_table()
         assert t.get_formatted_string("csv") == t.get_csv_string()
         # args passed through
-        assert t.get_formatted_string("csv", border=False) == t.get_csv_string(border=False)
+        assert t.get_formatted_string("csv", border=False) == t.get_csv_string(
+            border=False
+        )
 
     def test_json(self):
         t = helper_table()
         assert t.get_formatted_string("json") == t.get_json_string()
         # args passed through
-        assert t.get_formatted_string("json", border=False) == t.get_json_string(border=False)
+        assert t.get_formatted_string("json", border=False) == t.get_json_string(
+            border=False
+        )
 
     def test_html(self):
         t = helper_table()
         assert t.get_formatted_string("html") == t.get_html_string()
         # args passed through
-        assert t.get_formatted_string("html", border=False) == t.get_html_string(border=False)
+        assert t.get_formatted_string("html", border=False) == t.get_html_string(
+            border=False
+        )
 
     def test_latex(self):
         t = helper_table()
         assert t.get_formatted_string("latex") == t.get_latex_string()
         # args passed through
-        assert t.get_formatted_string("latex", border=False) == t.get_latex_string(border=False)
+        assert t.get_formatted_string("latex", border=False) == t.get_latex_string(
+            border=False
+        )
 
     def test_invalid(self):
         t = helper_table()


### PR DESCRIPTION
In a couple uses of `PrettyTable`, I have added a similar function to allow for less code from my CLI projects. In those projects, I allow specifying the output format type as an arguments.