### PR TITLE
doc: mypy-compliant type for column alignement

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,10 @@ You can also change the alignment of individual columns based on the correspondi
 name by treating the `align` attribute as if it were a dictionary.
 
 ```python
-table.align["City name"] = "l"
-table.align["Area"] = "c"
-table.align["Population"] = "r"
-table.align["Annual Rainfall"] = "c"
+(table.align)["City name"] = "l"
+(table.align)["Area"] = "c"
+(table.align)["Population"] = "r"
+(table.align)["Annual Rainfall"] = "c"
 print(table)
 ```
 


### PR DESCRIPTION
Using property for `align` confuses mypy type checker.

This MR updates the documentation to make clear how to properly use `table.align[fieldname]`.
