### PR TITLE
Add missing type annotations for properties

### DIFF
--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,3 +1,3 @@
-mypy==1.15.0
+mypy==1.16.0
 types-colorama
 wcwidth-stubs

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -771,11 +771,11 @@ class PrettyTable:
         self._xhtml = val
 
     @property
-    def none_format(self):
+    def none_format(self) -> dict[str, str | None]:
         return self._none_format
 
     @none_format.setter
-    def none_format(self, val):
+    def none_format(self, val: str | dict[str, str | None] | None):
         if not self._field_names:
             self._none_format = {}
         elif val is None or (isinstance(val, dict) and len(val) == 0):
@@ -783,11 +783,12 @@ class PrettyTable:
                 self._none_format[field] = None
         else:
             self._validate_none_format(val)
+            val = cast(str, val)
             for field in self._field_names:
                 self._none_format[field] = val
 
     @property
-    def field_names(self):
+    def field_names(self) -> list[str]:
         """List or tuple of field names
 
         When setting field_names, if there are already field names the new list
@@ -796,8 +797,8 @@ class PrettyTable:
         return self._field_names
 
     @field_names.setter
-    def field_names(self, val) -> None:
-        val = [str(x) for x in val]
+    def field_names(self, val: Sequence[Any]) -> None:
+        val = cast("list[str]", [str(x) for x in val])
         self._validate_option("field_names", val)
         old_names = None
         if self._field_names:
@@ -827,7 +828,7 @@ class PrettyTable:
             self.valign = "t"
 
     @property
-    def align(self):
+    def align(self) -> dict[str, AlignType]:
         """Controls alignment of fields
         Arguments:
 
@@ -835,7 +836,7 @@ class PrettyTable:
         return self._align
 
     @align.setter
-    def align(self, val) -> None:
+    def align(self, val: AlignType | dict[str, AlignType] | None) -> None:
         if val is None or (isinstance(val, dict) and len(val) == 0):
             if not self._field_names:
                 self._align = {BASE_ALIGN_VALUE: "c"}
@@ -844,6 +845,7 @@ class PrettyTable:
                     self._align[field] = "c"
         else:
             self._validate_align(val)
+            val = cast(AlignType, val)
             if not self._field_names:
                 self._align = {BASE_ALIGN_VALUE: val}
             else:
@@ -851,7 +853,7 @@ class PrettyTable:
                     self._align[field] = val
 
     @property
-    def valign(self):
+    def valign(self) -> dict[str, VAlignType]:
         """Controls vertical alignment of fields
         Arguments:
 
@@ -859,7 +861,7 @@ class PrettyTable:
         return self._valign
 
     @valign.setter
-    def valign(self, val) -> None:
+    def valign(self, val: VAlignType | dict[str, VAlignType] | None) -> None:
         if not self._field_names:
             self._valign = {}
         elif val is None or (isinstance(val, dict) and len(val) == 0):
@@ -867,11 +869,12 @@ class PrettyTable:
                 self._valign[field] = "t"
         else:
             self._validate_valign(val)
+            val = cast(VAlignType, val)
             for field in self._field_names:
                 self._valign[field] = val
 
     @property
-    def max_width(self):
+    def max_width(self) -> dict[str, int]:
         """Controls maximum width of fields
         Arguments:
 
@@ -879,16 +882,17 @@ class PrettyTable:
         return self._max_width
 
     @max_width.setter
-    def max_width(self, val) -> None:
+    def max_width(self, val: int | dict[str, int] | None) -> None:
         if val is None or (isinstance(val, dict) and len(val) == 0):
             self._max_width = {}
         else:
             self._validate_option("max_width", val)
+            val = cast(int, val)
             for field in self._field_names:
                 self._max_width[field] = val
 
     @property
-    def min_width(self):
+    def min_width(self) -> dict[str, int]:
         """Controls minimum width of fields
         Arguments:
 
@@ -896,11 +900,12 @@ class PrettyTable:
         return self._min_width
 
     @min_width.setter
-    def min_width(self, val) -> None:
+    def min_width(self, val: int | dict[str, int] | None) -> None:
         if val is None or (isinstance(val, dict) and len(val) == 0):
             self._min_width = {}
         else:
             self._validate_option("min_width", val)
+            val = cast(int, val)
             for field in self._field_names:
                 self._min_width[field] = val
 
@@ -1134,7 +1139,7 @@ class PrettyTable:
         self._vrules = val
 
     @property
-    def int_format(self):
+    def int_format(self) -> dict[str, str]:
         """Controls formatting of integer data
         Arguments:
 
@@ -1142,16 +1147,17 @@ class PrettyTable:
         return self._int_format
 
     @int_format.setter
-    def int_format(self, val) -> None:
+    def int_format(self, val: str | dict[str, str] | None) -> None:
         if val is None or (isinstance(val, dict) and len(val) == 0):
             self._int_format = {}
         else:
             self._validate_option("int_format", val)
+            val = cast(str, val)
             for field in self._field_names:
                 self._int_format[field] = val
 
     @property
-    def float_format(self):
+    def float_format(self) -> dict[str, str]:
         """Controls formatting of floating point data
         Arguments:
 
@@ -1159,16 +1165,17 @@ class PrettyTable:
         return self._float_format
 
     @float_format.setter
-    def float_format(self, val) -> None:
+    def float_format(self, val: str | dict[str, str] | None) -> None:
         if val is None or (isinstance(val, dict) and len(val) == 0):
             self._float_format = {}
         else:
             self._validate_option("float_format", val)
+            val = cast(str, val)
             for field in self._field_names:
                 self._float_format[field] = val
 
     @property
-    def custom_format(self):
+    def custom_format(self) -> dict[str, Callable[[str, Any], str]]:
         """Controls formatting of any column using callable
         Arguments:
 
@@ -1176,7 +1183,10 @@ class PrettyTable:
         return self._custom_format
 
     @custom_format.setter
-    def custom_format(self, val):
+    def custom_format(
+        self,
+        val: Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]] | None,
+    ):
         if val is None:
             self._custom_format = {}
         elif isinstance(val, dict):

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -440,7 +440,7 @@ class PrettyTable:
         else:
             self._break_on_hyphens = True
 
-    def _column_specific_args(self):
+    def _column_specific_args(self) -> None:
         # Column specific arguments, use property.setters
         for attr in (
             "align",

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -973,7 +973,7 @@ class TestCustomFormatter:
     def test_set_custom_format_invalid_type_throw_error(self) -> None:
         table = PrettyTable()
         with pytest.raises(TypeError) as e:
-            table.custom_format = "Some String"
+            table.custom_format = "Some String"  # type: ignore[assignment]
         assert "The custom_format property need to be a dictionary or callable" in str(
             e.value
         )


### PR DESCRIPTION
This one would have been my last typing PR. Unfortunately though, it requires support for different property `getter` and `setter` types, which mypy doesn't have (yet). If those attributes were only used internally, it wouldn't be a big deal to add a few type ignores. However as these are also accessed and set from outside, it's probably not helpful to add them at this time. If the mypy issue ever get's resolved, the PR could be resurrected. Until then, I'll probably close this PR in a few days.

- https://github.com/python/mypy/issues/3004