### PR TITLE
Temporarily pin pytest<8 due to pytest-lazy-fixture#65

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,9 @@ dependencies = [
 ]
 [project.optional-dependencies]
 tests = [
-  "pytest",
+  # Temporarily pin pytest due to
+  # https://github.com/TvoroG/pytest-lazy-fixture/issues/65
+  "pytest<8",
   "pytest-cov",
   "pytest-lazy-fixture",
 ]


### PR DESCRIPTION
pytest 8 was just released but pytest-lazy-fixture doesn't yet support it:

```pytb
.tox\py\lib\site-packages\pluggy\_hooks.py:501: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
.tox\py\lib\site-packages\pluggy\_manager.py:119: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
.tox\py\lib\site-packages\_pytest\python.py:277: in pytest_pycollect_makeitem
    return list(collector._genfunctions(name, obj))
.tox\py\lib\site-packages\_pytest\python.py:506: in _genfunctions
    self.ihook.pytest_generate_tests.call_extra(methods, dict(metafunc=metafunc))
.tox\py\lib\site-packages\pluggy\_hooks.py:562: in call_extra
    return self._hookexec(self.name, hookimpls, kwargs, firstresult)
.tox\py\lib\site-packages\pluggy\_manager.py:[119](https://github.com/hugovk/prettytable/actions/runs/7699842249/job/20982359292#step:5:120): in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
.tox\py\lib\site-packages\pytest_lazyfixture.py:74: in pytest_generate_tests
    normalize_metafunc_calls(metafunc, 'funcargs')
.tox\py\lib\site-packages\pytest_lazyfixture.py:81: in normalize_metafunc_calls
    calls = normalize_call(callspec, metafunc, valtype, used_keys)
.tox\py\lib\site-packages\pytest_lazyfixture.py:105: in normalize_call
    valtype_keys = set(getattr(callspec, valtype).keys()) - used_keys
E   AttributeError: 'CallSpec2' object has no attribute 'funcargs'
```

See https://github.com/TvoroG/pytest-lazy-fixture/issues/65.