### PR TITLE
Change how size of headers are calculated to fix ColorTable with title

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1888,7 +1888,7 @@ class PrettyTable:
         bits.append(endpoint)
         title = " " * lpad + title + " " * rpad
         lpad, rpad = self._get_padding_widths(options)
-        sum_widths = sum(n + lpad + rpad + 1 for n in self._widths)
+        sum_widths = sum([n + lpad + rpad + 1 for n in self._widths])
 
         bits.append(self._justify(title, sum_widths - 1, "c"))
         bits.append(endpoint)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1888,7 +1888,7 @@ class PrettyTable:
         bits.append(endpoint)
         title = " " * lpad + title + " " * rpad
         lpad, rpad = self._get_padding_widths(options)
-        sum_widths = sum((n + lpad + rpad + 1 for n in self._widths))
+        sum_widths = sum(n + lpad + rpad + 1 for n in self._widths)
 
         bits.append(self._justify(title, sum_widths - 1, "c"))
         bits.append(endpoint)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1888,9 +1888,9 @@ class PrettyTable:
         bits.append(endpoint)
         title = " " * lpad + title + " " * rpad
         lpad, rpad = self._get_padding_widths(options)
-        total_widths = [n + lpad + rpad + 1 for n in self._widths]
+        sum_widths = sum((n + lpad + rpad + 1 for n in self._widths))
 
-        bits.append(self._justify(title, sum(total_widths) - 1, "c"))
+        bits.append(self._justify(title, sum_widths - 1, "c"))
         bits.append(endpoint)
         lines.append("".join(bits))
         return "\n".join(lines)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1887,7 +1887,10 @@ class PrettyTable:
         )
         bits.append(endpoint)
         title = " " * lpad + title + " " * rpad
-        bits.append(self._justify(title, len(self._hrule) - 2, "c"))
+        lpad, rpad = self._get_padding_widths(options)
+        total_widths = [n + lpad + rpad + 1 for n in self._widths]
+
+        bits.append(self._justify(title, sum(total_widths) - 1, "c"))
         bits.append(endpoint)
         lines.append("".join(bits))
         return "\n".join(lines)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1902,9 +1902,11 @@ class PrettyTable:
             if options["hrules"] in (ALL, FRAME):
                 bits.append(self._stringify_hrule(options, "top_"))
                 if options["title"] and options["vrules"] in (ALL, FRAME):
+                    left_j_len = len(self.left_junction_char)
+                    right_j_len = len(self.right_junction_char)
                     bits[-1] = (
                         self.left_junction_char
-                        + bits[-1][1:-1]
+                        + bits[-1][left_j_len:-right_j_len]
                         + self.right_junction_char
                     )
                 bits.append("\n")

--- a/tests/test_colortable.py
+++ b/tests/test_colortable.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from prettytable import PrettyTable
-from prettytable.colortable import RESET_CODE, ColorTable, Theme
+from prettytable.colortable import RESET_CODE, ColorTable, Theme, Themes
 
 
 @pytest.fixture
@@ -94,3 +94,63 @@ class TestFormatCode:
     def test_multiple(self) -> None:
         assert Theme.format_code("30;42") == "\x1b[30;42m"
         assert Theme.format_code("\x1b[30;42m") == "\x1b[30;42m"
