### PR TITLE
Add option to truncate column headers to column width

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,11 @@ The options are:
 | `top_left_junction_char`     | Single character string used to draw top-left line junctions. Default: `junction_char`.                                                                                                          |
 | `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                                                                      |
 | `bottom_left_junction_char`  | Single character string used to draw bottom-left line junctions. Default: `junction_char`.                                                                                                       |
+| `min_table_width`            | Number of characters used for the minimum total table width                                                                                                                                      |
+| `max_table_width`            | Number of characters used for the maximum total table width                                                                                                                                      |
+| `max_width`                  | Number of characters used for maximum width of a column                                                                                                                                          |
+| `min_width`                  | Number of characters used for minimum width of a column                                                                                                                                          |
+| `use_header_width`           | A Boolean option (must be `True` or `False`). Controls whether the width of the header is used for compuzting column width. Default `True`                                                       |
 
 You can set the style options to your own settings in two ways:
 

--- a/README.md
+++ b/README.md
@@ -502,11 +502,11 @@ The options are:
 | `top_left_junction_char`     | Single character string used to draw top-left line junctions. Default: `junction_char`.                                                                                                          |
 | `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                                                                      |
 | `bottom_left_junction_char`  | Single character string used to draw bottom-left line junctions. Default: `junction_char`.                                                                                                       |
-| `min_table_width`            | Number of characters used for the minimum total table width                                                                                                                                      |
-| `max_table_width`            | Number of characters used for the maximum total table width                                                                                                                                      |
-| `max_width`                  | Number of characters used for maximum width of a column                                                                                                                                          |
-| `min_width`                  | Number of characters used for minimum width of a column                                                                                                                                          |
-| `use_header_width`           | A Boolean option (must be `True` or `False`). Controls whether the width of the header is used for compuzting column width. Default `True`                                                       |
+| `min_table_width`            | Number of characters used for the minimum total table width.                                                                                                                                     |
+| `max_table_width`            | Number of characters used for the maximum total table width.                                                                                                                                     |
+| `max_width`                  | Number of characters used for maximum width of a column.                                                                                                                                         |
+| `min_width`                  | Number of characters used for minimum width of a column.                                                                                                                                         |
+| `use_header_width`           | A Boolean option (must be `True` or `False`). Controls whether the width of the header is used for computing column width. Default: `True`.                                                      |
 
 You can set the style options to your own settings in two ways:
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -101,6 +101,7 @@ class OptionsType(TypedDict):
     end: int | None
     fields: Sequence[str | None] | None
     header: bool
+    use_header_width: bool
     border: bool
     preserve_internal_border: bool
     sortby: str | None
@@ -171,6 +172,7 @@ class PrettyTable:
     _reversesort: bool
     _sort_key: Callable[[RowType], SupportsRichComparison]
     _header: bool
+    _use_header_width: bool
     _header_style: HeaderStyleType
     _border: bool
     _preserve_internal_border: bool
@@ -217,6 +219,7 @@ class PrettyTable:
         start - index of first data row to include in output
         end - index of last data row to include in output PLUS ONE (list slice style)
         header - print a header showing field names (True or False)
+        use_header_width - reflect width of header
         header_style - stylisation to apply to field names in header
             ("cap", "title", "upper", "lower" or None)
         border - print a border around the table (True or False)
@@ -283,6 +286,7 @@ class PrettyTable:
             "end",
             "fields",
             "header",
+            "use_header_width",
             "border",
             "preserve_internal_border",
             "sortby",
@@ -349,6 +353,10 @@ class PrettyTable:
             self._header = kwargs["header"]
         else:
             self._header = True
+        if kwargs["use_header_width"] in (True, False):
+            self._use_header_width = kwargs["use_header_width"]
+        else:
+            self._use_header_width = True
         self._header_style = kwargs["header_style"] or None
         if kwargs["border"] in (True, False):
             self._border = kwargs["border"]
