### PR TITLE
Test with tox-uv

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build:
     if: github.repository_owner == 'jazzband'
@@ -36,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U build twine wheel
+          python -m pip install -U build twine
 
       - name: Build package
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,16 +25,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U tox
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Tox tests
         run: |
-          tox -e py
+          uvx --with tox-uv tox -e py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3.1.5


### PR DESCRIPTION

# Before

No cache: 25m 33s

https://github.com/hugovk/prettytable/actions/runs/11368496368/usage

With cache: 12m 57s

https://github.com/hugovk/prettytable/actions/runs/11368720670/usage

# After

No cache: 19m 17s

https://github.com/hugovk/prettytable/actions/runs/11368499962/usage

With cache: 9m 25s

https://github.com/hugovk/prettytable/actions/runs/11368819433/usage

---

Also add colour to release workflow and no need to install wheel package.
