### PR TITLE
Performance: remove unnecessary deepcopies and add some lru_caches

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -33,7 +33,7 @@
 
 from __future__ import annotations
 
-import functools
+from functools import lru_cache
 import io
 import re
 import warnings

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -38,6 +38,7 @@ import re
 import warnings
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import IntEnum
+from functools import lru_cache
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, cast
 
@@ -148,7 +149,7 @@ class OptionsType(TypedDict):
 _re = re.compile(r"\033\[[0-9;]*m|\033\(B")
 
 
-@functools.lru_cache
+@lru_cache
 def _get_size(text: str) -> tuple[int, int]:
     lines = text.split("\n")
     height = len(lines)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2705,7 +2705,7 @@ class PrettyTable:
 ##############################
 
 
-@functools.lru_cache
+@lru_cache
 def _str_block_width(val: str) -> int:
     import wcwidth  # type: ignore[import-untyped]
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -33,7 +33,6 @@
 
 from __future__ import annotations
 
-from functools import lru_cache
 import io
 import re
 import warnings

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -33,6 +33,7 @@
 
 from __future__ import annotations
 
+import functools
 import io
 import re
 import warnings
@@ -148,6 +149,7 @@ class OptionsType(TypedDict):
 _re = re.compile(r"\033\[[0-9;]*m|\033\(B")
 
 
+@functools.lru_cache
 def _get_size(text: str) -> tuple[int, int]:
     lines = text.split("\n")
     height = len(lines)
@@ -1861,12 +1863,11 @@ class PrettyTable:
         Arguments:
 
         options - dictionary of option settings."""
-        import copy
 
         if options["oldsortslice"]:
-            rows = copy.deepcopy(self._rows[options["start"] : options["end"]])
+            rows = self._rows[options["start"] : options["end"]]
         else:
-            rows = copy.deepcopy(self._rows)
+            rows = self._rows
 
         # Sort
         if options["sortby"]:
@@ -1890,12 +1891,10 @@ class PrettyTable:
         Arguments:
 
         options - dictionary of option settings."""
-        import copy
-
         if options["oldsortslice"]:
-            dividers = copy.deepcopy(self._dividers[options["start"] : options["end"]])
+            dividers = self._dividers[options["start"] : options["end"]]
         else:
-            dividers = copy.deepcopy(self._dividers)
+            dividers = self._dividers
 
         if options["sortby"]:
             dividers = [False for divider in dividers]
@@ -2707,6 +2706,7 @@ class PrettyTable:
 ##############################
 
 
+@functools.lru_cache
 def _str_block_width(val: str) -> int:
     import wcwidth  # type: ignore[import-untyped]
 


### PR DESCRIPTION
which led to some improvements in test performance

from
```
  lint: OK (2.01=setup[0.03]+cmd[1.98] seconds)
  mypy: OK (2.15=setup[2.02]+cmd[0.13] seconds)
  pypy3: SKIP (0.02 seconds)
  py314: SKIP (0.01 seconds)
  py313: OK (2.92=setup[1.78]+cmd[1.15] seconds)
  py312: OK (2.88=setup[1.70]+cmd[1.18] seconds)
  py311: SKIP (0.01 seconds)
  py310: SKIP (0.01 seconds)
  py39: OK (4.96=setup[3.70]+cmd[1.26] seconds)
  congratulations :) (15.02 seconds)
```
to:
```
  lint: OK (2.06=setup[0.02]+cmd[2.04] seconds)
  mypy: OK (2.16=setup[2.04]+cmd[0.11] seconds)
  pypy3: SKIP (0.01 seconds)
  py314: SKIP (0.01 seconds)
  py313: OK (2.91=setup[1.85]+cmd[1.07] seconds)
  py312: OK (2.78=setup[1.73]+cmd[1.05] seconds)
  py311: SKIP (0.01 seconds)
  py310: SKIP (0.01 seconds)
  py39: OK (4.74=setup[3.60]+cmd[1.14] seconds)
  congratulations :) (14.72 seconds)
```
which are around 7%

in an example with 25.000 rows:
```python
from prettytable import PrettyTable
import random

def add_rows(table):
    table.add_row(
        ["Adelaide", 1295, random.randint(0, 9999999), random.randint(0, 9999)]
    )
    table.add_row(
        ["Brisbane", 5905, random.randint(0, 9999999), random.randint(0, 9999)]
    )
    table.add_row(["Darwin", 112, random.randint(0, 9999999), random.randint(0, 9999)])
    table.add_row(["Hobart", 1357, random.randint(0, 9999999), random.randint(0, 9999)])
    table.add_row(["Sydney", 2058, random.randint(0, 9999999), random.randint(0, 9999)])
    table.add_row(
        ["Melbourne", 1566, random.randint(0, 9999999), random.randint(0, 9999)]
    )
    table.add_row(["Perth", 5386, random.randint(0, 9999999), random.randint(0, 9999)])

def create_table():
    table = PrettyTable(
        field_names=["City name", "Area", "Population", "Annual Rainfall"],
    )
    for i in range(5000):
        add_rows(table)
    return table

def get_table():
    t = create_table()
    return t

def main():
    t = get_table()
    s = t.get_string()

if __name__ == "__main__":
    main()

```

it improved on my machine from 1.12secs to 328msecs:

from
```
~/privat/repos/prettytable performance *1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 1.12 sec per loop
~/privat/repos/prettytable performance *1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 1.12 sec per loop
~/privat/repos/prettytable performance *1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 1.1 sec per loop
```
to
```
~/privat/repos/prettytable performance !1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 328 msec per loop
~/privat/repos/prettytable performance !1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 326 msec per loop
~/privat/repos/prettytable performance !1 ?2 ❯ venv/bin/python -m timeit "import test; test.main()"
1 loop, best of 5: 328 msec per loop
```

Those improvements are > 300%

I can't find any reason for deepcopies here. The results  of the internal `_get_rows()` function are not modified anywhere in the code. The `copy()` and the `PrettyTable()[start:end]`  functionality is not touched.