@@ -534,6 +542,7 @@ class PrettyTable:
             self._validate_all_field_names(option, val)
         elif option in (
             "header",
+            "use_header_width",
             "border",
             "preserve_internal_border",
             "reversesort",
@@ -1001,6 +1010,22 @@ class PrettyTable:
     def header(self, val: bool) -> None:
         self._validate_option("header", val)
         self._header = val
+
+    @property
+    def use_header_width(self) -> bool:
+        """Controls whether header is icluded in computing width computation
+
+        Arguments:
+
+        use_header_width - respect width of fieldname in header to calculate column
+            width (True or False)
+        """
+        return self._use_header_width
+
+    @use_header_width.setter
+    def use_header_width(self, val: bool) -> None:
+        self._validate_option("use_header_width", val)
+        self._use_header_width = val
 
     @property
     def header_style(self) -> HeaderStyleType:
@@ -1768,7 +1793,7 @@ class PrettyTable:
         return table_width
 
     def _compute_widths(self, rows: list[list[str]], options: OptionsType) -> None:
-        if options["header"]:
+        if options["header"] and options["use_header_width"]:
             widths = [_get_size(field)[0] for field in self._field_names]
         else:
             widths = len(self.field_names) * [0]
@@ -1925,6 +1950,7 @@ class PrettyTable:
         end - index of last data row to include in output PLUS ONE (list slice style)
         fields - names of fields (columns) to include
         header - print a header showing field names (True or False)
+        use_header_width - reflect width of header
         border - print a border around the table (True or False)
         preserve_internal_border - print a border inside the table even if
             border is disabled (True or False)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1950,7 +1950,7 @@ class PrettyTable:
         end - index of last data row to include in output PLUS ONE (list slice style)
         fields - names of fields (columns) to include
         header - print a header showing field names (True or False)
-        use_header_width - reflect width of header
+        use_header_width - reflect width of header (True or False)
         border - print a border around the table (True or False)
         preserve_internal_border - print a border inside the table even if
             border is disabled (True or False)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -219,7 +219,7 @@ class PrettyTable:
         start - index of first data row to include in output
         end - index of last data row to include in output PLUS ONE (list slice style)
         header - print a header showing field names (True or False)
-        use_header_width - reflect width of header
+        use_header_width - reflect width of header (True or False)
         header_style - stylisation to apply to field names in header
             ("cap", "title", "upper", "lower" or None)
         border - print a border around the table (True or False)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1013,7 +1013,7 @@ class PrettyTable:
 
     @property
     def use_header_width(self) -> bool:
-        """Controls whether header is icluded in computing width computation
+        """Controls whether header is included in computing width
 
         Arguments:
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2547,65 +2547,40 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
-    def test_table_maxwidth_wo_headerwidth(self) -> None:
-        """See also #165"""
-        table = PrettyTable(
-            [
-                "A Field Name",
-                "B Field Name",
-                "D Field Name",
-                "E Field Name",
-                "F Field Name",
-                "G Field Name",
-                "H Field Name",
-                "I Field Name",
-                "J Field Name",
-                "K Field Name",
-                "L Field Name",
-                "M Field Name",
-            ],
-            use_header_width=False,
-        )
-        table.add_row([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
-
-        assert (
-            table.get_string()
-            == """+---+---+---+---+---+---+---+---+---+---+----+----+
+    @pytest.mark.parametrize("set_with_parameter", [True, False])
+    def test_table_max_width_wo_header_width(self, set_with_parameter) -> None:
+        # Arrange
+        headers = [
+            "A Field Name",
+            "B Field Name",
+            "D Field Name",
+            "E Field Name",
+            "F Field Name",
+            "G Field Name",
+            "H Field Name",
+            "I Field Name",
+            "J Field Name",
+            "K Field Name",
+            "L Field Name",
+            "M Field Name",
+        ]
+        row = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        expected = """+---+---+---+---+---+---+---+---+---+---+----+----+
 | A | B | D | E | F | G | H | I | J | K | L  | M  |
 +---+---+---+---+---+---+---+---+---+---+----+----+
 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
 +---+---+---+---+---+---+---+---+---+---+----+----+"""
-        )
 
-    def test_table_maxwidth_wo_headerwidth_setter(self) -> None:
-        """See also #165"""
-        table = PrettyTable(
-            [
-                "A Field Name",
-                "B Field Name",
-                "D Field Name",
-                "E Field Name",
-                "F Field Name",
-                "G Field Name",
-                "H Field Name",
-                "I Field Name",
-                "J Field Name",
-                "K Field Name",
-                "L Field Name",
-                "M Field Name",
-            ]
-        )
-        table.use_header_width = False
-        table.add_row([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+        # Act
+        if set_with_parameter:
+            table = PrettyTable(headers, use_header_width=False)
+        else:
+            table = PrettyTable(headers)
+            table.use_header_width = False
+        table.add_row(row)
 
-        assert (
-            table.get_string()
-            == """+---+---+---+---+---+---+---+---+---+---+----+----+
-| A | B | D | E | F | G | H | I | J | K | L  | M  |
-+---+---+---+---+---+---+---+---+---+---+----+----+
-| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
-+---+---+---+---+---+---+---+---+---+---+----+----+"""
-        )
+        # Assert
+        assert table.get_string() == expected
 
     def test_table_width_on_init_wo_columns(self) -> None:
         """See also #272"""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2547,6 +2547,36 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
+    def test_table_maxwidth_wo_headers(self) -> None:
+        """See also #165"""
+        table = PrettyTable(
+            [
+                "A Field Name",
+                "B Field Name",
+                "D Field Name",
+                "E Field Name",
+                "F Field Name",
+                "G Field Name",
+                "H Field Name",
+                "I Field Name",
+                "J Field Name",
+                "K Field Name",
+                "L Field Name",
+                "M Field Name",
+            ],
+            use_header_width=False,
+        )
+        table.add_row([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+
+        assert (
+            table.get_string()
+            == """+---+---+---+---+---+---+---+---+---+---+----+----+
+| A | B | D | E | F | G | H | I | J | K | L  | M  |
++---+---+---+---+---+---+---+---+---+---+----+----+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
++---+---+---+---+---+---+---+---+---+---+----+----+"""
+        )
+
     def test_table_width_on_init_wo_columns(self) -> None:
         """See also #272"""
         table = PrettyTable(max_width=10)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -2547,7 +2547,7 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
-    def test_table_maxwidth_wo_headers(self) -> None:
+    def test_table_maxwidth_wo_headerwidth(self) -> None:
         """See also #165"""
         table = PrettyTable(
             [
@@ -2566,6 +2566,36 @@ class TestMaxTableWidth:
             ],
             use_header_width=False,
         )
+        table.add_row([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+
+        assert (
+            table.get_string()
+            == """+---+---+---+---+---+---+---+---+---+---+----+----+
+| A | B | D | E | F | G | H | I | J | K | L  | M  |
++---+---+---+---+---+---+---+---+---+---+----+----+
+| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
++---+---+---+---+---+---+---+---+---+---+----+----+"""
+        )
+
+    def test_table_maxwidth_wo_headerwidth_setter(self) -> None:
+        """See also #165"""
+        table = PrettyTable(
+            [
+                "A Field Name",
+                "B Field Name",
+                "D Field Name",
+                "E Field Name",
+                "F Field Name",
+                "G Field Name",
+                "H Field Name",
+                "I Field Name",
+                "J Field Name",
+                "K Field Name",
+                "L Field Name",
+                "M Field Name",
+            ]
+        )
+        table.use_header_width = False
         table.add_row([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
 
         assert (


### PR DESCRIPTION
fixes #165 

introduced a new option `use_header_width`which is defaulted to `True`