### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` call

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,3 +20,13 @@ jobs:
           python-version: "3.x"
           cache: pip
       - uses: pre-commit/action@v3.0.1
+
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
+      - name: Mypy
+        run: uvx --with tox-uv tox -e mypy

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# hatch-vcs
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,14 +34,6 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-colorama]
-        args: [--pretty, --show-error-codes]
-        exclude: ^tests/
-
   - repo: https://github.com/tox-dev/pyproject-fmt
     rev: 2.2.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ urls.Source = "https://github.com/jazzband/prettytable"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/prettytable/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
-
+from ._version import __version__
 from .prettytable import (
     ALL,
     DEFAULT,
@@ -44,14 +43,5 @@ __all__ = [
     "from_html",
     "from_html_one",
     "from_json",
+    "__version__",
 ]
-
-
-def __getattr__(name: str) -> Any:
-    if name == "__version__":
-        import importlib.metadata
-
-        return importlib.metadata.version(__name__)
-
-    msg = f"module '{__name__}' has no attribute '{name}'"
-    raise AttributeError(msg)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2545,7 +2545,7 @@ class PrettyTable:
 
 
 def _str_block_width(val: str) -> int:
-    import wcwidth  # type: ignore[import-not-found]
+    import wcwidth  # type: ignore[import-untyped]
 
     return wcwidth.wcswidth(_re.sub("", val))
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
+    mypy
     py{py3, 313, 312, 311, 310, 39}
 
 [testenv]
@@ -27,3 +28,10 @@ pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy]
+deps =
+    mypy==1.11.2
+    types-colorama
+commands =
+    mypy . {posargs} --exclude tests


### PR DESCRIPTION
We're lazily importing it, but the call itself is slow (for example, can be 15ms), so let's generate the version instead.