### PR TITLE
Fix default styles not being reset between `set_style()` calls

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1454,6 +1454,7 @@ class PrettyTable:
 
     def set_style(self, style: TableStyle) -> None:
         self._style = style
+        self._set_default_style()
         if style == TableStyle.DEFAULT:
             self._set_default_style()
         elif style == TableStyle.MSWORD_FRIENDLY:
@@ -1475,7 +1476,6 @@ class PrettyTable:
             raise ValueError(msg)
 
     def _set_orgmode_style(self) -> None:
-        self._set_default_style()
         self.orgmode = True
 
     def _set_markdown_style(self) -> None:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1453,11 +1453,9 @@ class PrettyTable:
     ##############################
 
     def set_style(self, style: TableStyle) -> None:
-        self._style = style
         self._set_default_style()
-        if style == TableStyle.DEFAULT:
-            self._set_default_style()
-        elif style == TableStyle.MSWORD_FRIENDLY:
+        self._style = style
+        if style == TableStyle.MSWORD_FRIENDLY:
             self._set_msword_style()
         elif style == TableStyle.PLAIN_COLUMNS:
             self._set_columns_style()

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1469,7 +1469,7 @@ class PrettyTable:
             self._set_single_border_style()
         elif style == TableStyle.RANDOM:
             self._set_random_style()
-        else:
+        elif style != TableStyle.DEFAULT:
             msg = "Invalid pre-set style"
             raise ValueError(msg)
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1713,6 +1713,135 @@ class TestStyle:
             t.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
+        "original_style,style, expected",
+        [
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.DEFAULT,
+                """
++---+---------+---------+---------+
+|   | Field 1 | Field 2 | Field 3 |
++---+---------+---------+---------+
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
++---+---------+---------+---------+
+""",
+                id="DEFAULT",
+            ),
+            pytest.param(
+                TableStyle.MSWORD_FRIENDLY,
+                TableStyle.MARKDOWN,
+                """
+|     | Field 1 | Field 2 | Field 3 |
+| :-: | :-----: | :-----: | :-----: |
+|  1  | value 1 |  value2 |  value3 |
+|  4  | value 4 |  value5 |  value6 |
+|  7  | value 7 |  value8 |  value9 |
+""",
+                id="MARKDOWN",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.MSWORD_FRIENDLY,
+                """
+|   | Field 1 | Field 2 | Field 3 |
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+""",
+                id="MSWORD_FRIENDLY",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.ORGMODE,
+                """
+|---+---------+---------+---------|
+|   | Field 1 | Field 2 | Field 3 |
+|---+---------+---------+---------|
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+|---+---------+---------+---------|
+""",
+                id="ORGMODE",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.PLAIN_COLUMNS,
+                """
+         Field 1        Field 2        Field 3        
+1        value 1         value2         value3        
+4        value 4         value5         value6        
+7        value 7         value8         value9
+""",  # noqa: W291
+                id="PLAIN_COLUMNS",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.RANDOM,
+                """
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+%    1     value 1     value2     value3%
+%    4     value 4     value5     value6%
+%    7     value 7     value8     value9%
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+""",
+                id="RANDOM",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.DOUBLE_BORDER,
+                """
+╔═══╦═════════╦═════════╦═════════╗
+║   ║ Field 1 ║ Field 2 ║ Field 3 ║
+╠═══╬═════════╬═════════╬═════════╣
+║ 1 ║ value 1 ║  value2 ║  value3 ║
+║ 4 ║ value 4 ║  value5 ║  value6 ║
+║ 7 ║ value 7 ║  value8 ║  value9 ║
+╚═══╩═════════╩═════════╩═════════╝
+""",
+                id="DOUBLE_BORDER"
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.SINGLE_BORDER,
+                """
+┌───┬─────────┬─────────┬─────────┐
+│   │ Field 1 │ Field 2 │ Field 3 │
+├───┼─────────┼─────────┼─────────┤
+│ 1 │ value 1 │  value2 │  value3 │
+│ 4 │ value 4 │  value5 │  value6 │
+│ 7 │ value 7 │  value8 │  value9 │
+└───┴─────────┴─────────┴─────────┘
+""",
+                id="SINGLE_BORDER"
+            ),
+        ],
+    )
+
+    def test_style_reset(self,original_style,style,expected) -> None:
+        """
+            Testing to ensure that default styling is reset between changes
+            of styles on a PrettyTable
+
+        Args:
+            style (str): Style to be used (Default, markdown, etc)
+            expected (str): The expected format of style as a string representation
+        """
+        # Arrange
+        t = helper_table()
+        random.seed(1234)
+
+        # Act
+        t.set_style(original_style)
+        t.set_style(style)
+
+        # Assert
+        result = t.get_string()
+        assert result.strip() == expected.strip()
+
+    @pytest.mark.parametrize(
         "style, expected",
         [
             pytest.param(

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1801,7 +1801,7 @@ class TestStyle:
 ║ 7 ║ value 7 ║  value8 ║  value9 ║
 ╚═══╩═════════╩═════════╩═════════╝
 """,
-                id="DOUBLE_BORDER"
+                id="DOUBLE_BORDER",
             ),
             pytest.param(
                 TableStyle.MARKDOWN,
@@ -1815,12 +1815,11 @@ class TestStyle:
 │ 7 │ value 7 │  value8 │  value9 │
 └───┴─────────┴─────────┴─────────┘
 """,
-                id="SINGLE_BORDER"
+                id="SINGLE_BORDER",
             ),
         ],
     )
-
-    def test_style_reset(self,original_style,style,expected) -> None:
+    def test_style_reset(self, original_style, style, expected) -> None:
         """
             Testing to ensure that default styling is reset between changes
             of styles on a PrettyTable


### PR DESCRIPTION
Looks to fix issue as outlined in [Issue 341](https://github.com/prettytable/prettytable/issues/341)

Addition of pytest tests for testing if default has been reset after initially having another style. The case of random is tested, but frankly a redundant test as other cases cover every scenario of a reset.

Added resetting of styles in the set_style method along with removal of the default_reset in the orgmode setter.