### PR TITLE
Add `add_divider()` method to create sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,14 +391,15 @@ instance of the data in the `sort_by` column.
 
 #### Adding sections to a table
 
-You can divide your table into different sections using the `divider` argument. This
-will add a dividing line into the table under the row who has this field set. So we can
-set up a table like this:
+You can divide your table into different sections using the `add_divider` method or
+`divider` argument . This will add a dividing line into the table under the row who has
+this field set. So we can set up a table like this:
 
 ```python
 table = PrettyTable()
 table.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
 table.add_row(["Adelaide", 1295, 1158259, 600.5])
+table.add_divider()
 table.add_row(["Brisbane", 5905, 1857594, 1146.4])
 table.add_row(["Darwin", 112, 120900, 1714.7])
 table.add_row(["Hobart", 1357, 205556, 619.5], divider=True)
@@ -414,6 +415,7 @@ to get a table like this:
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
 |  Adelaide | 1295 |  1158259   |      600.5      |
++-----------+------+------------+-----------------+
 |  Brisbane | 5905 |  1857594   |      1146.4     |
 |   Darwin  | 112  |   120900   |      1714.7     |
 |   Hobart  | 1357 |   205556   |      619.5      |

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1618,6 +1618,11 @@ class PrettyTable:
         del self._rows[row_index]
         del self._dividers[row_index]
 
+    def add_divider(self) -> None:
+        """Add a divider to the table"""
+        if len(self._dividers) >= 1:
+            self._dividers[-1] = True
+
     def add_column(
         self,
         fieldname: str,

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2830,56 +2830,6 @@ class TestFields:
         )
 
 
-class TestRowEndSection:
-    def test_row_end_section(self) -> None:
-        table = PrettyTable()
-        table.set_style(TableStyle.SINGLE_BORDER)
-        v = 1
-        for row in range(4):
-            if row % 2 == 0:
-                table.add_row(
-                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=True
-                )
-            else:
-                table.add_row(
-                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=False
-                )
-            v += 3
-        table.del_row(0)
-        print(table)
-        assert (
-            table.get_string().strip()
-            == """
-┌──────────┬─────────┬─────────┐
-│ Field 1  │ Field 2 │ Field 3 │
-├──────────┼─────────┼─────────┤
-│ value 4  │  value5 │  value6 │
-│ value 7  │  value8 │  value9 │
-├──────────┼─────────┼─────────┤
-│ value 10 │ value11 │ value12 │
-└──────────┴─────────┴─────────┘
-""".strip()
-        )
-
-
-class TestClearing:
-    def test_clear_rows(self, row_prettytable: PrettyTable) -> None:
-        t = helper_table()
-        t.add_row([0, "a", "b", "c"], divider=True)
-        t.clear_rows()
-        assert t.rows == []
-        assert t.dividers == []
-        assert t.field_names == ["", "Field 1", "Field 2", "Field 3"]
-
-    def test_clear(self, row_prettytable: PrettyTable) -> None:
-        t = helper_table()
-        t.add_row([0, "a", "b", "c"], divider=True)
-        t.clear()
-        assert t.rows == []
-        assert t.dividers == []
-        assert t.field_names == []
-
-
 class TestPreservingInternalBorders:
     def test_internal_border_preserved(self) -> None:
         pt = helper_table()

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -9,30 +9,21 @@ class TestRowEndSection:
     def test_row_end_section(self) -> None:
         table = PrettyTable()
         table.set_style(TableStyle.SINGLE_BORDER)
-        v = 1
-        for row in range(4):
-            if row % 2 == 0:
-                table.add_row(
-                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=True
-                )
-            else:
-                table.add_row(
-                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=False
-                )
-            v += 3
-        table.del_row(0)
-        print(table)
+        table.add_row(["value 4", "value 5", "value 6"])
+        table.add_row(["value 7", "value 8", "value 9"], divider=True)
+        table.add_row(["value 10", "value 11", "value 12"])
+
         assert (
             table.get_string().strip()
             == """
-┌──────────┬─────────┬─────────┐
-│ Field 1  │ Field 2 │ Field 3 │
-├──────────┼─────────┼─────────┤
-│ value 4  │  value5 │  value6 │
-│ value 7  │  value8 │  value9 │
-├──────────┼─────────┼─────────┤
-│ value 10 │ value11 │ value12 │
-└──────────┴─────────┴─────────┘
+┌──────────┬──────────┬──────────┐
+│ Field 1  │ Field 2  │ Field 3  │
+├──────────┼──────────┼──────────┤
+│ value 4  │ value 5  │ value 6  │
+│ value 7  │ value 8  │ value 9  │
+├──────────┼──────────┼──────────┤
+│ value 10 │ value 11 │ value 12 │
+└──────────┴──────────┴──────────┘
 """.strip()
         )
 

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from test_prettytable import helper_table
+
+from prettytable import PrettyTable, TableStyle
+
+
+class TestRowEndSection:
+    def test_row_end_section(self) -> None:
+        table = PrettyTable()
+        table.set_style(TableStyle.SINGLE_BORDER)
+        v = 1
+        for row in range(4):
+            if row % 2 == 0:
+                table.add_row(
+                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=True
+                )
+            else:
+                table.add_row(
+                    [f"value {v}", f"value{v+1}", f"value{v+2}"], divider=False
+                )
+            v += 3
+        table.del_row(0)
+        print(table)
+        assert (
+            table.get_string().strip()
+            == """
+┌──────────┬─────────┬─────────┐
+│ Field 1  │ Field 2 │ Field 3 │
+├──────────┼─────────┼─────────┤
+│ value 4  │  value5 │  value6 │
+│ value 7  │  value8 │  value9 │
+├──────────┼─────────┼─────────┤
+│ value 10 │ value11 │ value12 │
+└──────────┴─────────┴─────────┘
+""".strip()
+        )
+
+
+class TestClearing:
+    def test_clear_rows(self) -> None:
+        t = helper_table()
+        t.add_row([0, "a", "b", "c"], divider=True)
+        t.clear_rows()
+        assert t.rows == []
+        assert t.dividers == []
+        assert t.field_names == ["", "Field 1", "Field 2", "Field 3"]
+
+    def test_clear(self) -> None:
+        t = helper_table()
+        t.add_row([0, "a", "b", "c"], divider=True)
+        t.clear()
+        assert t.rows == []
+        assert t.dividers == []
+        assert t.field_names == []

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -6,16 +6,7 @@ from prettytable import PrettyTable, TableStyle
 
 
 class TestRowEndSection:
-    def test_row_end_section(self) -> None:
-        table = PrettyTable()
-        table.set_style(TableStyle.SINGLE_BORDER)
-        table.add_row(["value 4", "value 5", "value 6"])
-        table.add_row(["value 7", "value 8", "value 9"], divider=True)
-        table.add_row(["value 10", "value 11", "value 12"])
-
-        assert (
-            table.get_string().strip()
-            == """
+    EXPECTED_RESULT = """
 ┌──────────┬──────────┬──────────┐
 │ Field 1  │ Field 2  │ Field 3  │
 ├──────────┼──────────┼──────────┤
@@ -25,7 +16,25 @@ class TestRowEndSection:
 │ value 10 │ value 11 │ value 12 │
 └──────────┴──────────┴──────────┘
 """.strip()
-        )
+
+    def test_row_end_section_via_argument(self) -> None:
+        table = PrettyTable()
+        table.set_style(TableStyle.SINGLE_BORDER)
+        table.add_row(["value 4", "value 5", "value 6"])
+        table.add_row(["value 7", "value 8", "value 9"], divider=True)
+        table.add_row(["value 10", "value 11", "value 12"])
+
+        assert table.get_string().strip() == self.EXPECTED_RESULT
+
+    def test_row_end_section_via_method(self) -> None:
+        table = PrettyTable()
+        table.set_style(TableStyle.SINGLE_BORDER)
+        table.add_row(["value 4", "value 5", "value 6"])
+        table.add_row(["value 7", "value 8", "value 9"])
+        table.add_divider()
+        table.add_row(["value 10", "value 11", "value 12"])
+
+        assert table.get_string().strip() == self.EXPECTED_RESULT
 
 
 class TestClearing:


### PR DESCRIPTION
Fixes https://github.com/prettytable/prettytable/issues/242.

If you're adding rows in a loop, and want a divider after this, perhaps to show a total row, it's a bit of a pain to have to calculate which is the last loop row.

This PR adds an `add_divider()` method, so you can explicitly call it in between `add_row()` calls.

For example, these are equivalent:

```python
from prettytable import PrettyTable, TableStyle

