### PR TITLE
Adjust format validation

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -91,6 +91,7 @@ class PrettyTable:
     _top_left_junction_char: str | None
     _bottom_right_junction_char: str | None
     _bottom_left_junction_char: str | None
+    _format: bool
     _print_empty: bool
     _oldsortslice: bool
     _escape_header: bool
@@ -399,7 +400,6 @@ class PrettyTable:
             "padding_width",
             "left_padding_width",
             "right_padding_width",
-            "format",
         ):
             self._validate_nonnegative_int(option, val)
         elif option == "sortby":
@@ -418,6 +418,7 @@ class PrettyTable:
             "preserve_internal_border",
             "reversesort",
             "xhtml",
+            "format",
             "print_empty",
             "oldsortslice",
             "escape_header",
@@ -1241,7 +1242,7 @@ class PrettyTable:
         self._bottom_left_junction_char = val
 
     @property
-    def format(self):
+    def format(self) -> bool:
         """Controls whether or not HTML tables are formatted to match styling options
 
         Arguments:
@@ -1250,7 +1251,7 @@ class PrettyTable:
         return self._format
 
     @format.setter
-    def format(self, val) -> None:
+    def format(self, val: bool) -> None:
         self._validate_option("format", val)
         self._format = val
 


### PR DESCRIPTION
The docstring for `format` says it should be either `True` or `False`. Change the validator from `_validate_nonnegative_int` to `_validate_true_or_false` to better reflect that.

It succeeded previously as `_validate_nonnegative_int` uses `int(value) >= 0`.