### PR TITLE
Drop support for EOL Python 3.7

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,6 +8,9 @@ jobs:
   label:
     runs-on: ubuntu-latest
 
+    permissions:
+      issues: write
+
     steps:
       - uses: mheap/github-action-required-labels@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
@@ -33,17 +33,18 @@ repos:
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
+      - id: check-json
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.9.2
+    rev: 0.10.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.2
+    rev: v0.13
     hooks:
       - id: validate-pyproject
 
@@ -53,14 +54,14 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6
+    rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]
         exclude: ^.github/ISSUE_TEMPLATE/bug_report.md$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.2.0"
+    rev: "v1.3.0"
     hooks:
       - id: mypy
         additional_dependencies: [types-colorama, types-setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,12 @@ readme = "README.md"
 license = {text = "BSD (3 clause)"}
 maintainers = [{name ="Jazzband"}]
 authors = [{name = "Luke Maurits", email = "luke@maurits.id.au"}]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -33,7 +32,6 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  'importlib-metadata; python_version < "3.8"',
   "wcwidth",
 ]
 [project.optional-dependencies]

--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -44,11 +44,6 @@ __all__ = [
     "from_json",
 ]
 
-try:
-    # Python 3.8+
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # <Python 3.7 and lower
-    import importlib_metadata  # type: ignore
+import importlib.metadata
 
-__version__ = importlib_metadata.version(__name__)
+__version__ = importlib.metadata.version(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
-    py{py3, 312, 311, 310, 39, 38, 37}
+    py{py3, 312, 311, 310, 39, 38}
 
 [testenv]
 extras =


### PR DESCRIPTION
Changes proposed in this pull request:

 * Drop support for Python 3.7, EOL this month
   * https://devguide.python.org/versions/
   * https://peps.python.org/pep-0537/
 * Not planning a major bump, `requires-python = ">=3.8"` makes sure people get the right version
