### PR TITLE
workflows/test.yml: bump coverage-action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3.1.5
+        uses: codecov/codecov-action@v4
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
https://github.com/codecov/codecov-action/releases/tag/v4.0.0

https://github.com/codecov/codecov-action/compare/v3.1.5...v4.0.1

Amongst other things, this also addresses the Nodejs 16 deprecation which was the reason for pinning to v3.1.5