### PR TITLE
Use PEP 639 licence expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs",
-  "hatchling",
+  "hatchling>=1.27",
 ]
 
 [project]
@@ -10,11 +10,11 @@ name = "prettytable"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 readme = "README.md"
 license = "BSD-3-Clause"
+license-files = [ "LICENSE" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Luke Maurits", email = "luke@maurits.id.au" } ]
 requires-python = ">=3.9"
 classifiers = [
-  "License :: OSI Approved :: BSD License",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
* https://peps.python.org/pep-0639/
* https://packaging.python.org/en/latest/specifications/core-metadata/
* https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/170

This depends on (at least) all these, thanks to everyone for making it happen:

* packaging 24.2 https://packaging.pypa.io/en/stable/changelog.html
* Hatchling 1.27 https://hatch.pypa.io/dev/history/hatchling/
* Twine 6.1.0 https://twine.readthedocs.io/en/stable/changelog.html
* PyPI publish GitHub Action v1.12.4 https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4
* build-and-inspect-python-package v2.12.0 https://github.com/hynek/build-and-inspect-python-package/releases/tag/v2.12.0