### PR TITLE
Use Codecov with a token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -34,10 +36,11 @@ jobs:
           uvx --with tox-uv tox -e py
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3.1.5
+        uses: codecov/codecov-action@v4
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   success:
     needs: test


### PR DESCRIPTION
Token from https://app.codecov.io/gh/prettytable/prettytable/config/general

Added to https://github.com/prettytable/prettytable/settings/secrets/actions as `CODECOV_TOKEN`

---

Also fix:

```console
❯ zizmor .github/workflows/test.yml
🌈 completed test.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/test.yml:21:9
   |
21 |       - uses: actions/checkout@v4
   |         ------------------------- does not set persist-credentials: false
   |

1 findings (0 unknown, 0 informational, 0 low, 1 medium, 0 high)
```
