### PR TITLE
Use SPDX license identifier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.20.2
+    rev: v0.21
     hooks:
       - id: validate-pyproject
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 name = "prettytable"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 readme = "README.md"
-license = { text = "BSD (3 clause)" }
+license = "BSD-3-Clause"
 maintainers = [ { name = "Jazzband" } ]
 authors = [ { name = "Luke Maurits", email = "luke@maurits.id.au" } ]
 requires-python = ">=3.9"


### PR DESCRIPTION
The `hatch` documentation recommends to use of SPDX license identifier.
https://hatch.pypa.io/1.9/config/metadata/#spdx-expression

With that `hatchling` will write a compatible `License-Expression` to the package metadata.
```
...
License-Expression: BSD-3-Clause
...
```