### PR TITLE
PEP 703 attestations are now the default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Publish to PyPI on GitHub Releases.
@@ -75,5 +74,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true


### PR DESCRIPTION
Follow on from https://github.com/prettytable/prettytable/pull/336.

Since https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0 it's the default when using Trusted Publishing:

> Two months ago, in [v1.10.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.10.0), @woodruffw[💰](https://github.com/sponsors/woodruffw) integrated support for generating and uploading [PEP 740](https://peps.python.org/pep-0740/) digital attestations that can be used as provenance objects when analyzing dependency chains for the integrity.
> 
> To make sure it works well, it was implemented as an opt-in, so a relatively small subset of projects was able to try it out, and a few issues have been determined and fixed during this time.
> 
> That changes today! This version changes the feature toggle to [“on by default”](https://github.com/marketplace/actions/pypi-publish#generating-and-uploading-attestations). This means that from now on, every project making use of Trusted Publishing will start producing and publishing digital attestations without having to do any modifications to how they use this action.
> 
> @woodruffw[💰](https://github.com/sponsors/woodruffw) flipped the respective toggle in https://github.com/pypa/gh-action-pypi-publish/pull/277 with the possibility to opt-out.