+
+
+class TestColorTableRendering:
+    """ Tests for the rendering of the color table
+
+    Methods
+    -------
+    test_color_table_rendering
+        Tests the color table rendering using the default alignment (`'c'`)
+    """
+    def test_color_table_rendering(self) -> None:
+        """ Tests the color table rendering using the default alignment (`'c'`) """
+        chars = {
+            "+": "\x1b[36m+\x1b[0m\x1b[96m",
+            "-": "\x1b[34m-\x1b[0m\x1b[96m",
+            "|": "\x1b[34m|\x1b[0m\x1b[96m",
+            " ": " "
+        }
+
+        plus = chars.get("+")
+        minus = chars.get("-")
+        pipe = chars.get("|")
+        space = chars.get(" ")
+
+        # +-----------------------+
+        # |        Efforts        |
+        # +---+---+---+---+---+---+
+        # | A | B | C | D | E | f |
+        # +---+---+---+---+---+---+
+        # | 1 | 2 | 3 | 4 | 5 | 6 |
+        # +---+---+---+---+---+---+
+
+        header = (
+            plus +  minus * 23 + plus,
+            pipe + space * 8 + "Efforts" + space * 8 + pipe,
+            (plus + minus * 3) * 6 + plus
+        )
+
+        body = (
+            "".join((pipe + space + char + space for char in "ABCDEF")) + pipe,
+            (plus + minus * 3) * 6 + plus,
+            "".join((pipe + space + char + space for char in "123456")) + pipe,
+            (plus + minus * 3) * 6 + plus,
+        )
+
+        header_str = str("\n".join(header))
+        body_str = str("\n".join(body))
+
+        table = ColorTable(
+            ("A", "B", "C", "D", "E", "F"),
+            theme=Themes.OCEAN,
+        )
+
+        table.title = "Efforts"
+        table.add_row([1, 2, 3, 4, 5, 6])
+
+        expected = header_str + "\n" + body_str + '\x1b[0m'
+        result = str(table)
+
+        assert expected == result

--- a/tests/test_colortable.py
+++ b/tests/test_colortable.py
@@ -97,20 +97,21 @@ class TestFormatCode:
 
 
 class TestColorTableRendering:
-    """ Tests for the rendering of the color table
+    """Tests for the rendering of the color table
 
     Methods
     -------
     test_color_table_rendering
         Tests the color table rendering using the default alignment (`'c'`)
     """
+
     def test_color_table_rendering(self) -> None:
-        """ Tests the color table rendering using the default alignment (`'c'`) """
+        """Tests the color table rendering using the default alignment (`'c'`)"""
         chars = {
             "+": "\x1b[36m+\x1b[0m\x1b[96m",
             "-": "\x1b[34m-\x1b[0m\x1b[96m",
             "|": "\x1b[34m|\x1b[0m\x1b[96m",
-            " ": " "
+            " ": " ",
         }
 
         plus = chars.get("+")
@@ -127,15 +128,15 @@ class TestColorTableRendering:
         # +---+---+---+---+---+---+
 
         header = (
-            plus +  minus * 23 + plus,
+            plus + minus * 23 + plus,
             pipe + space * 8 + "Efforts" + space * 8 + pipe,
-            (plus + minus * 3) * 6 + plus
+            (plus + minus * 3) * 6 + plus,
         )
 
         body = (
-            "".join((pipe + space + char + space for char in "ABCDEF")) + pipe,
+            "".join(pipe + space + char + space for char in "ABCDEF") + pipe,
             (plus + minus * 3) * 6 + plus,
-            "".join((pipe + space + char + space for char in "123456")) + pipe,
+            "".join(pipe + space + char + space for char in "123456") + pipe,
             (plus + minus * 3) * 6 + plus,
         )
 
@@ -150,7 +151,7 @@ class TestColorTableRendering:
         table.title = "Efforts"
         table.add_row([1, 2, 3, 4, 5, 6])
 
-        expected = header_str + "\n" + body_str + '\x1b[0m'
+        expected = header_str + "\n" + body_str + "\x1b[0m"
         result = str(table)
 
         assert expected == result


### PR DESCRIPTION
Fixes #290

The issue that the `ColorTable` is experiencing deals with its incorporation of ANSI escape character sequences. The `ColorTable` class works by incorporating ANSI escape character sequences both before and after the character it represents. That creates a discrepancy in how `PrettyTable` and `ColorTable` portray the same character.

I altered how `_stringify_title` computes its width. Instead of relying on `self._hrule`, it now uses the padding widths and the widths of the columns themselves. From my testing, this seems to work well. I also modified the way `_stringify_header` slices the `bits` value. The old code used hard values of `1` and `-1`, which doesn't account for the length of a single character when someone uses `ColorTable`.

If you see anything that stands out, or you have input on a different solution, please let me know. I am open to the discussion. Also, I didn't see any tests related to the table rendering for `ColorTable`, so I didn't add any. All of the original tests are passing for both `ColorTable` and `PrettyTable` with these recent changes.