### PR TITLE
Remove `--unsafe-fixes` from Ruff pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v0.2.0
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --unsafe-fixes]
+        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1


### PR DESCRIPTION
It was a temporary addition.