### PR TITLE
Release to PyPI using Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Build package
+
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 1
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: hynek/build-and-inspect-python-package@v2
+
+  # Publish to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: |
+      github.repository_owner == 'prettytable'
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+          repository-url: https://test.pypi.org/legacy/
+
+  # Publish to PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish to PyPI
+    # Only run for published releases.
+    if: |
+      github.repository_owner == 'prettytable'
+      && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,50 +1,20 @@
 # Release checklist
 
 - [ ] Get `main` to the appropriate code release state.
-      [GitHub Actions](https://github.com/prettytable/prettytable/actions) should be
-      running cleanly for all merges to `main`.
-      [![GitHub Actions status](https://github.com/prettytable/prettytable/workflows/Test/badge.svg)](https://github.com/prettytable/prettytable/actions)
+      [GitHub Actions](https://github.com/hugovk/tinytext/actions) should be running
+      cleanly for all merges to `main`.
+      [![GitHub Actions status](https://github.com/hugovk/tinytext/workflows/Test/badge.svg)](https://github.com/hugovk/tinytext/actions)
 
-* [ ] Start from a freshly cloned repo:
+- [ ] Edit release draft, adjust text if needed:
+      https://github.com/hugovk/tinytext/releases
 
-```bash
-cd /tmp
-rm -rf prettytable
-git clone https://github.com/prettytable/prettytable
-cd prettytable
-```
+- [ ] Check next tag is correct, amend if needed
 
-- [ ] (Optional) Create a distribution and release on **TestPyPI**:
+- [ ] Publish release
 
-```bash
-pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-twine check --strict dist/* && twine upload --repository testpypi dist/*
-```
-
-- [ ] (Optional) Check **test** installation:
-
-```bash
-pip3 uninstall -y prettytable
-pip3 install -U -i https://test.pypi.org/simple/ prettytable --pre
-python3 -c "import prettytable; print(prettytable.__version__)"
-```
-
-- [ ] Tag with the version number:
-
-```bash
-git tag -a 2.1.0 -m "Release 2.1.0"
-```
-
-- [ ] Create a distribution and release on **live PyPI**:
-
-```bash
-pip install -U pip build keyring twine
-rm -rf build dist
-python -m build
-twine check --strict dist/* && twine upload --repository pypi dist/*
-```
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/hugovk/tinytext/actions/workflows/deploy.yml)
+      has deployed to [PyPI](https://pypi.org/project/tinytext/#history)
 
 - [ ] Check installation:
 
@@ -53,16 +23,3 @@ pip uninstall -y prettytable
 pip install -U prettytable
 python3 -c "import prettytable; print(prettytable.__version__)"
 ```
-
-- [ ] Push tag:
-
-```bash
-git push --tags
-```
-
-- [ ] Edit release draft, adjust text if needed:
-      https://github.com/prettytable/prettytable/releases
-
-- [ ] Check next tag is correct, amend if needed
-
-- [ ] Publish release


### PR DESCRIPTION
PyPI has introduced "Trusted Publishers", a method to release files from CI using OIDC and generated, short-lived tokens, rather than long-lived tokens on the developer's own machine. This is both safer, and makes releasing easier and more convenient.

https://docs.pypi.org/trusted-publishers/

This PR adds a workflow to deploy to PyPI for new GitHub releases.

It also deploys to Test PyPI on merges to `main`, to make sure the release machinery is well oiled.

I've set up the PyPIs with this:

<img width="403" alt="image" src="https://github.com/user-attachments/assets/61053a4f-e765-4afe-9003-4cfc96590287">

* https://test.pypi.org/manage/project/prettytable/settings/publishing/
* https://pypi.org/manage/project/prettytable/settings/publishing/

---

PEP 740 ("Index support for digital attestations") introduces signatures which links the PyPI package to the GitHub repo, and helps users verify the source and authenticity of packages. This is only available with Trusted Publishing.

PyPI is still implementing support, but we can already start using it, which should also help them test out.

* https://peps.python.org/pep-0740/
* https://github.com/pypa/gh-action-pypi-publish#generating-and-uploading-attestations
* https://github.com/pypi/warehouse/issues/15871

All we need to do to enable this is add:
```yml
        with:
          attestations: true
```

