### PR TITLE
Consider column args when columns are set after initialization (#272)

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -847,7 +847,6 @@ class PrettyTable:
 
     @max_width.setter
     def max_width(self, val) -> None:
-        print("max_width setter")
         if val is None or (isinstance(val, dict) and len(val) == 0):
             self._max_width = {}
         else:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2354,6 +2354,69 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
+    def test_table_width_ctor1(self) -> None:
+        table = PrettyTable(max_width=10)
+        table.add_row(
+            [
+                "Lorem",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "ipsum",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "dolor",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+            ]
+        )
+
+        assert (
+            table.get_string().strip()
+            == """
++---------+------------+---------+------------+---------+------------+
+| Field 1 |  Field 2   | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+------------+---------+------------+---------+------------+
+|  Lorem  |   Lorem    |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         |   ipsum    |         |   ipsum    |         |   ipsum    |
+|         | dolor sit  |         | dolor sit  |         | dolor sit  |
+|         |   amet,    |         |   amet,    |         |   amet,    |
+|         | consetetur |         | consetetur |         | consetetur |
+|         | sadipscing |         | sadipscing |         | sadipscing |
+|         | elitr, sed |         | elitr, sed |         | elitr, sed |
+|         |    diam    |         |    diam    |         |    diam    |
++---------+------------+---------+------------+---------+------------+""".strip()
+        )
+
+    def test_table_width_ctor2(self) -> None:
+        table = PrettyTable(
+            ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
+            max_width=10,
+        )
+        table.add_row(
+            [
+                "Lorem",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "ipsum",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "dolor",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+            ]
+        )
+
+        assert (
+            table.get_string().strip()
+            == """
++---------+------------+---------+------------+---------+------------+
+| Field 1 |  Field 2   | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+------------+---------+------------+---------+------------+
+|  Lorem  |   Lorem    |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         |   ipsum    |         |   ipsum    |         |   ipsum    |
+|         | dolor sit  |         | dolor sit  |         | dolor sit  |
+|         |   amet,    |         |   amet,    |         |   amet,    |
+|         | consetetur |         | consetetur |         | consetetur |
+|         | sadipscing |         | sadipscing |         | sadipscing |
+|         | elitr, sed |         | elitr, sed |         | elitr, sed |
+|         |    diam    |         |    diam    |         |    diam    |
++---------+------------+---------+------------+---------+------------+""".strip()
+        )
+
     def test_max_table_width_wide_vrules_frame(self) -> None:
         table = PrettyTable()
         table.max_table_width = 52

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2354,7 +2354,7 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
-    def test_table_width_ctor1(self) -> None:
+    def test_table_width_on_init_wo_columns(self) -> None:
         table = PrettyTable(max_width=10)
         table.add_row(
             [
@@ -2384,7 +2384,7 @@ class TestMaxTableWidth:
 +---------+------------+---------+------------+---------+------------+""".strip()
         )
 
-    def test_table_width_ctor2(self) -> None:
+    def test_table_width_on_init_with_columns(self) -> None:
         table = PrettyTable(
             ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
             max_width=10,

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2355,6 +2355,7 @@ class TestMaxTableWidth:
         )
 
     def test_table_width_on_init_wo_columns(self) -> None:
+        """See also #272"""
         table = PrettyTable(max_width=10)
         table.add_row(
             [
@@ -2385,6 +2386,7 @@ class TestMaxTableWidth:
         )
 
     def test_table_width_on_init_with_columns(self) -> None:
+        """See also #272"""
         table = PrettyTable(
             ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
             max_width=10,
@@ -2415,6 +2417,22 @@ class TestMaxTableWidth:
 |         | elitr, sed |         | elitr, sed |         | elitr, sed |
 |         |    diam    |         |    diam    |         |    diam    |
 +---------+------------+---------+------------+---------+------------+""".strip()
+        )
+
+    def test_table_float_formatting_on_init_wo_columns(self) -> None:
+        """See also #243"""
+        table = prettytable.PrettyTable(float_format="10.2")
+        table.field_names = ["Metric", "Initial sol.", "Best sol."]
+        table.add_rows([["foo", 1.0 / 3.0, 1.0 / 3.0]])
+
+        assert (
+            table.get_string().strip()
+            == """
++--------+--------------+------------+
+| Metric | Initial sol. | Best sol.  |
++--------+--------------+------------+
+|  foo   |        0.33  |       0.33 |
++--------+--------------+------------+""".strip()
         )
 
     def test_max_table_width_wide_vrules_frame(self) -> None:


### PR DESCRIPTION
fixes #272

If columns are not defined during initialization, but params like max_width are set, they are not evaluated.
Now column specific args are evaluated again after setting columns.

Added a test case for this scenario