table = PrettyTable()
table.set_style(TableStyle.SINGLE_BORDER)
table.add_divider()
table.add_row([11, 12, 13, 14])
table.add_row([21, 22, 23, 24])
t.add_row([31, 32, 33, 34], divider=True)
table.add_row([41, 42, 43, 44])
print(table)
```
```python
from prettytable import PrettyTable, TableStyle

table = PrettyTable()
table.set_style(TableStyle.SINGLE_BORDER)
table.add_divider()
table.add_row([11, 12, 13, 14])
table.add_row([21, 22, 23, 24])
table.add_row([31, 22, 23, 24])
table.add_divider()
table.add_row([41, 42, 43, 44])
print(table)
```
And both produce:
```
┌─────────┬─────────┬─────────┬─────────┐
│ Field 1 │ Field 2 │ Field 3 │ Field 4 │
├─────────┼─────────┼─────────┼─────────┤
│    11   │    12   │    13   │    14   │
│    21   │    22   │    23   │    24   │
│    31   │    22   │    23   │    24   │
├─────────┼─────────┼─────────┼─────────┤
│    41   │    42   │    43   │    44   │
└─────────┴─────────┴─────────┴─────────┘
```

As part of this, refactor the divider tests into their own file, because `tests/test_prettytable.py` is over 3,000 lines long!

Also unroll the loop in the test, to make it easier to understand what the test does at a glance, and easier to compare with the new test added for `add_divider()`.