### PR TITLE
Speedup: lazy imports and remove import

### DIFF
--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from .prettytable import (
     ALL,
     DEFAULT,
@@ -44,6 +46,12 @@ __all__ = [
     "from_json",
 ]
 
-import importlib.metadata
 
-__version__ = importlib.metadata.version(__name__)
+def __getattr__(name: str) -> Any:
+    if name == "__version__":
+        import importlib.metadata
+
+        return importlib.metadata.version(__name__)
+
+    msg = f"module '{__name__}' has no attribute '{name}'"
+    raise AttributeError(msg)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -40,8 +40,6 @@ from html import escape
 from html.parser import HTMLParser
 from typing import Any
 
-import wcwidth  # type: ignore
-
 # hrule styles
 FRAME = 0
 ALL = 1
@@ -2419,6 +2417,8 @@ class PrettyTable:
 
 
 def _str_block_width(val):
+    import wcwidth  # type: ignore
+
     return wcwidth.wcswidth(_re.sub("", val))
 
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -34,7 +34,6 @@
 from __future__ import annotations
 
 import io
-import math
 import re
 from html.parser import HTMLParser
 from typing import Any
@@ -1595,7 +1594,7 @@ class PrettyTable:
             if table_width > self._max_table_width:
                 # Shrink widths in proportion
                 scale = 1.0 * self._max_table_width / table_width
-                widths = [int(math.floor(w * scale)) for w in widths]
+                widths = [int(w * scale) for w in widths]
                 self._widths = widths
 
         # Are we under min_table_width or title width?
@@ -1627,7 +1626,7 @@ class PrettyTable:
             if content_width < min_width:
                 # Grow widths in proportion
                 scale = 1.0 * min_width / content_width
-                widths = [int(math.floor(w * scale)) for w in widths]
+                widths = [int(w * scale) for w in widths]
                 if sum(widths) < min_width:
                     widths[-1] += min_width - sum(widths)
                 self._widths = widths

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import copy
 import csv
 import io
-import json
 import math
 import random
 import re
@@ -2082,6 +2081,7 @@ class PrettyTable:
         a PrettyTable formatting option (skip the header row) and indent as a
         json.dumps keyword argument.
         """
+        import json
 
         options = self._get_options(kwargs)
         json_options: Any = dict(indent=4, separators=(",", ": "), sort_keys=True)
@@ -2465,6 +2465,8 @@ def from_db_cursor(cursor, **kwargs):
 
 
 def from_json(json_string, **kwargs):
+    import json
+
     table = PrettyTable(**kwargs)
     objects = json.loads(json_string)
     table.field_names = objects[0]

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -34,7 +34,6 @@
 from __future__ import annotations
 
 import copy
-import csv
 import io
 import math
 import re
@@ -2055,6 +2054,7 @@ class PrettyTable:
         header as a PrettyTable formatting option (skip the header row) and
         delimiter as a csv.writer keyword argument.
         """
+        import csv
 
         options = self._get_options(kwargs)
         csv_options = {
@@ -2424,6 +2424,8 @@ def _str_block_width(val):
 
 
 def from_csv(fp, field_names: Any | None = None, **kwargs):
+    import csv
+
     fmtparams = {}
     for param in [
         "delimiter",

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -37,7 +37,6 @@ import copy
 import csv
 import io
 import math
-import random
 import re
 import textwrap
 from html import escape
@@ -1378,6 +1377,8 @@ class PrettyTable:
 
     def _set_random_style(self):
         # Just for fun!
+        import random
+
         self.header = random.choice((True, False))
         self.border = random.choice((True, False))
         self._hrules = random.choice((ALL, FRAME, HEADER, NONE))

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -33,7 +33,6 @@
 
 from __future__ import annotations
 
-import copy
 import io
 import math
 import re
@@ -1520,6 +1519,8 @@ class PrettyTable:
     ##############################
 
     def copy(self):
+        import copy
+
         return copy.deepcopy(self)
 
     def get_formatted_string(self, out_format: str = "text", **kwargs) -> str:
@@ -1653,6 +1654,7 @@ class PrettyTable:
         Arguments:
 
         options - dictionary of option settings."""
+        import copy
 
         if options["oldsortslice"]:
             rows = copy.deepcopy(self._rows[options["start"] : options["end"]])
@@ -1681,6 +1683,7 @@ class PrettyTable:
         Arguments:
 
         options - dictionary of option settings."""
+        import copy
 
         if options["oldsortslice"]:
             dividers = copy.deepcopy(self._dividers[options["start"] : options["end"]])

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import io
 import math
 import re
-import textwrap
 from html import escape
 from html.parser import HTMLParser
 from typing import Any
@@ -1946,6 +1945,8 @@ class PrettyTable:
         return "".join(bits)
 
     def _stringify_row(self, row, options, hrule):
+        import textwrap
+
         for index, field, value, width in zip(
             range(0, len(row)), self._field_names, row, self._widths
         ):

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import io
 import math
 import re
-from html import escape
 from html.parser import HTMLParser
 from typing import Any
 
@@ -2147,6 +2146,8 @@ class PrettyTable:
         return string
 
     def _get_simple_html_string(self, options):
+        from html import escape
+
         lines = []
         if options["xhtml"]:
             linebreak = "<br/>"
@@ -2199,6 +2200,8 @@ class PrettyTable:
         return "\n".join(lines)
 
     def _get_formatted_html_string(self, options):
+        from html import escape
+
         lines = []
         lpad, rpad = self._get_padding_widths(options)
         if options["xhtml"]:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -110,7 +110,7 @@ class TestNoneOption:
     def test_none_char_invalid_option(self):
         with pytest.raises(TypeError) as exc:
             PrettyTable(["Field 1", "Field 2", "Field 3"], none_format=2)
-            assert "must be a string." in exc.value
+        assert "must be a string" in str(exc.value)
 
     def test_no_value_replace_none(self):
         t = PrettyTable(["Field 1", "Field 2", "Field 3"])

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -32,6 +32,13 @@ from prettytable import (
 )
 
 
+def test_version() -> None:
+    assert isinstance(prettytable.__version__, str)
+    assert prettytable.__version__[0].isdigit()
+    assert prettytable.__version__.count(".") >= 2
+    assert prettytable.__version__[-1].isdigit()
+
+
 def helper_table(rows=3):
     t = PrettyTable(["Field 1", "Field 2", "Field 3"])
     v = 1

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2107,6 +2107,16 @@ class TestPreservingInternalBorders:
 
 
 class TestGeneralOutput:
+    def test_copy(self) -> None:
+        # Arrange
+        t = helper_table()
+
+        # Act
+        t_copy = t.copy()
+
+        # Assert
+        assert t.get_string() == t_copy.get_string()
+
     def test_text(self):
         t = helper_table()
         assert t.get_formatted_string("text") == t.get_string()

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ commands =
       --cov-report term \
       --cov-report xml \
       {posargs}
-    coverage report
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Command-line interfaces value speed, and unused imports can slow things down a lot.

We can use `python -X importtime` and tuna to identify bottlenecks: https://medium.com/alan/how-we-improved-our-python-backend-start-up-time-2c33cd4873c8

For example:

```sh
python3.13 -X importtime -c 'import prettytable' 2> import.log
tuna import.log
```

We're using Python 3.13.0a3 here, because it already includes some optimisations of its own.

# Baseline

Starting on `main`, `prettytable`: 0.027 s (87.8%)

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/8c699317-63f7-4039-afbe-e2f861b81328">

And let's begin by zooming into `prettytable.prettytable`: 0.010s (32.8%)

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/5d6c82c6-4618-4c57-98a4-9413f303f339">

# Lazy import json

`json` is a good first target. Taking 0.001 s (2.7%), it's only used by one function to load from JSON, and another to save. If doing plain text tables (or HTML etc), you won't use them.
Let's move the import into those two functions where it's actually needed:

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/2c40515f-5875-4ec0-bc0f-3b223a943fac">

Result: `prettytable.prettytable`: 0.009 s (30.3%)

# Lazy import random

`random` is only used by a function to set random styles, and is mostly for fun. Lazy import it to save 0.001 s (1.8%):

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/e58b93e7-c5b6-49e4-a03a-b9069303701e">

Result: `prettytable.prettytable` 0.009 s (28.5%)

# Lazy import csv

Like `json`, `csv` is only used for loading or saving CSV and takes 0.003 s (10.8%).

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/8d7402ad-60d8-4667-bcc7-e705f1c3b44d">

Result: `prettytable.prettytable` 0.008 s (27.1%)

# Lazy import copy

Used in three places: a function to return a copy of a table. Is this used much? And also in other functions, themselves used when getting a number of string, HTML, CSV, JSON, Latex versions of a table. That's quite a few, so will likely end up being imported anyway, but it's a simple change and we may save 0.001 s (2.7%) in a few places.

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/c8a98ee6-178b-4ecd-9ca2-88a79684fa2b">

Result: `prettytable.prettytable` 0.008 s (25.9%)

# Lazy import textwrap

Only used in one function when getting a string version of a table. I think a common operation, but again, a quick saving for those cases when not.

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/5a8dba4f-165c-4636-aeed-84ea46a19b9c">

Result: `prettytable.prettytable` 0.007 s (24.6%)

# Lazy import wcwidth

Called by one function, but itself called several times, mostly for getting string tables? Well, saving of 0.001 s (2.2%) if not needed.


Result: `prettytable.prettytable` 0.007 s (23.0%)

# Lazy import html.escape

Only used when getting HTML versions of tables: 0.001 s (2.3%)

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/baf83b19-447a-4085-9e76-6615b5318292">

Result: `prettytable.prettytable` 0.007 s (22.5%)


# Replace math.floor with int

For positive inputs `math.floor` and `int` give the same results, we can avoid importing `math` to save a (rounded) 0.000 s (0.9%). We were calling `int` on the result of `math.floor` anyway!

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/a26351a6-d32a-48da-a3b3-6e24739eafb2">

Result: `prettytable.prettytable` 0.006 s (21.6%)

# Lazy import importlib.metadata

Finally, let's step out back to `prettytable`:

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/31ffe7c1-f3da-4e3e-adf2-2c77e12bee5b">

`importlib.metadata` takes a big chunk of the original: 0.015 s (50.9%)!

We only use this to set `__version__` on the off-chance someone might access it:

```python
import importlib.metadata

__version__ = importlib.metadata.version(__name__)
```

We can instead only import when `__version__` is accessed:

```python
def __getattr__(name: str) -> Any:
    if name == "__version__":
        import importlib.metadata

        return importlib.metadata.version(__name__)

    msg = f"module '{__name__}' has no attribute '{name}'"
    raise AttributeError(msg)
``` 

<img width="1582" alt="image" src="https://github.com/jazzband/prettytable/assets/1324225/a9337b42-c658-4bd2-8ff1-1e686e7f103e">

Result: `prettytable` 0.007 s (65.1%).

---

Compare with our original `prettytable`: 0.027 s (87.8%), that's a big saving! 

This is an idealised result and in reality a few of these will be imported, based on the use case. Still, those that do apply will help CLIs.

A quick look at the remaining "big" ones:

* `typing` 0.003 s (24.3%) - not easy to remove without removing type hints entirely. The stdlib has already optimised `typing` for 3.13, so already better than before.
* `re` 0.002 s (18.5%) - used to compile a regex to save time later. Used before calculating widths. Could potentially be replaced with some `str.replace` calls. Something to consider another time.
* `html.parser.HTMLParser` 0.002 s (17.0%) - used to subclass. Could potentially be moved and only imported/created when needing to parse those things, but could technically change the public API. Something to consider another time.

But we've achieved enough here for now!
