### PR TITLE
Refactor tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: end-of-file-fixer
       - id: forbid-submodules
       - id: trailing-whitespace
-        exclude: .github/ISSUE_TEMPLATE/bug_report.md|tests/test_prettytable.py
+        exclude: .github/ISSUE_TEMPLATE/bug_report.md|tests/test_style.py|tests/test_prettytable.py
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.31.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,18 @@ def row_prettytable(field_name_less_table) -> PrettyTable:
     # Row by row...
     field_name_less_table.field_names = CITY_DATA_HEADER
     return field_name_less_table
+
+
+@pytest.fixture(scope="function")
+def empty_helper_table() -> PrettyTable:
+    return PrettyTable(["", "Field 1", "Field 2", "Field 3"])
+
+
+@pytest.fixture(scope="function")
+def helper_table(empty_helper_table: PrettyTable) -> PrettyTable:
+    v = 1
+    for row in range(3):
+        # Some have spaces, some not, to help test padding columns of different widths
+        empty_helper_table.add_row([v, f"value {v}", f"value{v+1}", f"value{v+2}"])
+        v += 3
+    return empty_helper_table

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import io
+
+import pytest
+from test_prettytable import CITY_DATA, CITY_DATA_HEADER
+
+from prettytable import PrettyTable, from_csv
+
+
+@pytest.fixture(scope="function")
+def col_prettytable() -> PrettyTable:
+    # Column by column...
+    table = PrettyTable()
+    for idx, colname in enumerate(CITY_DATA_HEADER):
+        table.add_column(colname, [row[idx] for row in CITY_DATA])
+    return table
+
+
+@pytest.fixture(scope="function")
+def city_data() -> PrettyTable:
+    """Just build the Australian capital city data example table."""
+    table = PrettyTable(CITY_DATA_HEADER)
+    for row in CITY_DATA:
+        table.add_row(row)
+    return table
+
+
+@pytest.fixture(scope="function")
+def city_data_from_csv() -> PrettyTable:
+    csv_string = ", ".join(CITY_DATA_HEADER)
+    for row in CITY_DATA:
+        csv_string += "\n" + ",".join(str(fld) for fld in row)
+    csv_fp = io.StringIO(csv_string)
+    return from_csv(csv_fp)
+
+
+@pytest.fixture
+def mix_prettytable() -> PrettyTable:
+    # A mix of both!
+    table = PrettyTable()
+    table.field_names = [CITY_DATA_HEADER[0], CITY_DATA_HEADER[1]]
+    for row in CITY_DATA:
+        table.add_row([row[0], row[1]])
+    for idx, colname in enumerate(CITY_DATA_HEADER[2:]):
+        table.add_column(colname, [row[idx + 2] for row in CITY_DATA])
+    return table
+
+
+@pytest.fixture(scope="function")
+def field_name_less_table() -> PrettyTable:
+    table = PrettyTable()
+    for row in CITY_DATA:
+        table.add_row(row)
+    return table
+
+
+@pytest.fixture(scope="function")
+def row_prettytable(field_name_less_table) -> PrettyTable:
+    # Row by row...
+    field_name_less_table.field_names = CITY_DATA_HEADER
+    return field_name_less_table

--- a/tests/test_colortable.py
+++ b/tests/test_colortable.py
@@ -1,37 +1,18 @@
 from __future__ import annotations
 
 import pytest
+from test_prettytable import CITY_DATA, CITY_DATA_HEADER
 
 from prettytable import PrettyTable
 from prettytable.colortable import RESET_CODE, ColorTable, Theme, Themes
 
 
 @pytest.fixture
-def row_prettytable() -> PrettyTable:
-    # Row by row...
-    table = PrettyTable()
-    table.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
-    table.add_row(["Adelaide", 1295, 1158259, 600.5])
-    table.add_row(["Brisbane", 5905, 1857594, 1146.4])
-    table.add_row(["Darwin", 112, 120900, 1714.7])
-    table.add_row(["Hobart", 1357, 205556, 619.5])
-    table.add_row(["Sydney", 2058, 4336374, 1214.8])
-    table.add_row(["Melbourne", 1566, 3806092, 646.9])
-    table.add_row(["Perth", 5386, 1554769, 869.4])
-    return table
-
-
-@pytest.fixture
 def row_colortable():
     table = ColorTable()
-    table.field_names = ["City name", "Area", "Population", "Annual Rainfall"]
-    table.add_row(["Adelaide", 1295, 1158259, 600.5])
-    table.add_row(["Brisbane", 5905, 1857594, 1146.4])
-    table.add_row(["Darwin", 112, 120900, 1714.7])
-    table.add_row(["Hobart", 1357, 205556, 619.5])
-    table.add_row(["Sydney", 2058, 4336374, 1214.8])
-    table.add_row(["Melbourne", 1566, 3806092, 646.9])
-    table.add_row(["Perth", 5386, 1554769, 869.4])
+    table.field_names = CITY_DATA_HEADER
+    for row in CITY_DATA:
+        table.add_row(row)
     return table
 
 

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import pytest
+from test_prettytable import helper_table
+
+from prettytable import PrettyTable, from_html, from_html_one
+
+
+class TestHtmlConstructor:
+    def test_html_and_back(self, city_data: PrettyTable) -> None:
+        html_string = city_data.get_html_string()
+        new_table = from_html(html_string)[0]
+        assert new_table.get_string() == city_data.get_string()
+
+    def test_html_one_and_back(self, city_data: PrettyTable) -> None:
+        html_string = city_data.get_html_string()
+        new_table = from_html_one(html_string)
+        assert new_table.get_string() == city_data.get_string()
+
+    def test_html_one_fail_on_many(self, city_data: PrettyTable) -> None:
+        html_string = city_data.get_html_string()
+        html_string += city_data.get_html_string()
+        with pytest.raises(ValueError):
+            from_html_one(html_string)
+
+
+class TestHtmlOutput:
+    def test_html_output(self) -> None:
+        t = helper_table()
+        result = t.get_html_string()
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th>Field 2</th>
+            <th>Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>value 1</td>
+            <td>value2</td>
+            <td>value3</td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td>value 4</td>
+            <td>value5</td>
+            <td>value6</td>
+        </tr>
+        <tr>
+            <td>7</td>
+            <td>value 7</td>
+            <td>value8</td>
+            <td>value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_html_output_formatted(self) -> None:
+        t = helper_table()
+        result = t.get_html_string(format=True)
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_with_title(self) -> None:
+        t = helper_table()
+        t.title = "Title & Title"
+        result = t.get_html_string(attributes={"bgcolor": "red", "a<b": "1<2"})
+        assert (
+            result.strip()
+            == """
+<table bgcolor="red" a&lt;b="1&lt;2">
+    <caption>Title &amp; Title</caption>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th>Field 2</th>
+            <th>Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>value 1</td>
+            <td>value2</td>
+            <td>value3</td>
+        </tr>
+        <tr>
+            <td>4</td>
+            <td>value 4</td>
+            <td>value5</td>
+            <td>value6</td>
+        </tr>
+        <tr>
+            <td>7</td>
+            <td>value 7</td>
+            <td>value8</td>
+            <td>value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_html_output_formatted_with_title(self) -> None:
+        t = helper_table()
+        t.title = "Title & Title"
+        result = t.get_html_string(
+            attributes={"bgcolor": "red", "a<b": "1<2"}, format=True
+        )
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols" bgcolor="red" a&lt;b="1&lt;2">
+    <caption>Title &amp; Title</caption>
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_without_escaped_header(self) -> None:
+        t = helper_table(rows=0)
+        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
+        result = t.get_html_string(escape_header=False)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th><em>Field 2</em></th>
+            <th><a href='#'>Field 3</a></th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_html_output_without_escaped_data(self) -> None:
+        t = helper_table(rows=0)
+        t.add_row(
+            [
+                1,
+                "<b>value 1</b>",
+                "<span style='text-decoration: underline;'>value2</span>",
+                "<a href='#'>value3</a>",
+            ]
+        )
+        result = t.get_html_string(escape_data=False)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th>Field 2</th>
+            <th>Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td><b>value 1</b></td>
+            <td><span style='text-decoration: underline;'>value2</span></td>
+            <td><a href='#'>value3</a></td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_html_output_with_escaped_header(self) -> None:
+        t = helper_table(rows=0)
+        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
+        result = t.get_html_string(escape_header=True)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th>&lt;em&gt;Field 2&lt;/em&gt;</th>
+            <th>&lt;a href=&#x27;#&#x27;&gt;Field 3&lt;/a&gt;</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_html_output_with_escaped_data(self) -> None:
+        t = helper_table(rows=0)
+        t.add_row(
+            [
+                1,
+                "<b>value 1</b>",
+                "<span style='text-decoration: underline;'>value2</span>",
+                "<a href='#'>value3</a>",
+            ]
+        )
+        result = t.get_html_string(escape_data=True)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th></th>
+            <th>Field 1</th>
+            <th>Field 2</th>
+            <th>Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>1</td>
+            <td>&lt;b&gt;value 1&lt;/b&gt;</td>
+            <td>&lt;span style=&#x27;text-decoration: underline;&#x27;&gt;value2&lt;/span&gt;</td>
+            <td>&lt;a href=&#x27;#&#x27;&gt;value3&lt;/a&gt;</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_formatted_without_escaped_header(self) -> None:
+        t = helper_table(rows=0)
+        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
+        result = t.get_html_string(escape_header=False, format=True)
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"><em>Field 2</em></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"><a href='#'>Field 3</a></th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_formatted_without_escaped_data(self) -> None:
+        t = helper_table(rows=0)
+        t.add_row(
+            [
+                1,
+                "<b>value 1</b>",
+                "<span style='text-decoration: underline;'>value2</span>",
+                "<a href='#'>value3</a>",
+            ]
+        )
+        result = t.get_html_string(escape_data=False, format=True)
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><b>value 1</b></td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><span style='text-decoration: underline;'>value2</span></td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><a href='#'>value3</a></td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_formatted_with_escaped_header(self) -> None:
+        t = helper_table(rows=0)
+        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
+        result = t.get_html_string(escape_header=True, format=True)
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">&lt;em&gt;Field 2&lt;/em&gt;</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">&lt;a href=&#x27;#&#x27;&gt;Field 3&lt;/a&gt;</th>
+        </tr>
+    </thead>
+    <tbody>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_html_output_formatted_with_escaped_data(self) -> None:
+        t = helper_table(rows=0)
+        t.add_row(
+            [
+                1,
+                "<b>value 1</b>",
+                "<span style='text-decoration: underline;'>value2</span>",
+                "<a href='#'>value3</a>",
+            ]
+        )
+        result = t.get_html_string(escape_data=True, format=True)
+        assert (
+            result.strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;b&gt;value 1&lt;/b&gt;</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;span style=&#x27;text-decoration: underline;&#x27;&gt;value2&lt;/span&gt;</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;a href=&#x27;#&#x27;&gt;value3&lt;/a&gt;</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )
+
+    def test_table_formatted_html_autoindex(self) -> None:
+        """See also #199"""
+        table = PrettyTable(["Field 1", "Field 2", "Field 3"])
+        for row in range(1, 3 * 3, 3):
+            table.add_row(
+                [f"value {row*100}", f"value {row+1*100}", f"value {row+2*100}"]
+            )
+        table.format = True
+        table.add_autoindex("I")
+
+        assert (
+            table.get_html_string().strip()
+            == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">I</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 100</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 101</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 201</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">2</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 400</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 104</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 204</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">3</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 700</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 107</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 207</td>
+        </tr>
+    </tbody>
+</table>""".strip()  # noqa: E501
+        )
+
+    def test_internal_border_preserved_html(self) -> None:
+        pt = helper_table()
+        pt.format = True
+        pt.border = False
+        pt.preserve_internal_border = True
+
+        assert (
+            pt.get_html_string().strip()
+            == """
+<table rules="cols">
+    <thead>
+        <tr>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
+        </tr>
+        <tr>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()  # noqa: E501
+        )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from prettytable import PrettyTable, from_html, from_html_one
+from prettytable import HRuleStyle, PrettyTable, from_html, from_html_one
 
 
 class TestHtmlConstructor:
@@ -524,4 +524,62 @@ class TestHtmlOutput:
     </tbody>
 </table>
 """.strip()  # noqa: E501
+        )
+
+    def test_break_line_html(self) -> None:
+        table = PrettyTable(["Field 1", "Field 2"])
+        table.add_row(["value 1", "value2\nsecond line"])
+        table.add_row(["value 3", "value4"])
+        result = table.get_html_string(hrules=HRuleStyle.ALL)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th>Field 1</th>
+            <th>Field 2</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>value 1</td>
+            <td>value2<br>second line</td>
+        </tr>
+        <tr>
+            <td>value 3</td>
+            <td>value4</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+        )
+
+    def test_break_line_xhtml(self) -> None:
+        table = PrettyTable(["Field 1", "Field 2"])
+        table.add_row(["value 1", "value2\nsecond line"])
+        table.add_row(["value 3", "value4"])
+        result = table.get_html_string(hrules=HRuleStyle.ALL, xhtml=True)
+        assert (
+            result.strip()
+            == """
+<table>
+    <thead>
+        <tr>
+            <th>Field 1</th>
+            <th>Field 2</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>value 1</td>
+            <td>value2<br/>second line</td>
+        </tr>
+        <tr>
+            <td>value 3</td>
+            <td>value4</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
         )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from test_prettytable import helper_table
 
 from prettytable import PrettyTable, from_html, from_html_one
 
@@ -25,9 +24,8 @@ class TestHtmlConstructor:
 
 
 class TestHtmlOutput:
-    def test_html_output(self) -> None:
-        t = helper_table()
-        result = t.get_html_string()
+    def test_html_output(self, helper_table: PrettyTable) -> None:
+        result = helper_table.get_html_string()
         assert (
             result.strip()
             == """
@@ -64,9 +62,8 @@ class TestHtmlOutput:
 """.strip()
         )
 
-    def test_html_output_formatted(self) -> None:
-        t = helper_table()
-        result = t.get_html_string(format=True)
+    def test_html_output_formatted(self, helper_table: PrettyTable) -> None:
+        result = helper_table.get_html_string(format=True)
         assert (
             result.strip()
             == """
@@ -103,10 +100,11 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_with_title(self) -> None:
-        t = helper_table()
-        t.title = "Title & Title"
-        result = t.get_html_string(attributes={"bgcolor": "red", "a<b": "1<2"})
+    def test_html_output_with_title(self, helper_table: PrettyTable) -> None:
+        helper_table.title = "Title & Title"
+        result = helper_table.get_html_string(
+            attributes={"bgcolor": "red", "a<b": "1<2"}
+        )
         assert (
             result.strip()
             == """
@@ -144,10 +142,9 @@ class TestHtmlOutput:
 """.strip()
         )
 
-    def test_html_output_formatted_with_title(self) -> None:
-        t = helper_table()
-        t.title = "Title & Title"
-        result = t.get_html_string(
+    def test_html_output_formatted_with_title(self, helper_table: PrettyTable) -> None:
+        helper_table.title = "Title & Title"
+        result = helper_table.get_html_string(
             attributes={"bgcolor": "red", "a<b": "1<2"}, format=True
         )
         assert (
@@ -187,10 +184,16 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_without_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=False)
+    def test_html_output_without_escaped_header(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.field_names = [
+            "",
+            "Field 1",
+            "<em>Field 2</em>",
+            "<a href='#'>Field 3</a>",
+        ]
+        result = empty_helper_table.get_html_string(escape_header=False)
         assert (
             result.strip()
             == """
@@ -209,9 +212,10 @@ class TestHtmlOutput:
 """.strip()
         )
 
-    def test_html_output_without_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
+    def test_html_output_without_escaped_data(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.add_row(
             [
                 1,
                 "<b>value 1</b>",
@@ -219,7 +223,7 @@ class TestHtmlOutput:
                 "<a href='#'>value3</a>",
             ]
         )
-        result = t.get_html_string(escape_data=False)
+        result = empty_helper_table.get_html_string(escape_data=False)
         assert (
             result.strip()
             == """
@@ -244,10 +248,16 @@ class TestHtmlOutput:
 """.strip()
         )
 
-    def test_html_output_with_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=True)
+    def test_html_output_with_escaped_header(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.field_names = [
+            "",
+            "Field 1",
+            "<em>Field 2</em>",
+            "<a href='#'>Field 3</a>",
+        ]
+        result = empty_helper_table.get_html_string(escape_header=True)
         assert (
             result.strip()
             == """
@@ -266,9 +276,10 @@ class TestHtmlOutput:
 """.strip()
         )
 
-    def test_html_output_with_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
+    def test_html_output_with_escaped_data(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.add_row(
             [
                 1,
                 "<b>value 1</b>",
@@ -276,7 +287,7 @@ class TestHtmlOutput:
                 "<a href='#'>value3</a>",
             ]
         )
-        result = t.get_html_string(escape_data=True)
+        result = empty_helper_table.get_html_string(escape_data=True)
         assert (
             result.strip()
             == """
@@ -301,10 +312,16 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_formatted_without_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=False, format=True)
+    def test_html_output_formatted_without_escaped_header(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.field_names = [
+            "",
+            "Field 1",
+            "<em>Field 2</em>",
+            "<a href='#'>Field 3</a>",
+        ]
+        result = empty_helper_table.get_html_string(escape_header=False, format=True)
         assert (
             result.strip()
             == """
@@ -323,9 +340,10 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_formatted_without_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
+    def test_html_output_formatted_without_escaped_data(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.add_row(
             [
                 1,
                 "<b>value 1</b>",
@@ -333,7 +351,7 @@ class TestHtmlOutput:
                 "<a href='#'>value3</a>",
             ]
         )
-        result = t.get_html_string(escape_data=False, format=True)
+        result = empty_helper_table.get_html_string(escape_data=False, format=True)
         assert (
             result.strip()
             == """
@@ -358,10 +376,16 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_formatted_with_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=True, format=True)
+    def test_html_output_formatted_with_escaped_header(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.field_names = [
+            "",
+            "Field 1",
+            "<em>Field 2</em>",
+            "<a href='#'>Field 3</a>",
+        ]
+        result = empty_helper_table.get_html_string(escape_header=True, format=True)
         assert (
             result.strip()
             == """
@@ -380,9 +404,10 @@ class TestHtmlOutput:
 """.strip()  # noqa: E501
         )
 
-    def test_html_output_formatted_with_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
+    def test_html_output_formatted_with_escaped_data(
+        self, empty_helper_table: PrettyTable
+    ) -> None:
+        empty_helper_table.add_row(
             [
                 1,
                 "<b>value 1</b>",
@@ -390,7 +415,7 @@ class TestHtmlOutput:
                 "<a href='#'>value3</a>",
             ]
         )
-        result = t.get_html_string(escape_data=True, format=True)
+        result = empty_helper_table.get_html_string(escape_data=True, format=True)
         assert (
             result.strip()
             == """
@@ -460,14 +485,13 @@ class TestHtmlOutput:
 </table>""".strip()  # noqa: E501
         )
 
-    def test_internal_border_preserved_html(self) -> None:
-        pt = helper_table()
-        pt.format = True
-        pt.border = False
-        pt.preserve_internal_border = True
+    def test_internal_border_preserved_html(self, helper_table: PrettyTable) -> None:
+        helper_table.format = True
+        helper_table.border = False
+        helper_table.preserve_internal_border = True
 
         assert (
-            pt.get_html_string().strip()
+            helper_table.get_html_string().strip()
             == """
 <table rules="cols">
     <thead>

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from test_prettytable import helper_table
-
 from prettytable import PrettyTable, from_json
 
 
 class TestJSONOutput:
-    def test_json_output(self) -> None:
-        t = helper_table()
-        result = t.get_json_string()
+    def test_json_output(self, helper_table) -> None:
+        result = helper_table.get_json_string()
         assert (
             result.strip()
             == """
@@ -40,7 +37,7 @@ class TestJSONOutput:
 ]""".strip()
         )
         options = {"fields": ["Field 1", "Field 3"]}
-        result = t.get_json_string(**options)
+        result = helper_table.get_json_string(**options)
         assert (
             result.strip()
             == """
@@ -64,9 +61,10 @@ class TestJSONOutput:
 ]""".strip()
         )
 
-    def test_json_output_options(self) -> None:
-        t = helper_table()
-        result = t.get_json_string(header=False, indent=None, separators=(",", ":"))
+    def test_json_output_options(self, helper_table) -> None:
+        result = helper_table.get_json_string(
+            header=False, indent=None, separators=(",", ":")
+        )
         assert (
             result
             == """[{"":1,"Field 1":"value 1","Field 2":"value2","Field 3":"value3"},"""

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,7 +4,7 @@ from prettytable import PrettyTable, from_json
 
 
 class TestJSONOutput:
-    def test_json_output(self, helper_table) -> None:
+    def test_json_output(self, helper_table: PrettyTable) -> None:
         result = helper_table.get_json_string()
         assert (
             result.strip()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from test_prettytable import helper_table
+
+from prettytable import PrettyTable, from_json
+
+
+class TestJSONOutput:
+    def test_json_output(self) -> None:
+        t = helper_table()
+        result = t.get_json_string()
+        assert (
+            result.strip()
+            == """
+[
+    [
+        "",
+        "Field 1",
+        "Field 2",
+        "Field 3"
+    ],
+    {
+        "": 1,
+        "Field 1": "value 1",
+        "Field 2": "value2",
+        "Field 3": "value3"
+    },
+    {
+        "": 4,
+        "Field 1": "value 4",
+        "Field 2": "value5",
+        "Field 3": "value6"
+    },
+    {
+        "": 7,
+        "Field 1": "value 7",
+        "Field 2": "value8",
+        "Field 3": "value9"
+    }
+]""".strip()
+        )
+        options = {"fields": ["Field 1", "Field 3"]}
+        result = t.get_json_string(**options)
+        assert (
+            result.strip()
+            == """
+[
+    [
+        "Field 1",
+        "Field 3"
+    ],
+    {
+        "Field 1": "value 1",
+        "Field 3": "value3"
+    },
+    {
+        "Field 1": "value 4",
+        "Field 3": "value6"
+    },
+    {
+        "Field 1": "value 7",
+        "Field 3": "value9"
+    }
+]""".strip()
+        )
+
+    def test_json_output_options(self) -> None:
+        t = helper_table()
+        result = t.get_json_string(header=False, indent=None, separators=(",", ":"))
+        assert (
+            result
+            == """[{"":1,"Field 1":"value 1","Field 2":"value2","Field 3":"value3"},"""
+            """{"":4,"Field 1":"value 4","Field 2":"value5","Field 3":"value6"},"""
+            """{"":7,"Field 1":"value 7","Field 2":"value8","Field 3":"value9"}]"""
+        )
+
+
+class TestJSONConstructor:
+    def test_json_and_back(self, city_data: PrettyTable) -> None:
+        json_string = city_data.get_json_string()
+        new_table = from_json(json_string)
+        assert new_table.get_string() == city_data.get_string()

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from test_prettytable import helper_table
+
+from prettytable import HRuleStyle, VRuleStyle
+
+
+class TestLatexOutput:
+    def test_latex_output(self) -> None:
+        t = helper_table()
+        assert t.get_latex_string() == (
+            "\\begin{tabular}{cccc}\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\end{tabular}"
+        )
+        options = {"fields": ["Field 1", "Field 3"]}
+        assert t.get_latex_string(**options) == (
+            "\\begin{tabular}{cc}\r\n"
+            "Field 1 & Field 3 \\\\\r\n"
+            "value 1 & value3 \\\\\r\n"
+            "value 4 & value6 \\\\\r\n"
+            "value 7 & value9 \\\\\r\n"
+            "\\end{tabular}"
+        )
+
+    def test_latex_output_formatted(self) -> None:
+        t = helper_table()
+        assert t.get_latex_string(format=True) == (
+            "\\begin{tabular}{|c|c|c|c|}\r\n"
+            "\\hline\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\hline\r\n"
+            "\\end{tabular}"
+        )
+
+        options = {"fields": ["Field 1", "Field 3"]}
+        assert t.get_latex_string(format=True, **options) == (
+            "\\begin{tabular}{|c|c|}\r\n"
+            "\\hline\r\n"
+            "Field 1 & Field 3 \\\\\r\n"
+            "value 1 & value3 \\\\\r\n"
+            "value 4 & value6 \\\\\r\n"
+            "value 7 & value9 \\\\\r\n"
+            "\\hline\r\n"
+            "\\end{tabular}"
+        )
+
+        options = {"vrules": VRuleStyle.FRAME}
+        assert t.get_latex_string(format=True, **options) == (
+            "\\begin{tabular}{|cccc|}\r\n"
+            "\\hline\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\hline\r\n"
+            "\\end{tabular}"
+        )
+
+        options = {"hrules": HRuleStyle.ALL}
+        assert t.get_latex_string(format=True, **options) == (
+            "\\begin{tabular}{|c|c|c|c|}\r\n"
+            "\\hline\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "\\hline\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "\\hline\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "\\hline\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\hline\r\n"
+            "\\end{tabular}"
+        )
+
+    def test_latex_output_header(self) -> None:
+        t = helper_table()
+        assert t.get_latex_string(format=True, hrules=HRuleStyle.HEADER) == (
+            "\\begin{tabular}{|c|c|c|c|}\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "\\hline\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\end{tabular}"
+        )
+
+    def test_internal_border_preserved_latex(self) -> None:
+        pt = helper_table()
+        pt.border = False
+        pt.format = True
+        pt.preserve_internal_border = True
+
+        assert pt.get_latex_string().strip() == (
+            "\\begin{tabular}{c|c|c|c}\r\n"
+            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
+            "1 & value 1 & value2 & value3 \\\\\r\n"
+            "4 & value 4 & value5 & value6 \\\\\r\n"
+            "7 & value 7 & value8 & value9 \\\\\r\n"
+            "\\end{tabular}"
+        )

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from test_prettytable import helper_table
-
 from prettytable import HRuleStyle, VRuleStyle
 
 
 class TestLatexOutput:
-    def test_latex_output(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string() == (
+    def test_latex_output(self, helper_table) -> None:
+        assert helper_table.get_latex_string() == (
             "\\begin{tabular}{cccc}\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
             "1 & value 1 & value2 & value3 \\\\\r\n"
@@ -17,7 +14,7 @@ class TestLatexOutput:
             "\\end{tabular}"
         )
         options = {"fields": ["Field 1", "Field 3"]}
-        assert t.get_latex_string(**options) == (
+        assert helper_table.get_latex_string(**options) == (
             "\\begin{tabular}{cc}\r\n"
             "Field 1 & Field 3 \\\\\r\n"
             "value 1 & value3 \\\\\r\n"
@@ -26,9 +23,8 @@ class TestLatexOutput:
             "\\end{tabular}"
         )
 
-    def test_latex_output_formatted(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string(format=True) == (
+    def test_latex_output_formatted(self, helper_table) -> None:
+        assert helper_table.get_latex_string(format=True) == (
             "\\begin{tabular}{|c|c|c|c|}\r\n"
             "\\hline\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
@@ -40,7 +36,7 @@ class TestLatexOutput:
         )
 
         options = {"fields": ["Field 1", "Field 3"]}
-        assert t.get_latex_string(format=True, **options) == (
+        assert helper_table.get_latex_string(format=True, **options) == (
             "\\begin{tabular}{|c|c|}\r\n"
             "\\hline\r\n"
             "Field 1 & Field 3 \\\\\r\n"
@@ -52,7 +48,7 @@ class TestLatexOutput:
         )
 
         options = {"vrules": VRuleStyle.FRAME}
-        assert t.get_latex_string(format=True, **options) == (
+        assert helper_table.get_latex_string(format=True, **options) == (
             "\\begin{tabular}{|cccc|}\r\n"
             "\\hline\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
@@ -64,7 +60,7 @@ class TestLatexOutput:
         )
 
         options = {"hrules": HRuleStyle.ALL}
-        assert t.get_latex_string(format=True, **options) == (
+        assert helper_table.get_latex_string(format=True, **options) == (
             "\\begin{tabular}{|c|c|c|c|}\r\n"
             "\\hline\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
@@ -78,9 +74,8 @@ class TestLatexOutput:
             "\\end{tabular}"
         )
 
-    def test_latex_output_header(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string(format=True, hrules=HRuleStyle.HEADER) == (
+    def test_latex_output_header(self, helper_table) -> None:
+        assert helper_table.get_latex_string(format=True, hrules=HRuleStyle.HEADER) == (
             "\\begin{tabular}{|c|c|c|c|}\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
             "\\hline\r\n"
@@ -90,13 +85,12 @@ class TestLatexOutput:
             "\\end{tabular}"
         )
 
-    def test_internal_border_preserved_latex(self) -> None:
-        pt = helper_table()
-        pt.border = False
-        pt.format = True
-        pt.preserve_internal_border = True
+    def test_internal_border_preserved_latex(self, helper_table) -> None:
+        helper_table.border = False
+        helper_table.format = True
+        helper_table.preserve_internal_border = True
 
-        assert pt.get_latex_string().strip() == (
+        assert helper_table.get_latex_string().strip() == (
             "\\begin{tabular}{c|c|c|c}\r\n"
             " & Field 1 & Field 2 & Field 3 \\\\\r\n"
             "1 & value 1 & value2 & value3 \\\\\r\n"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -558,6 +558,26 @@ class TestBasic:
         """All lines in a table should be of the same length."""
         self._test_all_length_equal(city_data_from_csv)
 
+    def test_rowcount(self, city_data: PrettyTable) -> None:
+        assert city_data.rowcount == 7
+
+    def test_colcount(self, city_data: PrettyTable) -> None:
+        assert city_data.colcount == 4
+
+    def test_getitem(self, city_data: PrettyTable) -> None:
+        assert (
+            city_data[1].get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Brisbane | 5905 |  1857594   |      1146.4     |
++-----------+------+------------+-----------------+"""
+        )
+
+    def test_invalid_getitem(self, city_data: PrettyTable) -> None:
+        with pytest.raises(IndexError):
+            assert city_data[10]
+
     @pytest.mark.usefixtures("init_db")
     def test_no_blank_lines_from_db(self, db_cursor) -> None:
         """No table should ever have blank lines in it."""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -12,6 +12,7 @@ import prettytable
 from prettytable import (
     HRuleStyle,
     PrettyTable,
+    RowType,
     TableStyle,
     VRuleStyle,
     from_db_cursor,
@@ -453,15 +454,14 @@ class TestBasic:
     def _test_all_length_equal(self, table: PrettyTable) -> None:
         string = table.get_string()
         lines = string.split("\n")
-        lengths = [len(line) for line in lines]
-        lengths = set(lengths)
+        lengths = {len(line) for line in lines}
         assert len(lengths) == 1
 
-    def test_no_blank_lines(self, city_data) -> None:
+    def test_no_blank_lines(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
         self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal(self, city_data) -> None:
+    def test_all_lengths_equal(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
         self._test_all_length_equal(city_data)
 
@@ -656,7 +656,7 @@ class TestRowFilter:
 |   Perth   | 5386 |  1554769   |      869.4      |
 +-----------+------+------------+-----------------+"""
 
-    def filter_function(self, vals: list[str]) -> bool:
+    def filter_function(self, vals: RowType) -> bool:
         return vals[2] > 999999
 
     def test_row_filter(self, city_data: PrettyTable) -> None:
@@ -687,7 +687,6 @@ def float_pt() -> PrettyTable:
 class TestFloatFormat:
     def test_no_decimals(self, float_pt: PrettyTable) -> None:
         float_pt.float_format = ".0f"
-        float_pt.caching = False
         assert "." not in float_pt.get_string()
 
     def test_round_to_5dp(self, float_pt: PrettyTable) -> None:
@@ -1467,7 +1466,7 @@ class TestGeneralOutput:
         t_copy = helper_table.copy()
         assert helper_table.get_string() == t_copy.get_string()
 
-    def test_text(self, helper_table: prettytable) -> None:
+    def test_text(self, helper_table: PrettyTable) -> None:
         assert helper_table.get_formatted_string("text") == helper_table.get_string()
         # test with default arg, too
         assert helper_table.get_formatted_string() == helper_table.get_string()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -757,35 +757,6 @@ class TestBreakLine:
         result = table.get_string(hrules=hrule)
         assert result.strip() == expected_result.strip()
 
-    def test_break_line_html(self) -> None:
-        table = PrettyTable(["Field 1", "Field 2"])
-        table.add_row(["value 1", "value2\nsecond line"])
-        table.add_row(["value 3", "value4"])
-        result = table.get_html_string(hrules=HRuleStyle.ALL)
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th>Field 1</th>
-            <th>Field 2</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>value 1</td>
-            <td>value2<br>second line</td>
-        </tr>
-        <tr>
-            <td>value 3</td>
-            <td>value4</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()
-        )
-
 
 class TestFromDB:
     @pytest.mark.usefixtures("init_db")

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1203,7 +1203,7 @@ class TestWidth:
         )
 
     @pytest.mark.parametrize("set_width_parameter", [True, False])
-    def test_table_max_width_wo_header_width(self, set_width_parameter) -> None:
+    def test_table_max_width_wo_header_width(self, set_width_parameter: bool) -> None:
         headers = [
             "A Field Name",
             "B Field Name",

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import io
-import random
 import sqlite3
 from math import e, pi, sqrt
 from typing import Any
@@ -16,11 +14,7 @@ from prettytable import (
     PrettyTable,
     TableStyle,
     VRuleStyle,
-    from_csv,
     from_db_cursor,
-    from_html,
-    from_html_one,
-    from_json,
 )
 
 
@@ -41,8 +35,9 @@ def helper_table(*, rows: int = 3) -> PrettyTable:
     return table
 
 
-TEST_TABLE_HEADER = ["City name", "Area", "Population", "Annual Rainfall"]
-TEST_TABLE = [
+# Australian capital city data example table
+CITY_DATA_HEADER = ["City name", "Area", "Population", "Annual Rainfall"]
+CITY_DATA = [
     ["Adelaide", 1295, 1158259, 600.5],
     ["Brisbane", 5905, 1857594, 1146.4],
     ["Darwin", 112, 120900, 1714.7],
@@ -51,37 +46,6 @@ TEST_TABLE = [
     ["Melbourne", 1566, 3806092, 646.9],
     ["Perth", 5386, 1554769, 869.4],
 ]
-
-
-@pytest.fixture
-def row_prettytable() -> PrettyTable:
-    # Row by row...
-    table = PrettyTable()
-    table.field_names = TEST_TABLE_HEADER
-    for row in TEST_TABLE:
-        table.add_row(row)
-    return table
-
-
-@pytest.fixture
-def col_prettytable() -> PrettyTable:
-    # Column by column...
-    table = PrettyTable()
-    for idx, colname in enumerate(TEST_TABLE_HEADER):
-        table.add_column(colname, [row[idx] for row in TEST_TABLE])
-    return table
-
-
-@pytest.fixture
-def mix_prettytable() -> PrettyTable:
-    # A mix of both!
-    table = PrettyTable()
-    table.field_names = [TEST_TABLE_HEADER[0], TEST_TABLE_HEADER[1]]
-    for row in TEST_TABLE:
-        table.add_row([row[0], row[1]])
-    for idx, colname in enumerate(TEST_TABLE_HEADER[2:]):
-        table.add_column(colname, [row[idx + 2] for row in TEST_TABLE])
-    return table
 
 
 class TestNoneOption:
@@ -258,10 +222,6 @@ class TestBuildEquivalence:
 
 class TestDeleteColumn:
     def test_delete_column(self, col_prettytable: PrettyTable) -> None:
-        # table = PrettyTable()
-        # table.add_column("City name", ["Adelaide", "Brisbane", "Darwin"])
-        # table.add_column("Area", [1295, 5905, 112])
-        # table.add_column("Population", [1158259, 1857594, 120900])
         col_prettytable.del_column("Area")
 
         assert (
@@ -279,20 +239,11 @@ class TestDeleteColumn:
 +-----------+------------+-----------------+"""
         )
 
-    def test_delete_illegal_column_raises_error(self) -> None:
-        table = PrettyTable()
-        table.add_column("City name", ["Adelaide", "Brisbane", "Darwin"])
-
+    def test_delete_illegal_column_raises_error(
+        self, col_prettytable: PrettyTable
+    ) -> None:
         with pytest.raises(ValueError):
-            table.del_column("City not-a-name")
-
-
-@pytest.fixture(scope="function")
-def field_name_less_table() -> PrettyTable:
-    table = PrettyTable()
-    for row in TEST_TABLE:
-        table.add_row(row)
-    return table
+            col_prettytable.del_column("City not-a-name")
 
 
 class TestFieldNameLessTable:
@@ -314,7 +265,7 @@ class TestFieldNameLessTable:
         assert "Adelaide & 1295 & 1158259 & 600.5 \\\\" in output
 
     def test_add_field_names_later(self, field_name_less_table: PrettyTable) -> None:
-        field_name_less_table.field_names = TEST_TABLE_HEADER
+        field_name_less_table.field_names = CITY_DATA_HEADER
         assert (
             "City name | Area | Population | Annual Rainfall"
             in field_name_less_table.get_string()
@@ -325,17 +276,18 @@ class TestFieldNameLessTable:
 def aligned_before_table() -> PrettyTable:
     table = PrettyTable()
     table.align = "r"
-    table.field_names = TEST_TABLE_HEADER
-    for row in TEST_TABLE:
+    table.field_names = CITY_DATA_HEADER
+    for row in CITY_DATA:
         table.add_row(row)
     return table
 
 
 @pytest.fixture(scope="function")
-def aligned_after_table() -> PrettyTable:
+def aligned_after_table(field_name_less_table) -> PrettyTable:
     table = PrettyTable()
-    table.field_names = TEST_TABLE_HEADER
-    for row in TEST_TABLE:
+    table.align = "r"
+    table.field_names = CITY_DATA_HEADER
+    for row in CITY_DATA:
         table.add_row(row)
     table.align = "r"
     return table
@@ -347,70 +299,39 @@ class TestAlignment:
     def test_aligned_ascii(
         self, aligned_before_table: PrettyTable, aligned_after_table: PrettyTable
     ) -> None:
-        before = aligned_before_table.get_string()
-        after = aligned_after_table.get_string()
-        assert before == after
+        assert aligned_before_table.get_string() == aligned_after_table.get_string()
 
     def test_aligned_html(
         self, aligned_before_table: PrettyTable, aligned_after_table: PrettyTable
     ) -> None:
-        before = aligned_before_table.get_html_string()
-        after = aligned_after_table.get_html_string()
-        assert before == after
+        assert (
+            aligned_before_table.get_html_string()
+            == aligned_after_table.get_html_string()
+        )
 
     def test_aligned_latex(
         self, aligned_before_table: PrettyTable, aligned_after_table: PrettyTable
     ) -> None:
-        before = aligned_before_table.get_latex_string()
-        after = aligned_after_table.get_latex_string()
-        assert before == after
-
-
-@pytest.fixture(scope="function")
-def city_data_prettytable() -> PrettyTable:
-    """Just build the Australian capital city data example table."""
-    table = PrettyTable(TEST_TABLE_HEADER)
-    for row in TEST_TABLE:
-        table.add_row(row)
-    return table
-
-
-@pytest.fixture(scope="function")
-def city_data_from_csv() -> PrettyTable:
-    csv_string = """City name, Area, Population, Annual Rainfall
-    Sydney, 2058, 4336374, 1214.8
-    Melbourne, 1566, 3806092, 646.9
-    Brisbane, 5905, 1857594, 1146.4
-    Perth, 5386, 1554769, 869.4
-    Adelaide, 1295, 1158259, 600.5
-    Hobart, 1357, 205556, 619.5
-    Darwin, 0112, 120900, 1714.7"""
-    csv_fp = io.StringIO(csv_string)
-    return from_csv(csv_fp)
+        assert (
+            aligned_before_table.get_latex_string()
+            == aligned_after_table.get_latex_string()
+        )
 
 
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""
 
-    def test_border(self, city_data_prettytable: PrettyTable) -> None:
-        default = city_data_prettytable.get_string()
-        override = city_data_prettytable.get_string(border=False)
-        assert default != override
+    def test_border(self, city_data: PrettyTable) -> None:
+        assert city_data.get_string() != city_data.get_string(border=False)
 
-    def test_header(self, city_data_prettytable) -> None:
-        default = city_data_prettytable.get_string()
-        override = city_data_prettytable.get_string(header=False)
-        assert default != override
+    def test_header(self, city_data) -> None:
+        assert city_data.get_string() != city_data.get_string(header=False)
 
-    def test_hrules_all(self, city_data_prettytable) -> None:
-        default = city_data_prettytable.get_string()
-        override = city_data_prettytable.get_string(hrules=HRuleStyle.ALL)
-        assert default != override
+    def test_hrules_all(self, city_data) -> None:
+        assert city_data.get_string() != city_data.get_string(hrules=HRuleStyle.ALL)
 
-    def test_hrules_none(self, city_data_prettytable) -> None:
-        default = city_data_prettytable.get_string()
-        override = city_data_prettytable.get_string(hrules=HRuleStyle.NONE)
-        assert default != override
+    def test_hrules_none(self, city_data) -> None:
+        assert city_data.get_string() != city_data.get_string(hrules=HRuleStyle.NONE)
 
 
 class TestOptionAttribute:
@@ -418,51 +339,63 @@ class TestOptionAttribute:
     Also make sure option settings are copied correctly when a table is cloned by
     slicing."""
 
-    def test_set_for_all_columns(self, city_data_prettytable) -> None:
-        city_data_prettytable.field_names = sorted(city_data_prettytable.field_names)
-        city_data_prettytable.align = "l"
-        city_data_prettytable.max_width = 10
-        city_data_prettytable.start = 2
-        city_data_prettytable.end = 4
-        city_data_prettytable.sortby = "Area"
-        city_data_prettytable.reversesort = True
-        city_data_prettytable.header = True
-        city_data_prettytable.border = False
-        city_data_prettytable.hrules = True
-        city_data_prettytable.int_format = "4"
-        city_data_prettytable.float_format = "2.2"
-        city_data_prettytable.padding_width = 2
-        city_data_prettytable.left_padding_width = 2
-        city_data_prettytable.right_padding_width = 2
-        city_data_prettytable.vertical_char = "!"
-        city_data_prettytable.horizontal_char = "~"
-        city_data_prettytable.junction_char = "*"
-        city_data_prettytable.top_junction_char = "@"
-        city_data_prettytable.bottom_junction_char = "#"
-        city_data_prettytable.right_junction_char = "$"
-        city_data_prettytable.left_junction_char = "%"
-        city_data_prettytable.top_right_junction_char = "^"
-        city_data_prettytable.top_left_junction_char = "&"
-        city_data_prettytable.bottom_right_junction_char = "("
-        city_data_prettytable.bottom_left_junction_char = ")"
-        city_data_prettytable.format = True
-        city_data_prettytable.attributes = {"class": "prettytable"}
-        assert (
-            city_data_prettytable.get_string() == city_data_prettytable[:].get_string()
-        )
+    def test_set_for_all_columns(self, city_data) -> None:
+        city_data.field_names = sorted(city_data.field_names)
+        city_data.align = "l"
+        city_data.max_width = 10
+        city_data.start = 2
+        city_data.end = 4
+        city_data.sortby = "Area"
+        city_data.reversesort = True
+        city_data.header = True
+        city_data.border = False
+        city_data.hrules = True
+        city_data.int_format = "4"
+        city_data.float_format = "2.2"
+        city_data.padding_width = 2
+        city_data.left_padding_width = 2
+        city_data.right_padding_width = 2
+        city_data.vertical_char = "!"
+        city_data.horizontal_char = "~"
+        city_data.junction_char = "*"
+        city_data.top_junction_char = "@"
+        city_data.bottom_junction_char = "#"
+        city_data.right_junction_char = "$"
+        city_data.left_junction_char = "%"
+        city_data.top_right_junction_char = "^"
+        city_data.top_left_junction_char = "&"
+        city_data.bottom_right_junction_char = "("
+        city_data.bottom_left_junction_char = ")"
+        city_data.format = True
+        city_data.attributes = {"class": "prettytable"}
+        assert city_data.get_string() == city_data[:].get_string()
 
-    def test_set_for_one_column(self, city_data_prettytable) -> None:
-        city_data_prettytable.align["Rainfall"] = "l"
-        city_data_prettytable.max_width["Name"] = 10
-        city_data_prettytable.int_format["Population"] = "4"
-        city_data_prettytable.float_format["Area"] = "2.2"
-        assert (
-            city_data_prettytable.get_string() == city_data_prettytable[:].get_string()
-        )
+    def test_set_for_one_column(self, city_data) -> None:
+        city_data.align["Rainfall"] = "l"
+        city_data.max_width["Name"] = 10
+        city_data.int_format["Population"] = "4"
+        city_data.float_format["Area"] = "2.2"
+        assert city_data.get_string() == city_data[:].get_string()
 
     def test_preserve_internal_border(self) -> None:
         table = PrettyTable(preserve_internal_border=True)
         assert table.preserve_internal_border is True
+
+    def test_internal_border_preserved(self) -> None:
+        pt = helper_table()
+        pt.border = False
+        pt.preserve_internal_border = True
+
+        assert (
+            pt.get_string().strip()
+            == """
+   | Field 1 | Field 2 | Field 3  
+---+---------+---------+---------
+ 1 | value 1 |  value2 |  value3  
+ 4 | value 4 |  value5 |  value6  
+ 7 | value 7 |  value8 |  value9  
+""".strip()  # noqa: W291
+        )
 
 
 @pytest.fixture(scope="module")
@@ -480,7 +413,7 @@ def init_db(db_cursor):
         "CREATE TABLE cities "
         "(name TEXT, area INTEGER, population INTEGER, rainfall REAL)"
     )
-    for row in TEST_TABLE:
+    for row in CITY_DATA:
         db_cursor.execute(f"INSERT INTO cities VALUES {tuple(row)}")
     yield
     db_cursor.execute("DROP TABLE cities")
@@ -489,10 +422,18 @@ def init_db(db_cursor):
 class TestBasic:
     """Some very basic tests."""
 
-    def test_table_rows(self, city_data_prettytable: PrettyTable) -> None:
-        rows = city_data_prettytable.rows
+    def test_table_rows(self, city_data: PrettyTable) -> None:
+        rows = city_data.rows
         assert len(rows) == 7
-        assert rows[0] == TEST_TABLE[0]
+        assert rows[0] == CITY_DATA[0]
+
+    def test_add_rows(self, city_data: PrettyTable) -> None:
+        """A table created with multiple add_row calls is the same as one created
+        with a single add_rows
+        """
+        table = PrettyTable(CITY_DATA_HEADER)
+        table.add_rows(CITY_DATA)
+        assert str(city_data) == str(table)
 
     def _test_no_blank_lines(self, table: PrettyTable) -> None:
         string = table.get_string()
@@ -506,132 +447,98 @@ class TestBasic:
         lengths = set(lengths)
         assert len(lengths) == 1
 
-    def test_no_blank_lines(self, city_data_prettytable) -> None:
+    def test_no_blank_lines(self, city_data) -> None:
         """No table should ever have blank lines in it."""
-        self._test_no_blank_lines(city_data_prettytable)
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal(self, city_data_prettytable) -> None:
+    def test_all_lengths_equal(self, city_data) -> None:
         """All lines in a table should be of the same length."""
-        self._test_all_length_equal(city_data_prettytable)
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_title(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_title(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.title = "My table"
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.title = "My table"
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_title(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_title(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.title = "My table"
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.title = "My table"
+        self._test_all_length_equal(city_data)
 
-    def test_all_lengths_equal_with_long_title(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_long_title(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length, even with a long title."""
-        city_data_prettytable.title = "My table (75 characters wide) " + "=" * 45
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.title = "My table (75 characters wide) " + "=" * 45
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_without_border(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_without_border(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.border = False
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.border = False
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_without_border(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_without_border(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.border = False
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.border = False
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_without_header(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_without_header(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.header = False
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.header = False
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_without_header(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_without_header(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.header = False
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.header = False
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_hrules_none(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_hrules_none(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.hrules = HRuleStyle.NONE
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.hrules = HRuleStyle.NONE
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_hrules_none(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_hrules_none(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.hrules = HRuleStyle.NONE
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.hrules = HRuleStyle.NONE
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_hrules_all(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_hrules_all(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.hrules = HRuleStyle.ALL
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.hrules = HRuleStyle.ALL
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_hrules_all(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_hrules_all(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.hrules = HRuleStyle.ALL
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.hrules = HRuleStyle.ALL
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_style_msword(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_style_msword(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.set_style(TableStyle.MSWORD_FRIENDLY)
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.set_style(TableStyle.MSWORD_FRIENDLY)
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_style_msword(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_style_msword(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.set_style(TableStyle.MSWORD_FRIENDLY)
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.set_style(TableStyle.MSWORD_FRIENDLY)
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_int_format(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_int_format(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.int_format = "04"
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.int_format = "04"
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_int_format(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_int_format(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.int_format = "04"
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.int_format = "04"
+        self._test_all_length_equal(city_data)
 
-    def test_no_blank_lines_with_float_format(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_no_blank_lines_with_float_format(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data_prettytable.float_format = "6.2f"
-        self._test_no_blank_lines(city_data_prettytable)
+        city_data.float_format = "6.2f"
+        self._test_no_blank_lines(city_data)
 
-    def test_all_lengths_equal_with_float_format(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
+    def test_all_lengths_equal_with_float_format(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data_prettytable.float_format = "6.2f"
-        self._test_all_length_equal(city_data_prettytable)
+        city_data.float_format = "6.2f"
+        self._test_all_length_equal(city_data)
 
     def test_no_blank_lines_from_csv(self, city_data_from_csv: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
@@ -659,174 +566,53 @@ class TestBasic:
 class TestEmptyTable:
     """Make sure the print_empty option works"""
 
-    def test_print_empty_true(self, city_data_prettytable: PrettyTable) -> None:
+    def test_print_empty_true(self, city_data: PrettyTable) -> None:
         table = PrettyTable()
-        table.field_names = TEST_TABLE_HEADER
+        table.field_names = CITY_DATA_HEADER
 
         assert table.get_string(print_empty=True) != ""
-        assert table.get_string(print_empty=True) != city_data_prettytable.get_string(
+        assert table.get_string(print_empty=True) != city_data.get_string(
             print_empty=True
         )
 
-    def test_print_empty_false(self, city_data_prettytable: PrettyTable) -> None:
+    def test_print_empty_false(self, city_data: PrettyTable) -> None:
         table = PrettyTable()
-        table.field_names = TEST_TABLE_HEADER
+        table.field_names = CITY_DATA_HEADER
 
         assert table.get_string(print_empty=False) == ""
-        assert table.get_string(print_empty=False) != city_data_prettytable.get_string(
+        assert table.get_string(print_empty=False) != city_data.get_string(
             print_empty=False
         )
 
     def test_interaction_with_border(self) -> None:
         table = PrettyTable()
-        table.field_names = TEST_TABLE_HEADER
+        table.field_names = CITY_DATA_HEADER
 
         assert table.get_string(border=False, print_empty=True) == ""
 
 
 class TestSlicing:
-    def test_slice_all(self, city_data_prettytable: PrettyTable) -> None:
-        table = city_data_prettytable[:]
-        assert city_data_prettytable.get_string() == table.get_string()
+    def test_slice_all(self, city_data: PrettyTable) -> None:
+        table = city_data[:]
+        assert city_data.get_string() == table.get_string()
 
-    def test_slice_first_two_rows(self, city_data_prettytable: PrettyTable) -> None:
-        table = city_data_prettytable[0:2]
+    def test_slice_first_two_rows(self, city_data: PrettyTable) -> None:
+        table = city_data[0:2]
         string = table.get_string()
         assert len(string.split("\n")) == 6
         for rowidx in (0, 1):
-            assert TEST_TABLE[rowidx][0] in string
+            assert CITY_DATA[rowidx][0] in string
         for rowidx in (2, 3, 4, 5, 6):
-            assert TEST_TABLE[rowidx][0] not in string
+            assert CITY_DATA[rowidx][0] not in string
 
-    def test_slice_last_two_rows(self, city_data_prettytable: PrettyTable) -> None:
-        table = city_data_prettytable[-2:]
+    def test_slice_last_two_rows(self, city_data: PrettyTable) -> None:
+        table = city_data[-2:]
         string = table.get_string()
         assert len(string.split("\n")) == 6
         for rowidx in (0, 1, 2, 3, 4):
-            assert TEST_TABLE[rowidx][0] not in string
+            assert CITY_DATA[rowidx][0] not in string
         for rowidx in (5, 6):
-            assert TEST_TABLE[rowidx][0] in string
-
-
-class TestSorting:
-    def test_sort_by_different_per_columns(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
-        city_data_prettytable.sortby = city_data_prettytable.field_names[0]
-        old = city_data_prettytable.get_string()
-        for field in city_data_prettytable.field_names[1:]:
-            city_data_prettytable.sortby = field
-            new = city_data_prettytable.get_string()
-            assert new != old
-
-    def test_reverse_sort(self, city_data_prettytable: PrettyTable) -> None:
-        for field in city_data_prettytable.field_names:
-            city_data_prettytable.sortby = field
-            city_data_prettytable.reversesort = False
-            forward = city_data_prettytable.get_string()
-            city_data_prettytable.reversesort = True
-            backward = city_data_prettytable.get_string()
-            forward_lines = forward.split("\n")[2:]  # Discard header lines
-            backward_lines = backward.split("\n")[2:]
-            backward_lines.reverse()
-            assert forward_lines == backward_lines
-
-    def test_sort_key(self, city_data_prettytable: PrettyTable) -> None:
-        # Test sorting by length of city name
-        def key(vals):
-            vals[0] = len(vals[0])
-            return vals
-
-        city_data_prettytable.sortby = "City name"
-        city_data_prettytable.sort_key = key
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-+-----------+------+------------+-----------------+
-| City name | Area | Population | Annual Rainfall |
-+-----------+------+------------+-----------------+
-|   Perth   | 5386 |  1554769   |      869.4      |
-|   Darwin  | 112  |   120900   |      1714.7     |
-|   Hobart  | 1357 |   205556   |      619.5      |
-|   Sydney  | 2058 |  4336374   |      1214.8     |
-|  Adelaide | 1295 |  1158259   |      600.5      |
-|  Brisbane | 5905 |  1857594   |      1146.4     |
-| Melbourne | 1566 |  3806092   |      646.9      |
-+-----------+------+------------+-----------------+
-""".strip()
-        )
-
-    def test_sort_key_at_class_declaration(self) -> None:
-        # Test sorting by length of city name
-        def key(vals):
-            vals[0] = len(vals[0])
-            return vals
-
-        table = PrettyTable(
-            field_names=["City name", "Area", "Population", "Annual Rainfall"],
-            sortby="City name",
-            sort_key=key,
-        )
-        assert table.sort_key == key
-        table.add_row(["Adelaide", 1295, 1158259, 600.5])
-        table.add_row(["Brisbane", 5905, 1857594, 1146.4])
-        table.add_row(["Darwin", 112, 120900, 1714.7])
-        table.add_row(["Hobart", 1357, 205556, 619.5])
-        table.add_row(["Sydney", 2058, 4336374, 1214.8])
-        table.add_row(["Melbourne", 1566, 3806092, 646.9])
-        table.add_row(["Perth", 5386, 1554769, 869.4])
-        assert (
-            """+-----------+------+------------+-----------------+
-| City name | Area | Population | Annual Rainfall |
-+-----------+------+------------+-----------------+
-|   Perth   | 5386 |  1554769   |      869.4      |
-|   Darwin  | 112  |   120900   |      1714.7     |
-|   Hobart  | 1357 |   205556   |      619.5      |
-|   Sydney  | 2058 |  4336374   |      1214.8     |
-|  Adelaide | 1295 |  1158259   |      600.5      |
-|  Brisbane | 5905 |  1857594   |      1146.4     |
-| Melbourne | 1566 |  3806092   |      646.9      |
-+-----------+------+------------+-----------------+"""
-            == table.get_string().strip()
-        )
-
-    def test_sort_slice(self) -> None:
-        """Make sure sorting and slicing interact in the expected way"""
-        table = PrettyTable(["Foo"])
-        for i in range(20, 0, -1):
-            table.add_row([i])
-        new_style = table.get_string(sortby="Foo", end=10)
-        assert "10" in new_style
-        assert "20" not in new_style
-        oldstyle = table.get_string(sortby="Foo", end=10, oldsortslice=True)
-        assert "10" not in oldstyle
-        assert "20" in oldstyle
-
-    def test_sortby_at_class_declaration(self) -> None:
-        """
-        Fix #354 where initialization of a table with sortby fails
-        """
-        table = PrettyTable(
-            field_names=["City name", "Area", "Population", "Annual Rainfall"],
-            sortby="Area",
-        )
-        assert table.sortby == "Area"
-        for row in TEST_TABLE:
-            table.add_row(row)
-        assert (
-            """+-----------+------+------------+-----------------+
-| City name | Area | Population | Annual Rainfall |
-+-----------+------+------------+-----------------+
-|   Darwin  | 112  |   120900   |      1714.7     |
-|  Adelaide | 1295 |  1158259   |      600.5      |
-|   Hobart  | 1357 |   205556   |      619.5      |
-| Melbourne | 1566 |  3806092   |      646.9      |
-|   Sydney  | 2058 |  4336374   |      1214.8     |
-|   Perth   | 5386 |  1554769   |      869.4      |
-|  Brisbane | 5905 |  1857594   |      1146.4     |
-+-----------+------+------------+-----------------+"""
-            == table.get_string().strip()
-        )
+            assert CITY_DATA[rowidx][0] in string
 
 
 class TestRowFilter:
@@ -843,17 +629,17 @@ class TestRowFilter:
     def filter_function(self, vals: list[str]) -> bool:
         return vals[2] > 999999
 
-    def test_row_filter(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.row_filter = self.filter_function
-        assert city_data_prettytable.row_filter == self.filter_function
-        assert self.EXPECTED_RESULT == city_data_prettytable.get_string()
+    def test_row_filter(self, city_data: PrettyTable) -> None:
+        city_data.row_filter = self.filter_function
+        assert city_data.row_filter == self.filter_function
+        assert self.EXPECTED_RESULT == city_data.get_string()
 
     def test_row_filter_at_class_declaration(self) -> None:
         table = PrettyTable(
-            field_names=["City name", "Area", "Population", "Annual Rainfall"],
+            field_names=CITY_DATA_HEADER,
             row_filter=self.filter_function,
         )
-        for row in TEST_TABLE:
+        for row in CITY_DATA:
             table.add_row(row)
         assert table.row_filter == self.filter_function
         assert self.EXPECTED_RESULT == table.get_string().strip()
@@ -991,948 +777,11 @@ class TestBreakLine:
         )
 
 
-class TestAnsiWidth:
-    colored = "\033[31mC\033[32mO\033[31mL\033[32mO\033[31mR\033[32mE\033[31mD\033[0m"
-
-    def test_color(self) -> None:
-        table = PrettyTable(["Field 1", "Field 2"])
-        table.add_row([self.colored, self.colored])
-        table.add_row(["nothing", "neither"])
-        result = table.get_string()
-        assert (
-            result.strip()
-            == f"""
-+---------+---------+
-| Field 1 | Field 2 |
-+---------+---------+
-| {self.colored} | {self.colored} |
-| nothing | neither |
-+---------+---------+
-""".strip()
-        )
-
-    def test_reset(self) -> None:
-        table = PrettyTable(["Field 1", "Field 2"])
-        table.add_row(["abc def\033(B", "\033[31mabc def\033[m"])
-        table.add_row(["nothing", "neither"])
-        result = table.get_string()
-        assert (
-            result.strip()
-            == """
-+---------+---------+
-| Field 1 | Field 2 |
-+---------+---------+
-| abc def\033(B | \033[31mabc def\033[m |
-| nothing | neither |
-+---------+---------+
-""".strip()
-        )
-
-
 class TestFromDB:
     @pytest.mark.usefixtures("init_db")
     def test_non_select_cursor(self, db_cursor) -> None:
-        db_cursor.execute(
-            'INSERT INTO cities VALUES ("Adelaide", 1295, 1158259, 600.5)'
-        )
+        db_cursor.execute(f"INSERT INTO cities VALUES {tuple(CITY_DATA[0])}")
         assert from_db_cursor(db_cursor) is None
-
-
-class TestJSONOutput:
-    def test_json_output(self) -> None:
-        t = helper_table()
-        result = t.get_json_string()
-        assert (
-            result.strip()
-            == """
-[
-    [
-        "",
-        "Field 1",
-        "Field 2",
-        "Field 3"
-    ],
-    {
-        "": 1,
-        "Field 1": "value 1",
-        "Field 2": "value2",
-        "Field 3": "value3"
-    },
-    {
-        "": 4,
-        "Field 1": "value 4",
-        "Field 2": "value5",
-        "Field 3": "value6"
-    },
-    {
-        "": 7,
-        "Field 1": "value 7",
-        "Field 2": "value8",
-        "Field 3": "value9"
-    }
-]""".strip()
-        )
-        options = {"fields": ["Field 1", "Field 3"]}
-        result = t.get_json_string(**options)
-        assert (
-            result.strip()
-            == """
-[
-    [
-        "Field 1",
-        "Field 3"
-    ],
-    {
-        "Field 1": "value 1",
-        "Field 3": "value3"
-    },
-    {
-        "Field 1": "value 4",
-        "Field 3": "value6"
-    },
-    {
-        "Field 1": "value 7",
-        "Field 3": "value9"
-    }
-]""".strip()
-        )
-
-    def test_json_output_options(self) -> None:
-        t = helper_table()
-        result = t.get_json_string(header=False, indent=None, separators=(",", ":"))
-        assert (
-            result
-            == """[{"":1,"Field 1":"value 1","Field 2":"value2","Field 3":"value3"},"""
-            """{"":4,"Field 1":"value 4","Field 2":"value5","Field 3":"value6"},"""
-            """{"":7,"Field 1":"value 7","Field 2":"value8","Field 3":"value9"}]"""
-        )
-
-
-class TestHtmlOutput:
-    def test_html_output(self) -> None:
-        t = helper_table()
-        result = t.get_html_string()
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th>Field 2</th>
-            <th>Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>1</td>
-            <td>value 1</td>
-            <td>value2</td>
-            <td>value3</td>
-        </tr>
-        <tr>
-            <td>4</td>
-            <td>value 4</td>
-            <td>value5</td>
-            <td>value6</td>
-        </tr>
-        <tr>
-            <td>7</td>
-            <td>value 7</td>
-            <td>value8</td>
-            <td>value9</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()
-        )
-
-    def test_html_output_formatted(self) -> None:
-        t = helper_table()
-        result = t.get_html_string(format=True)
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_with_title(self) -> None:
-        t = helper_table()
-        t.title = "Title & Title"
-        result = t.get_html_string(attributes={"bgcolor": "red", "a<b": "1<2"})
-        assert (
-            result.strip()
-            == """
-<table bgcolor="red" a&lt;b="1&lt;2">
-    <caption>Title &amp; Title</caption>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th>Field 2</th>
-            <th>Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>1</td>
-            <td>value 1</td>
-            <td>value2</td>
-            <td>value3</td>
-        </tr>
-        <tr>
-            <td>4</td>
-            <td>value 4</td>
-            <td>value5</td>
-            <td>value6</td>
-        </tr>
-        <tr>
-            <td>7</td>
-            <td>value 7</td>
-            <td>value8</td>
-            <td>value9</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()
-        )
-
-    def test_html_output_formatted_with_title(self) -> None:
-        t = helper_table()
-        t.title = "Title & Title"
-        result = t.get_html_string(
-            attributes={"bgcolor": "red", "a<b": "1<2"}, format=True
-        )
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols" bgcolor="red" a&lt;b="1&lt;2">
-    <caption>Title &amp; Title</caption>
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_without_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=False)
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th><em>Field 2</em></th>
-            <th><a href='#'>Field 3</a></th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-</table>
-""".strip()
-        )
-
-    def test_html_output_without_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
-            [
-                1,
-                "<b>value 1</b>",
-                "<span style='text-decoration: underline;'>value2</span>",
-                "<a href='#'>value3</a>",
-            ]
-        )
-        result = t.get_html_string(escape_data=False)
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th>Field 2</th>
-            <th>Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>1</td>
-            <td><b>value 1</b></td>
-            <td><span style='text-decoration: underline;'>value2</span></td>
-            <td><a href='#'>value3</a></td>
-        </tr>
-    </tbody>
-</table>
-""".strip()
-        )
-
-    def test_html_output_with_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=True)
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th>&lt;em&gt;Field 2&lt;/em&gt;</th>
-            <th>&lt;a href=&#x27;#&#x27;&gt;Field 3&lt;/a&gt;</th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-</table>
-""".strip()
-        )
-
-    def test_html_output_with_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
-            [
-                1,
-                "<b>value 1</b>",
-                "<span style='text-decoration: underline;'>value2</span>",
-                "<a href='#'>value3</a>",
-            ]
-        )
-        result = t.get_html_string(escape_data=True)
-        assert (
-            result.strip()
-            == """
-<table>
-    <thead>
-        <tr>
-            <th></th>
-            <th>Field 1</th>
-            <th>Field 2</th>
-            <th>Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>1</td>
-            <td>&lt;b&gt;value 1&lt;/b&gt;</td>
-            <td>&lt;span style=&#x27;text-decoration: underline;&#x27;&gt;value2&lt;/span&gt;</td>
-            <td>&lt;a href=&#x27;#&#x27;&gt;value3&lt;/a&gt;</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_formatted_without_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=False, format=True)
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"><em>Field 2</em></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"><a href='#'>Field 3</a></th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_formatted_without_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
-            [
-                1,
-                "<b>value 1</b>",
-                "<span style='text-decoration: underline;'>value2</span>",
-                "<a href='#'>value3</a>",
-            ]
-        )
-        result = t.get_html_string(escape_data=False, format=True)
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><b>value 1</b></td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><span style='text-decoration: underline;'>value2</span></td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top"><a href='#'>value3</a></td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_formatted_with_escaped_header(self) -> None:
-        t = helper_table(rows=0)
-        t.field_names = ["", "Field 1", "<em>Field 2</em>", "<a href='#'>Field 3</a>"]
-        result = t.get_html_string(escape_header=True, format=True)
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">&lt;em&gt;Field 2&lt;/em&gt;</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">&lt;a href=&#x27;#&#x27;&gt;Field 3&lt;/a&gt;</th>
-        </tr>
-    </thead>
-    <tbody>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-    def test_html_output_formatted_with_escaped_data(self) -> None:
-        t = helper_table(rows=0)
-        t.add_row(
-            [
-                1,
-                "<b>value 1</b>",
-                "<span style='text-decoration: underline;'>value2</span>",
-                "<a href='#'>value3</a>",
-            ]
-        )
-        result = t.get_html_string(escape_data=True, format=True)
-        assert (
-            result.strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;b&gt;value 1&lt;/b&gt;</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;span style=&#x27;text-decoration: underline;&#x27;&gt;value2&lt;/span&gt;</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">&lt;a href=&#x27;#&#x27;&gt;value3&lt;/a&gt;</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-
-class TestPositionalJunctions:
-    """Verify different cases for positional-junction characters"""
-
-    def test_default(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═══════════╦══════╦════════════╦═════════════════╗
-║ City name ║ Area ║ Population ║ Annual Rainfall ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
-║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
-║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
-║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
-║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
-║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
-║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
-╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
-        )
-
-    def test_no_header(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.header = False
-
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═══════════╦══════╦═════════╦════════╗
-║  Adelaide ║ 1295 ║ 1158259 ║ 600.5  ║
-║  Brisbane ║ 5905 ║ 1857594 ║ 1146.4 ║
-║   Darwin  ║ 112  ║  120900 ║ 1714.7 ║
-║   Hobart  ║ 1357 ║  205556 ║ 619.5  ║
-║   Sydney  ║ 2058 ║ 4336374 ║ 1214.8 ║
-║ Melbourne ║ 1566 ║ 3806092 ║ 646.9  ║
-║   Perth   ║ 5386 ║ 1554769 ║ 869.4  ║
-╚═══════════╩══════╩═════════╩════════╝""".strip()
-        )
-
-    def test_with_title(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.title = "Title"
-
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═════════════════════════════════════════════════╗
-║                      Title                      ║
-╠═══════════╦══════╦════════════╦═════════════════╣
-║ City name ║ Area ║ Population ║ Annual Rainfall ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
-║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
-║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
-║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
-║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
-║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
-║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
-╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
-        )
-
-    def test_with_title_no_header(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.title = "Title"
-        city_data_prettytable.header = False
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═════════════════════════════════════╗
-║                Title                ║
-╠═══════════╦══════╦═════════╦════════╣
-║  Adelaide ║ 1295 ║ 1158259 ║ 600.5  ║
-║  Brisbane ║ 5905 ║ 1857594 ║ 1146.4 ║
-║   Darwin  ║ 112  ║  120900 ║ 1714.7 ║
-║   Hobart  ║ 1357 ║  205556 ║ 619.5  ║
-║   Sydney  ║ 2058 ║ 4336374 ║ 1214.8 ║
-║ Melbourne ║ 1566 ║ 3806092 ║ 646.9  ║
-║   Perth   ║ 5386 ║ 1554769 ║ 869.4  ║
-╚═══════════╩══════╩═════════╩════════╝""".strip()
-        )
-
-    def test_hrule_all(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.title = "Title"
-        city_data_prettytable.hrules = HRuleStyle.ALL
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═════════════════════════════════════════════════╗
-║                      Title                      ║
-╠═══════════╦══════╦════════════╦═════════════════╣
-║ City name ║ Area ║ Population ║ Annual Rainfall ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
-╠═══════════╬══════╬════════════╬═════════════════╣
-║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
-╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
-        )
-
-    def test_vrules_none(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.vrules = VRuleStyle.NONE
-        assert (
-            city_data_prettytable.get_string().strip()
-            == "═══════════════════════════════════════════════════\n"
-            "  City name   Area   Population   Annual Rainfall  \n"
-            "═══════════════════════════════════════════════════\n"
-            "   Adelaide   1295    1158259          600.5       \n"
-            "   Brisbane   5905    1857594          1146.4      \n"
-            "    Darwin    112      120900          1714.7      \n"
-            "    Hobart    1357     205556          619.5       \n"
-            "    Sydney    2058    4336374          1214.8      \n"
-            "  Melbourne   1566    3806092          646.9       \n"
-            "    Perth     5386    1554769          869.4       \n"
-            "═══════════════════════════════════════════════════".strip()
-        )
-
-    def test_vrules_frame_with_title(self, city_data_prettytable: PrettyTable) -> None:
-        city_data_prettytable.set_style(TableStyle.DOUBLE_BORDER)
-        city_data_prettytable.vrules = VRuleStyle.FRAME
-        city_data_prettytable.title = "Title"
-        assert (
-            city_data_prettytable.get_string().strip()
-            == """
-╔═════════════════════════════════════════════════╗
-║                      Title                      ║
-╠═════════════════════════════════════════════════╣
-║ City name   Area   Population   Annual Rainfall ║
-╠═════════════════════════════════════════════════╣
-║  Adelaide   1295    1158259          600.5      ║
-║  Brisbane   5905    1857594          1146.4     ║
-║   Darwin    112      120900          1714.7     ║
-║   Hobart    1357     205556          619.5      ║
-║   Sydney    2058    4336374          1214.8     ║
-║ Melbourne   1566    3806092          646.9      ║
-║   Perth     5386    1554769          869.4      ║
-╚═════════════════════════════════════════════════╝""".strip()
-        )
-
-
-class TestStyle:
-    @pytest.mark.parametrize(
-        "style, expected",
-        [
-            pytest.param(
-                TableStyle.DEFAULT,
-                """
-+---+---------+---------+---------+
-|   | Field 1 | Field 2 | Field 3 |
-+---+---------+---------+---------+
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-+---+---------+---------+---------+
-""",
-                id="DEFAULT",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,  # TODO fix
-                """
-|     | Field 1 | Field 2 | Field 3 |
-| :-: | :-----: | :-----: | :-----: |
-|  1  | value 1 |  value2 |  value3 |
-|  4  | value 4 |  value5 |  value6 |
-|  7  | value 7 |  value8 |  value9 |
-""",
-                id="MARKDOWN",
-            ),
-            pytest.param(
-                TableStyle.MSWORD_FRIENDLY,
-                """
-|   | Field 1 | Field 2 | Field 3 |
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-""",
-                id="MSWORD_FRIENDLY",
-            ),
-            pytest.param(
-                TableStyle.ORGMODE,
-                """
-|---+---------+---------+---------|
-|   | Field 1 | Field 2 | Field 3 |
-|---+---------+---------+---------|
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-|---+---------+---------+---------|
-""",
-                id="ORGMODE",
-            ),
-            pytest.param(
-                TableStyle.PLAIN_COLUMNS,
-                """
-         Field 1        Field 2        Field 3        
-1        value 1         value2         value3        
-4        value 4         value5         value6        
-7        value 7         value8         value9
-""",  # noqa: W291
-                id="PLAIN_COLUMNS",
-            ),
-            pytest.param(
-                TableStyle.RANDOM,
-                """
-'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
-%    1     value 1     value2     value3%
-%    4     value 4     value5     value6%
-%    7     value 7     value8     value9%
-'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
-""",
-                id="RANDOM",
-            ),
-            pytest.param(
-                TableStyle.DOUBLE_BORDER,
-                """
-╔═══╦═════════╦═════════╦═════════╗
-║   ║ Field 1 ║ Field 2 ║ Field 3 ║
-╠═══╬═════════╬═════════╬═════════╣
-║ 1 ║ value 1 ║  value2 ║  value3 ║
-║ 4 ║ value 4 ║  value5 ║  value6 ║
-║ 7 ║ value 7 ║  value8 ║  value9 ║
-╚═══╩═════════╩═════════╩═════════╝
-""",
-            ),
-            pytest.param(
-                TableStyle.SINGLE_BORDER,
-                """
-┌───┬─────────┬─────────┬─────────┐
-│   │ Field 1 │ Field 2 │ Field 3 │
-├───┼─────────┼─────────┼─────────┤
-│ 1 │ value 1 │  value2 │  value3 │
-│ 4 │ value 4 │  value5 │  value6 │
-│ 7 │ value 7 │  value8 │  value9 │
-└───┴─────────┴─────────┴─────────┘
-""",
-            ),
-        ],
-    )
-    def test_style(self, style, expected) -> None:
-        # Arrange
-        t = helper_table()
-        random.seed(1234)
-
-        # Act
-        t.set_style(style)
-
-        # Assert
-        result = t.get_string()
-        assert result.strip() == expected.strip()
-
-    def test_style_invalid(self) -> None:
-        # Arrange
-        t = helper_table()
-
-        # Act / Assert
-        # This is an hrule style, not a table style
-        with pytest.raises(ValueError):
-            t.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]
-
-    @pytest.mark.parametrize(
-        "original_style,style, expected",
-        [
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.DEFAULT,
-                """
-+---+---------+---------+---------+
-|   | Field 1 | Field 2 | Field 3 |
-+---+---------+---------+---------+
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-+---+---------+---------+---------+
-""",
-                id="DEFAULT",
-            ),
-            pytest.param(
-                TableStyle.MSWORD_FRIENDLY,
-                TableStyle.MARKDOWN,
-                """
-|     | Field 1 | Field 2 | Field 3 |
-| :-: | :-----: | :-----: | :-----: |
-|  1  | value 1 |  value2 |  value3 |
-|  4  | value 4 |  value5 |  value6 |
-|  7  | value 7 |  value8 |  value9 |
-""",
-                id="MARKDOWN",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.MSWORD_FRIENDLY,
-                """
-|   | Field 1 | Field 2 | Field 3 |
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-""",
-                id="MSWORD_FRIENDLY",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.ORGMODE,
-                """
-|---+---------+---------+---------|
-|   | Field 1 | Field 2 | Field 3 |
-|---+---------+---------+---------|
-| 1 | value 1 |  value2 |  value3 |
-| 4 | value 4 |  value5 |  value6 |
-| 7 | value 7 |  value8 |  value9 |
-|---+---------+---------+---------|
-""",
-                id="ORGMODE",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.PLAIN_COLUMNS,
-                """
-         Field 1        Field 2        Field 3        
-1        value 1         value2         value3        
-4        value 4         value5         value6        
-7        value 7         value8         value9
-""",  # noqa: W291
-                id="PLAIN_COLUMNS",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.RANDOM,
-                """
-'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
-%    1     value 1     value2     value3%
-%    4     value 4     value5     value6%
-%    7     value 7     value8     value9%
-'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
-""",
-                id="RANDOM",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.DOUBLE_BORDER,
-                """
-╔═══╦═════════╦═════════╦═════════╗
-║   ║ Field 1 ║ Field 2 ║ Field 3 ║
-╠═══╬═════════╬═════════╬═════════╣
-║ 1 ║ value 1 ║  value2 ║  value3 ║
-║ 4 ║ value 4 ║  value5 ║  value6 ║
-║ 7 ║ value 7 ║  value8 ║  value9 ║
-╚═══╩═════════╩═════════╩═════════╝
-""",
-                id="DOUBLE_BORDER",
-            ),
-            pytest.param(
-                TableStyle.MARKDOWN,
-                TableStyle.SINGLE_BORDER,
-                """
-┌───┬─────────┬─────────┬─────────┐
-│   │ Field 1 │ Field 2 │ Field 3 │
-├───┼─────────┼─────────┼─────────┤
-│ 1 │ value 1 │  value2 │  value3 │
-│ 4 │ value 4 │  value5 │  value6 │
-│ 7 │ value 7 │  value8 │  value9 │
-└───┴─────────┴─────────┴─────────┘
-""",
-                id="SINGLE_BORDER",
-            ),
-        ],
-    )
-    def test_style_reset(self, original_style, style, expected) -> None:
-        """
-            Testing to ensure that default styling is reset between changes
-            of styles on a PrettyTable
-
-        Args:
-            style (str): Style to be used (Default, markdown, etc)
-            expected (str): The expected format of style as a string representation
-        """
-        # Arrange
-        t = helper_table()
-        random.seed(1234)
-
-        # Act
-        t.set_style(original_style)
-        t.set_style(style)
-
-        # Assert
-        result = t.get_string()
-        assert result.strip() == expected.strip()
-
-    @pytest.mark.parametrize(
-        "style, expected",
-        [
-            pytest.param(
-                TableStyle.MARKDOWN,
-                """
-| l |  c  | r | Align left | Align centre | Align right |
-| :-| :-: |-: | :----------| :----------: |-----------: |
-| 1 |  2  | 3 | value 1    |    value2    |      value3 |
-| 4 |  5  | 6 | value 4    |    value5    |      value6 |
-| 7 |  8  | 9 | value 7    |    value8    |      value9 |
-""",
-                id="MARKDOWN",
-            ),
-        ],
-    )
-    def test_style_align(self, style, expected) -> None:
-        # Arrange
-        t = PrettyTable(["l", "c", "r", "Align left", "Align centre", "Align right"])
-        v = 1
-        for row in range(3):
-            # Some have spaces, some not, to help test padding columns of
-            # different widths
-            t.add_row([v, v + 1, v + 2, f"value {v}", f"value{v + 1}", f"value{v + 2}"])
-            v += 3
-
-        # Act
-        t.set_style(style)
-        t.align["l"] = t.align["Align left"] = "l"
-        t.align["c"] = t.align["Align centre"] = "c"
-        t.align["r"] = t.align["Align right"] = "r"
-
-        # Assert
-        result = t.get_string()
-        assert result.strip() == expected.strip()
 
 
 class TestCsvOutput:
@@ -1958,223 +807,7 @@ class TestCsvOutput:
         )
 
 
-class TestLatexOutput:
-    def test_latex_output(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string() == (
-            "\\begin{tabular}{cccc}\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\end{tabular}"
-        )
-        options = {"fields": ["Field 1", "Field 3"]}
-        assert t.get_latex_string(**options) == (
-            "\\begin{tabular}{cc}\r\n"
-            "Field 1 & Field 3 \\\\\r\n"
-            "value 1 & value3 \\\\\r\n"
-            "value 4 & value6 \\\\\r\n"
-            "value 7 & value9 \\\\\r\n"
-            "\\end{tabular}"
-        )
-
-    def test_latex_output_formatted(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string(format=True) == (
-            "\\begin{tabular}{|c|c|c|c|}\r\n"
-            "\\hline\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\hline\r\n"
-            "\\end{tabular}"
-        )
-
-        options = {"fields": ["Field 1", "Field 3"]}
-        assert t.get_latex_string(format=True, **options) == (
-            "\\begin{tabular}{|c|c|}\r\n"
-            "\\hline\r\n"
-            "Field 1 & Field 3 \\\\\r\n"
-            "value 1 & value3 \\\\\r\n"
-            "value 4 & value6 \\\\\r\n"
-            "value 7 & value9 \\\\\r\n"
-            "\\hline\r\n"
-            "\\end{tabular}"
-        )
-
-        options = {"vrules": VRuleStyle.FRAME}
-        assert t.get_latex_string(format=True, **options) == (
-            "\\begin{tabular}{|cccc|}\r\n"
-            "\\hline\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\hline\r\n"
-            "\\end{tabular}"
-        )
-
-        options = {"hrules": HRuleStyle.ALL}
-        assert t.get_latex_string(format=True, **options) == (
-            "\\begin{tabular}{|c|c|c|c|}\r\n"
-            "\\hline\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "\\hline\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "\\hline\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "\\hline\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\hline\r\n"
-            "\\end{tabular}"
-        )
-
-    def test_latex_output_header(self) -> None:
-        t = helper_table()
-        assert t.get_latex_string(format=True, hrules=HRuleStyle.HEADER) == (
-            "\\begin{tabular}{|c|c|c|c|}\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "\\hline\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\end{tabular}"
-        )
-
-
-class TestJSONConstructor:
-    def test_json_and_back(self, city_data_prettytable: PrettyTable) -> None:
-        json_string = city_data_prettytable.get_json_string()
-        new_table = from_json(json_string)
-        assert new_table.get_string() == city_data_prettytable.get_string()
-
-
-class TestHtmlConstructor:
-    def test_html_and_back(self, city_data_prettytable: PrettyTable) -> None:
-        html_string = city_data_prettytable.get_html_string()
-        new_table = from_html(html_string)[0]
-        assert new_table.get_string() == city_data_prettytable.get_string()
-
-    def test_html_one_and_back(self, city_data_prettytable: PrettyTable) -> None:
-        html_string = city_data_prettytable.get_html_string()
-        new_table = from_html_one(html_string)
-        assert new_table.get_string() == city_data_prettytable.get_string()
-
-    def test_html_one_fail_on_many(self, city_data_prettytable: PrettyTable) -> None:
-        html_string = city_data_prettytable.get_html_string()
-        html_string += city_data_prettytable.get_html_string()
-        with pytest.raises(ValueError):
-            from_html_one(html_string)
-
-
-@pytest.fixture
-def japanese_pretty_table() -> PrettyTable:
-    table = PrettyTable(["Kanji", "Hiragana", "English"])
-    table.add_row(["神戸", "こうべ", "Kobe"])
-    table.add_row(["京都", "きょうと", "Kyoto"])
-    table.add_row(["長崎", "ながさき", "Nagasaki"])
-    table.add_row(["名古屋", "なごや", "Nagoya"])
-    table.add_row(["大阪", "おおさか", "Osaka"])
-    table.add_row(["札幌", "さっぽろ", "Sapporo"])
-    table.add_row(["東京", "とうきょう", "Tokyo"])
-    table.add_row(["横浜", "よこはま", "Yokohama"])
-    return table
-
-
-@pytest.fixture
-def emoji_pretty_table() -> PrettyTable:
-    thunder1 = [
-        '\033[38;5;226m _`/""\033[38;5;250m.-.    \033[0m',
-        "\033[38;5;226m  ,\\_\033[38;5;250m(   ).  \033[0m",
-        "\033[38;5;226m   /\033[38;5;250m(___(__) \033[0m",
-        "\033[38;5;228;5m    ⚡\033[38;5;111;25mʻ ʻ\033[38;5;228;5m"
-        "⚡\033[38;5;111;25mʻ ʻ \033[0m",
-        "\033[38;5;111m    ʻ ʻ ʻ ʻ  \033[0m",
-    ]
-    thunder2 = [
-        "\033[38;5;240;1m     .-.     \033[0m",
-        "\033[38;5;240;1m    (   ).   \033[0m",
-        "\033[38;5;240;1m   (___(__)  \033[0m",
-        "\033[38;5;21;1m  ‚ʻ\033[38;5;228;5m⚡\033[38;5;21;25mʻ‚\033[38;5;228;5m"
-        "⚡\033[38;5;21;25m‚ʻ   \033[0m",
-        "\033[38;5;21;1m  ‚ʻ‚ʻ\033[38;5;228;5m⚡\033[38;5;21;25mʻ‚ʻ   \033[0m",
-    ]
-    table = PrettyTable(["Thunderbolt", "Lightning"])
-    for i in range(len(thunder1)):
-        table.add_row([thunder1[i], thunder2[i]])
-    return table
-
-
-class TestMultiPattern:
-    @pytest.mark.parametrize(
-        ["pt", "expected_output", "test_type"],
-        [
-            (
-                lf("city_data_prettytable"),
-                """
-+-----------+------+------------+-----------------+
-| City name | Area | Population | Annual Rainfall |
-+-----------+------+------------+-----------------+
-|  Adelaide | 1295 |  1158259   |      600.5      |
-|  Brisbane | 5905 |  1857594   |      1146.4     |
-|   Darwin  | 112  |   120900   |      1714.7     |
-|   Hobart  | 1357 |   205556   |      619.5      |
-|   Sydney  | 2058 |  4336374   |      1214.8     |
-| Melbourne | 1566 |  3806092   |      646.9      |
-|   Perth   | 5386 |  1554769   |      869.4      |
-+-----------+------+------------+-----------------+
-""",
-                "English Table",
-            ),
-            (
-                lf("japanese_pretty_table"),
-                """
-+--------+------------+----------+
-| Kanji  |  Hiragana  | English  |
-+--------+------------+----------+
-|  神戸  |   こうべ   |   Kobe   |
-|  京都  |  きょうと  |  Kyoto   |
-|  長崎  |  ながさき  | Nagasaki |
-| 名古屋 |   なごや   |  Nagoya  |
-|  大阪  |  おおさか  |  Osaka   |
-|  札幌  |  さっぽろ  | Sapporo  |
-|  東京  | とうきょう |  Tokyo   |
-|  横浜  |  よこはま  | Yokohama |
-+--------+------------+----------+
-
-""",
-                "Japanese table",
-            ),
-            (
-                lf("emoji_pretty_table"),
-                """
-+-----------------+-----------------+
-|   Thunderbolt   |    Lightning    |
-+-----------------+-----------------+
-|  \x1b[38;5;226m _`/""\x1b[38;5;250m.-.    \x1b[0m  |  \x1b[38;5;240;1m     .-.     \x1b[0m  |
-|  \x1b[38;5;226m  ,\\_\x1b[38;5;250m(   ).  \x1b[0m  |  \x1b[38;5;240;1m    (   ).   \x1b[0m  |
-|  \x1b[38;5;226m   /\x1b[38;5;250m(___(__) \x1b[0m  |  \x1b[38;5;240;1m   (___(__)  \x1b[0m  |
-| \x1b[38;5;228;5m    ⚡\x1b[38;5;111;25mʻ ʻ\x1b[38;5;228;5m⚡\x1b[38;5;111;25mʻ ʻ \x1b[0m | \x1b[38;5;21;1m  ‚ʻ\x1b[38;5;228;5m⚡\x1b[38;5;21;25mʻ‚\x1b[38;5;228;5m⚡\x1b[38;5;21;25m‚ʻ   \x1b[0m |
-|  \x1b[38;5;111m    ʻ ʻ ʻ ʻ  \x1b[0m  |  \x1b[38;5;21;1m  ‚ʻ‚ʻ\x1b[38;5;228;5m⚡\x1b[38;5;21;25mʻ‚ʻ   \x1b[0m |
-+-----------------+-----------------+
-            """,  # noqa: E501
-                "Emoji table",
-            ),
-        ],
-    )
-    def test_multi_pattern_outputs(
-        self, pt: PrettyTable, expected_output: str, test_type: str
-    ) -> None:
-        printed_table = pt.get_string()
-        assert (
-            printed_table.strip() == expected_output.strip()
-        ), f"Error output for test output of type {test_type}"
-
-
 def test_paginate() -> None:
-    # Arrange
     t = helper_table(rows=7)
     expected_page_1 = """
 +----+----------+---------+---------+
@@ -2196,58 +829,31 @@ def test_paginate() -> None:
 +----+----------+---------+---------+
 """.strip()
 
-    # Act
     paginated = t.paginate(page_length=4)
-
-    # Assert
     paginated = paginated.strip()
     assert paginated.startswith(expected_page_1)
     assert "\f" in paginated
     assert paginated.endswith(expected_page_2)
 
-    # Act
     paginated = t.paginate(page_length=4, line_break="\n")
-
-    # Assert
     assert "\f" not in paginated
     assert "\n" in paginated
 
 
-def test_add_rows() -> None:
-    """A table created with multiple add_row calls
-    is the same as one created with a single add_rows
-    """
-    # Arrange
-    table1 = PrettyTable(["A", "B", "C"])
-    table2 = PrettyTable(["A", "B", "C"])
-    table1.add_row([1, 2, 3])
-    table1.add_row([4, 5, 6])
-    rows = [
-        [1, 2, 3],
-        [4, 5, 6],
-    ]
-
-    # Act
-    table2.add_rows(rows)
-
-    # Assert
-    assert str(table1) == str(table2)
-
-
-def test_autoindex(city_data_prettytable: PrettyTable) -> None:
+def test_autoindex(city_data: PrettyTable) -> None:
     """Testing that a table with a custom index row is
     equal to the one produced by the function
     .add_autoindex()
     """
-    city_data_prettytable.field_names = TEST_TABLE_HEADER
-    city_data_prettytable.add_autoindex(fieldname="Test")
+    city_data.field_names = CITY_DATA_HEADER
+    city_data.add_autoindex(fieldname="Test")
 
     table2 = PrettyTable()
-    table2.field_names = ["Test"] + TEST_TABLE_HEADER
-    for idx, row in enumerate(TEST_TABLE):
+    table2.field_names = ["Test"] + CITY_DATA_HEADER
+    for idx, row in enumerate(CITY_DATA):
         table2.add_row([idx + 1] + row)
 
-    assert str(city_data_prettytable) == str(table2)
+    assert str(city_data) == str(table2)
 
 
 @pytest.fixture(scope="function")
@@ -2321,12 +927,10 @@ class TestCustomFormatter:
             e.value
         )
 
-    def test_use_custom_formatter_for_int(
-        self, city_data_prettytable: PrettyTable
-    ) -> None:
-        city_data_prettytable.custom_format["Annual Rainfall"] = lambda n, v: f"{v:.2f}"
+    def test_use_custom_formatter_for_int(self, city_data: PrettyTable) -> None:
+        city_data.custom_format["Annual Rainfall"] = lambda n, v: f"{v:.2f}"
         assert (
-            city_data_prettytable.get_string().strip()
+            city_data.get_string().strip()
             == """
 +-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
@@ -2397,7 +1001,84 @@ class TestRepr:
         assert row_prettytable._repr_html_() == row_prettytable.get_html_string()
 
 
-class TestMinTableWidth:
+class TestBreakOnHyphens:
+    row = [
+        "bluedevil breeze breeze-gtk eos-bash-shared glib2 "
+        "kactivitymanagerd kde-cli-tools kde-gtk-config kdecoration"
+    ]
+    EXPECTED_TRUE = """+------------------------------------------+
+|                 Field 1                  |
++------------------------------------------+
+|  bluedevil breeze breeze-gtk eos-bash-   |
+| shared glib2 kactivitymanagerd kde-cli-  |
+|     tools kde-gtk-config kdecoration     |
++------------------------------------------+"""
+    EXPECTED_FALSE = """+------------------------------------------+
+|                 Field 1                  |
++------------------------------------------+
+|       bluedevil breeze breeze-gtk        |
+| eos-bash-shared glib2 kactivitymanagerd  |
+| kde-cli-tools kde-gtk-config kdecoration |
++------------------------------------------+"""
+
+    def test_break_on_hyphens(self) -> None:
+        table = PrettyTable(max_width=40)
+        table.break_on_hyphens = False
+        assert not table.break_on_hyphens
+        table.add_row(self.row)
+        assert table.get_string().strip() == self.EXPECTED_FALSE
+
+    def test_break_on_hyphens_on_init(self) -> None:
+        table = PrettyTable(max_width=40, break_on_hyphens=False)
+        assert not table._break_on_hyphens
+        assert not table.break_on_hyphens
+        table.add_row(self.row)
+        assert table.get_string().strip() == self.EXPECTED_FALSE
+
+    def test_break_on_hyphens_default(self) -> None:
+        table = PrettyTable(max_width=40)
+        assert table.break_on_hyphens
+        table.add_row(self.row)
+        assert table.get_string().strip() == self.EXPECTED_TRUE
+
+
+class TestWidth:
+    colored = "\033[31mC\033[32mO\033[31mL\033[32mO\033[31mR\033[32mE\033[31mD\033[0m"
+
+    def test_color(self) -> None:
+        table = PrettyTable(["Field 1", "Field 2"])
+        table.add_row([self.colored, self.colored])
+        table.add_row(["nothing", "neither"])
+        result = table.get_string()
+        assert (
+            result.strip()
+            == f"""
++---------+---------+
+| Field 1 | Field 2 |
++---------+---------+
+| {self.colored} | {self.colored} |
+| nothing | neither |
++---------+---------+
+""".strip()
+        )
+
+    def test_reset(self) -> None:
+        table = PrettyTable(["Field 1", "Field 2"])
+        table.add_row(["abc def\033(B", "\033[31mabc def\033[m"])
+        table.add_row(["nothing", "neither"])
+        result = table.get_string()
+        assert (
+            result.strip()
+            == """
++---------+---------+
+| Field 1 | Field 2 |
++---------+---------+
+| abc def\033(B | \033[31mabc def\033[m |
+| nothing | neither |
++---------+---------+
+""".strip()
+        )
+
     @pytest.mark.parametrize(
         "loops, fields, desired_width, border, internal_border",
         [
@@ -2449,49 +1130,6 @@ class TestMinTableWidth:
                     desired_width,
                 ]
 
-
-class TestBreakOnHyphens:
-    row = [
-        "bluedevil breeze breeze-gtk eos-bash-shared glib2 "
-        "kactivitymanagerd kde-cli-tools kde-gtk-config kdecoration"
-    ]
-    EXPECTED_TRUE = """+------------------------------------------+
-|                 Field 1                  |
-+------------------------------------------+
-|  bluedevil breeze breeze-gtk eos-bash-   |
-| shared glib2 kactivitymanagerd kde-cli-  |
-|     tools kde-gtk-config kdecoration     |
-+------------------------------------------+"""
-    EXPECTED_FALSE = """+------------------------------------------+
-|                 Field 1                  |
-+------------------------------------------+
-|       bluedevil breeze breeze-gtk        |
-| eos-bash-shared glib2 kactivitymanagerd  |
-| kde-cli-tools kde-gtk-config kdecoration |
-+------------------------------------------+"""
-
-    def test_break_on_hyphens(self) -> None:
-        table = PrettyTable(max_width=40)
-        table.break_on_hyphens = False
-        assert not table.break_on_hyphens
-        table.add_row(self.row)
-        assert table.get_string().strip() == self.EXPECTED_FALSE
-
-    def test_break_on_hyphens_on_init(self) -> None:
-        table = PrettyTable(max_width=40, break_on_hyphens=False)
-        assert not table._break_on_hyphens
-        assert not table.break_on_hyphens
-        table.add_row(self.row)
-        assert table.get_string().strip() == self.EXPECTED_FALSE
-
-    def test_break_on_hyphens_default(self) -> None:
-        table = PrettyTable(max_width=40)
-        assert table.break_on_hyphens
-        table.add_row(self.row)
-        assert table.get_string().strip() == self.EXPECTED_TRUE
-
-
-class TestMaxTableWidth:
     def test_max_table_width(self) -> None:
         table = PrettyTable()
         table.max_table_width = 5
@@ -2568,9 +1206,8 @@ class TestMaxTableWidth:
 +---+-----------------+---+-----------------+---+-----------------+""".strip()
         )
 
-    @pytest.mark.parametrize("set_with_parameter", [True, False])
-    def test_table_max_width_wo_header_width(self, set_with_parameter) -> None:
-        # Arrange
+    @pytest.mark.parametrize("set_width_parameter", [True, False])
+    def test_table_max_width_wo_header_width(self, set_width_parameter) -> None:
         headers = [
             "A Field Name",
             "B Field Name",
@@ -2592,15 +1229,13 @@ class TestMaxTableWidth:
 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
 +---+---+---+---+---+---+---+---+---+---+----+----+"""
 
-        # Act
-        if set_with_parameter:
+        if set_width_parameter:
             table = PrettyTable(headers, use_header_width=False)
         else:
             table = PrettyTable(headers)
             table.use_header_width = False
         table.add_row(row)
 
-        # Assert
         assert table.get_string() == expected
 
     def test_table_width_on_init_wo_columns(self) -> None:
@@ -2721,51 +1356,6 @@ class TestMaxTableWidth:
 +--------+--------------+------------+""".strip()
         )
 
-    def test_table_formatted_html_autoindex(self) -> None:
-        """See also #199"""
-        table = PrettyTable(["Field 1", "Field 2", "Field 3"])
-        for row in range(1, 3 * 3, 3):
-            table.add_row(
-                [f"value {row*100}", f"value {row+1*100}", f"value {row+2*100}"]
-            )
-        table.format = True
-        table.add_autoindex("I")
-
-        assert (
-            table.get_html_string().strip()
-            == """
-<table frame="box" rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">I</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 100</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 101</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 201</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">2</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 400</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 104</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 204</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">3</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 700</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 107</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 207</td>
-        </tr>
-    </tbody>
-</table>""".strip()  # noqa: E501
-        )
-
     def test_max_table_width_wide_vrules_frame(self) -> None:
         table = PrettyTable()
         table.max_table_width = 52
@@ -2834,10 +1424,10 @@ class TestMaxTableWidth:
 class TestFields:
     def test_fields_at_class_declaration(self) -> None:
         table = PrettyTable(
-            field_names=TEST_TABLE_HEADER,
+            field_names=CITY_DATA_HEADER,
             fields=["City name", "Annual Rainfall"],
         )
-        for row in TEST_TABLE:
+        for row in CITY_DATA:
             table.add_row(row)
         assert (
             """+-----------+-----------------+
@@ -2856,9 +1446,9 @@ class TestFields:
 
     def test_fields(self) -> None:
         table = PrettyTable()
-        table.field_names = TEST_TABLE_HEADER
+        table.field_names = CITY_DATA_HEADER
         table.fields = ["City name", "Annual Rainfall"]
-        for row in TEST_TABLE:
+        for row in CITY_DATA:
             table.add_row(row)
         assert (
             """+-----------+-----------------+
@@ -2876,90 +1466,10 @@ class TestFields:
         )
 
 
-class TestPreservingInternalBorders:
-    def test_internal_border_preserved(self) -> None:
-        pt = helper_table()
-        pt.border = False
-        pt.preserve_internal_border = True
-
-        assert (
-            pt.get_string().strip()
-            == """
-   | Field 1 | Field 2 | Field 3  
----+---------+---------+---------
- 1 | value 1 |  value2 |  value3  
- 4 | value 4 |  value5 |  value6  
- 7 | value 7 |  value8 |  value9  
-""".strip()  # noqa: W291
-        )
-
-    def test_internal_border_preserved_latex(self) -> None:
-        pt = helper_table()
-        pt.border = False
-        pt.format = True
-        pt.preserve_internal_border = True
-
-        assert pt.get_latex_string().strip() == (
-            "\\begin{tabular}{c|c|c|c}\r\n"
-            " & Field 1 & Field 2 & Field 3 \\\\\r\n"
-            "1 & value 1 & value2 & value3 \\\\\r\n"
-            "4 & value 4 & value5 & value6 \\\\\r\n"
-            "7 & value 7 & value8 & value9 \\\\\r\n"
-            "\\end{tabular}"
-        )
-
-    def test_internal_border_preserved_html(self) -> None:
-        pt = helper_table()
-        pt.format = True
-        pt.border = False
-        pt.preserve_internal_border = True
-
-        assert (
-            pt.get_html_string().strip()
-            == """
-<table rules="cols">
-    <thead>
-        <tr>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
-            <th style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
-        </tr>
-        <tr>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
-            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
-        </tr>
-    </tbody>
-</table>
-""".strip()  # noqa: E501
-        )
-
-
 class TestGeneralOutput:
     def test_copy(self) -> None:
-        # Arrange
         t = helper_table()
-
-        # Act
         t_copy = t.copy()
-
-        # Assert
         assert t.get_string() == t_copy.get_string()
 
     def test_text(self) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -210,7 +210,7 @@ class TestBuildEquivalence:
         assert left_hand.get_latex_string() == right_hand.get_latex_string()
 
 
-class TestDeleteColumn:
+class TestDelete:
     def test_delete_column(self, col_prettytable: PrettyTable) -> None:
         col_prettytable.del_column("Area")
 
@@ -234,6 +234,27 @@ class TestDeleteColumn:
     ) -> None:
         with pytest.raises(ValueError):
             col_prettytable.del_column("City not-a-name")
+
+    def test_delete_row(self, city_data: PrettyTable) -> None:
+        city_data.del_row(2)
+
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+|   Hobart  | 1357 |   205556   |      619.5      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+| Melbourne | 1566 |  3806092   |      646.9      |
+|   Perth   | 5386 |  1554769   |      869.4      |
++-----------+------+------------+-----------------+"""
+        )
+
+    def test_delete_row_unavailable(self, city_data: PrettyTable) -> None:
+        with pytest.raises(IndexError):
+            city_data.del_row(10)
 
 
 class TestFieldNameLessTable:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -786,7 +786,7 @@ class TestFromDB:
 
 
 class TestCsvOutput:
-    def test_csv_output(self, helper_table) -> None:
+    def test_csv_output(self, helper_table: PrettyTable) -> None:
         assert helper_table.get_csv_string(delimiter="\t", header=False) == (
             "1\tvalue 1\tvalue2\tvalue3\r\n"
             "4\tvalue 4\tvalue5\tvalue6\r\n"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -77,16 +77,18 @@ class TestNoneOption:
         )
 
     def test_replace_none_all(self) -> None:
-        table = PrettyTable(["Field 1", "Field 2", "Field 3"], none_format="N/A")
-        table.add_row(["value 1", None, "None"])
+        table = PrettyTable(
+            ["Field 1", "Field 2", "Field 3", "Field 4"], none_format="N/A"
+        )
+        table.add_row(["value 1", None, "None", ""])
         assert (
             table.get_string().strip()
             == """
-+---------+---------+---------+
-| Field 1 | Field 2 | Field 3 |
-+---------+---------+---------+
-| value 1 |   N/A   |   N/A   |
-+---------+---------+---------+
++---------+---------+---------+---------+
+| Field 1 | Field 2 | Field 3 | Field 4 |
++---------+---------+---------+---------+
+| value 1 |   N/A   |   N/A   |         |
++---------+---------+---------+---------+
 """.strip()
         )
 
@@ -295,9 +297,8 @@ def aligned_before_table() -> PrettyTable:
 
 
 @pytest.fixture(scope="function")
-def aligned_after_table(field_name_less_table) -> PrettyTable:
+def aligned_after_table() -> PrettyTable:
     table = PrettyTable()
-    table.align = "r"
     table.field_names = CITY_DATA_HEADER
     for row in CITY_DATA:
         table.add_row(row)
@@ -336,13 +337,13 @@ class TestOptionOverride:
     def test_border(self, city_data: PrettyTable) -> None:
         assert city_data.get_string() != city_data.get_string(border=False)
 
-    def test_header(self, city_data) -> None:
+    def test_header(self, city_data: PrettyTable) -> None:
         assert city_data.get_string() != city_data.get_string(header=False)
 
-    def test_hrules_all(self, city_data) -> None:
+    def test_hrules_all(self, city_data: PrettyTable) -> None:
         assert city_data.get_string() != city_data.get_string(hrules=HRuleStyle.ALL)
 
-    def test_hrules_none(self, city_data) -> None:
+    def test_hrules_none(self, city_data: PrettyTable) -> None:
         assert city_data.get_string() != city_data.get_string(hrules=HRuleStyle.NONE)
 
 
@@ -351,7 +352,7 @@ class TestOptionAttribute:
     Also make sure option settings are copied correctly when a table is cloned by
     slicing."""
 
-    def test_set_for_all_columns(self, city_data) -> None:
+    def test_set_for_all_columns(self, city_data: PrettyTable) -> None:
         city_data.field_names = sorted(city_data.field_names)
         city_data.align = "l"
         city_data.max_width = 10

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -43,7 +43,7 @@ class TestClearing:
         assert helper_table.dividers == []
         assert helper_table.field_names == ["", "Field 1", "Field 2", "Field 3"]
 
-    def test_clear(self, helper_table) -> None:
+    def test_clear(self, helper_table: PrettyTable) -> None:
         helper_table.add_row([0, "a", "b", "c"], divider=True)
         helper_table.clear()
         assert helper_table.rows == []

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from test_prettytable import helper_table
-
 from prettytable import PrettyTable, TableStyle
 
 
@@ -38,18 +36,16 @@ class TestRowEndSection:
 
 
 class TestClearing:
-    def test_clear_rows(self) -> None:
-        t = helper_table()
-        t.add_row([0, "a", "b", "c"], divider=True)
-        t.clear_rows()
-        assert t.rows == []
-        assert t.dividers == []
-        assert t.field_names == ["", "Field 1", "Field 2", "Field 3"]
+    def test_clear_rows(self, helper_table) -> None:
+        helper_table.add_row([0, "a", "b", "c"], divider=True)
+        helper_table.clear_rows()
+        assert helper_table.rows == []
+        assert helper_table.dividers == []
+        assert helper_table.field_names == ["", "Field 1", "Field 2", "Field 3"]
 
-    def test_clear(self) -> None:
-        t = helper_table()
-        t.add_row([0, "a", "b", "c"], divider=True)
-        t.clear()
-        assert t.rows == []
-        assert t.dividers == []
-        assert t.field_names == []
+    def test_clear(self, helper_table) -> None:
+        helper_table.add_row([0, "a", "b", "c"], divider=True)
+        helper_table.clear()
+        assert helper_table.rows == []
+        assert helper_table.dividers == []
+        assert helper_table.field_names == []

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -36,7 +36,7 @@ class TestRowEndSection:
 
 
 class TestClearing:
-    def test_clear_rows(self, helper_table) -> None:
+    def test_clear_rows(self, helper_table: PrettyTable) -> None:
         helper_table.add_row([0, "a", "b", "c"], divider=True)
         helper_table.clear_rows()
         assert helper_table.rows == []

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from test_prettytable import CITY_DATA, CITY_DATA_HEADER
+
+from prettytable import PrettyTable
+
+
+class TestSorting:
+    def test_sort_by_different_per_columns(self, city_data: PrettyTable) -> None:
+        city_data.sortby = city_data.field_names[0]
+        old = city_data.get_string()
+        for field in city_data.field_names[1:]:
+            city_data.sortby = field
+            new = city_data.get_string()
+            assert new != old
+
+    def test_reverse_sort(self, city_data: PrettyTable) -> None:
+        for field in city_data.field_names:
+            city_data.sortby = field
+            city_data.reversesort = False
+            forward = city_data.get_string()
+            city_data.reversesort = True
+            backward = city_data.get_string()
+            forward_lines = forward.split("\n")[2:]  # Discard header lines
+            backward_lines = backward.split("\n")[2:]
+            backward_lines.reverse()
+            assert forward_lines == backward_lines
+
+    def test_sort_key(self, city_data: PrettyTable) -> None:
+        # Test sorting by length of city name
+        def key(vals):
+            vals[0] = len(vals[0])
+            return vals
+
+        city_data.sortby = "City name"
+        city_data.sort_key = key
+        assert (
+            city_data.get_string().strip()
+            == """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|   Perth   | 5386 |  1554769   |      869.4      |
+|   Darwin  | 112  |   120900   |      1714.7     |
+|   Hobart  | 1357 |   205556   |      619.5      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+| Melbourne | 1566 |  3806092   |      646.9      |
++-----------+------+------------+-----------------+
+""".strip()
+        )
+
+    def test_sort_key_at_class_declaration(self) -> None:
+        # Test sorting by length of city name
+        def key(vals):
+            vals[0] = len(vals[0])
+            return vals
+
+        table = PrettyTable(
+            field_names=CITY_DATA_HEADER,
+            sortby="City name",
+            sort_key=key,
+        )
+        assert table.sort_key == key
+        for row in CITY_DATA:
+            table.add_row(row)
+        assert (
+            """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|   Perth   | 5386 |  1554769   |      869.4      |
+|   Darwin  | 112  |   120900   |      1714.7     |
+|   Hobart  | 1357 |   205556   |      619.5      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+| Melbourne | 1566 |  3806092   |      646.9      |
++-----------+------+------------+-----------------+"""
+            == table.get_string().strip()
+        )
+
+    def test_sort_slice(self) -> None:
+        """Make sure sorting and slicing interact in the expected way"""
+        table = PrettyTable(["Foo"])
+        for i in range(20, 0, -1):
+            table.add_row([i])
+        new_style = table.get_string(sortby="Foo", end=10)
+        assert "10" in new_style
+        assert "20" not in new_style
+        oldstyle = table.get_string(sortby="Foo", end=10, oldsortslice=True)
+        assert "10" not in oldstyle
+        assert "20" in oldstyle
+
+    def test_sortby_at_class_declaration(self) -> None:
+        """
+        Fix #354 where initialization of a table with sortby fails
+        """
+        table = PrettyTable(
+            field_names=CITY_DATA_HEADER,
+            sortby="Area",
+        )
+        assert table.sortby == "Area"
+        for row in CITY_DATA:
+            table.add_row(row)
+        assert (
+            """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|   Darwin  | 112  |   120900   |      1714.7     |
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|   Hobart  | 1357 |   205556   |      619.5      |
+| Melbourne | 1566 |  3806092   |      646.9      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+|   Perth   | 5386 |  1554769   |      869.4      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
++-----------+------+------------+-----------------+"""
+            == table.get_string().strip()
+        )

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+from pytest_lazy_fixtures import lf
+from test_prettytable import helper_table
+
+from prettytable import HRuleStyle, PrettyTable, TableStyle, VRuleStyle
+
+
+class TestPositionalJunctions:
+    """Verify different cases for positional-junction characters"""
+
+    def test_default(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═══════════╦══════╦════════════╦═════════════════╗
+║ City name ║ Area ║ Population ║ Annual Rainfall ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
+║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
+║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
+║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
+║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
+║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
+║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
+╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
+        )
+
+    def test_no_header(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.header = False
+
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═══════════╦══════╦═════════╦════════╗
+║  Adelaide ║ 1295 ║ 1158259 ║ 600.5  ║
+║  Brisbane ║ 5905 ║ 1857594 ║ 1146.4 ║
+║   Darwin  ║ 112  ║  120900 ║ 1714.7 ║
+║   Hobart  ║ 1357 ║  205556 ║ 619.5  ║
+║   Sydney  ║ 2058 ║ 4336374 ║ 1214.8 ║
+║ Melbourne ║ 1566 ║ 3806092 ║ 646.9  ║
+║   Perth   ║ 5386 ║ 1554769 ║ 869.4  ║
+╚═══════════╩══════╩═════════╩════════╝""".strip()
+        )
+
+    def test_with_title(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.title = "Title"
+
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═════════════════════════════════════════════════╗
+║                      Title                      ║
+╠═══════════╦══════╦════════════╦═════════════════╣
+║ City name ║ Area ║ Population ║ Annual Rainfall ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
+║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
+║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
+║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
+║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
+║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
+║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
+╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
+        )
+
+    def test_with_title_no_header(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.title = "Title"
+        city_data.header = False
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═════════════════════════════════════╗
+║                Title                ║
+╠═══════════╦══════╦═════════╦════════╣
+║  Adelaide ║ 1295 ║ 1158259 ║ 600.5  ║
+║  Brisbane ║ 5905 ║ 1857594 ║ 1146.4 ║
+║   Darwin  ║ 112  ║  120900 ║ 1714.7 ║
+║   Hobart  ║ 1357 ║  205556 ║ 619.5  ║
+║   Sydney  ║ 2058 ║ 4336374 ║ 1214.8 ║
+║ Melbourne ║ 1566 ║ 3806092 ║ 646.9  ║
+║   Perth   ║ 5386 ║ 1554769 ║ 869.4  ║
+╚═══════════╩══════╩═════════╩════════╝""".strip()
+        )
+
+    def test_hrule_all(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.title = "Title"
+        city_data.hrules = HRuleStyle.ALL
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═════════════════════════════════════════════════╗
+║                      Title                      ║
+╠═══════════╦══════╦════════════╦═════════════════╣
+║ City name ║ Area ║ Population ║ Annual Rainfall ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║  Adelaide ║ 1295 ║  1158259   ║      600.5      ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║  Brisbane ║ 5905 ║  1857594   ║      1146.4     ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║   Darwin  ║ 112  ║   120900   ║      1714.7     ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║   Hobart  ║ 1357 ║   205556   ║      619.5      ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║   Sydney  ║ 2058 ║  4336374   ║      1214.8     ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║ Melbourne ║ 1566 ║  3806092   ║      646.9      ║
+╠═══════════╬══════╬════════════╬═════════════════╣
+║   Perth   ║ 5386 ║  1554769   ║      869.4      ║
+╚═══════════╩══════╩════════════╩═════════════════╝""".strip()
+        )
+
+    def test_vrules_none(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.vrules = VRuleStyle.NONE
+        assert (
+            city_data.get_string().strip()
+            == "═══════════════════════════════════════════════════\n"
+            "  City name   Area   Population   Annual Rainfall  \n"
+            "═══════════════════════════════════════════════════\n"
+            "   Adelaide   1295    1158259          600.5       \n"
+            "   Brisbane   5905    1857594          1146.4      \n"
+            "    Darwin    112      120900          1714.7      \n"
+            "    Hobart    1357     205556          619.5       \n"
+            "    Sydney    2058    4336374          1214.8      \n"
+            "  Melbourne   1566    3806092          646.9       \n"
+            "    Perth     5386    1554769          869.4       \n"
+            "═══════════════════════════════════════════════════".strip()
+        )
+
+    def test_vrules_frame_with_title(self, city_data: PrettyTable) -> None:
+        city_data.set_style(TableStyle.DOUBLE_BORDER)
+        city_data.vrules = VRuleStyle.FRAME
+        city_data.title = "Title"
+        assert (
+            city_data.get_string().strip()
+            == """
+╔═════════════════════════════════════════════════╗
+║                      Title                      ║
+╠═════════════════════════════════════════════════╣
+║ City name   Area   Population   Annual Rainfall ║
+╠═════════════════════════════════════════════════╣
+║  Adelaide   1295    1158259          600.5      ║
+║  Brisbane   5905    1857594          1146.4     ║
+║   Darwin    112      120900          1714.7     ║
+║   Hobart    1357     205556          619.5      ║
+║   Sydney    2058    4336374          1214.8     ║
+║ Melbourne   1566    3806092          646.9      ║
+║   Perth     5386    1554769          869.4      ║
+╚═════════════════════════════════════════════════╝""".strip()
+        )
+
+
+class TestStyle:
+    @pytest.mark.parametrize(
+        "style, expected",
+        [
+            pytest.param(
+                TableStyle.DEFAULT,
+                """
++---+---------+---------+---------+
+|   | Field 1 | Field 2 | Field 3 |
++---+---------+---------+---------+
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
++---+---------+---------+---------+
+""",
+                id="DEFAULT",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,  # TODO fix
+                """
+|     | Field 1 | Field 2 | Field 3 |
+| :-: | :-----: | :-----: | :-----: |
+|  1  | value 1 |  value2 |  value3 |
+|  4  | value 4 |  value5 |  value6 |
+|  7  | value 7 |  value8 |  value9 |
+""",
+                id="MARKDOWN",
+            ),
+            pytest.param(
+                TableStyle.MSWORD_FRIENDLY,
+                """
+|   | Field 1 | Field 2 | Field 3 |
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+""",
+                id="MSWORD_FRIENDLY",
+            ),
+            pytest.param(
+                TableStyle.ORGMODE,
+                """
+|---+---------+---------+---------|
+|   | Field 1 | Field 2 | Field 3 |
+|---+---------+---------+---------|
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+|---+---------+---------+---------|
+""",
+                id="ORGMODE",
+            ),
+            pytest.param(
+                TableStyle.PLAIN_COLUMNS,
+                """
+         Field 1        Field 2        Field 3        
+1        value 1         value2         value3        
+4        value 4         value5         value6        
+7        value 7         value8         value9
+""",  # noqa: W291
+                id="PLAIN_COLUMNS",
+            ),
+            pytest.param(
+                TableStyle.RANDOM,
+                """
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+%    1     value 1     value2     value3%
+%    4     value 4     value5     value6%
+%    7     value 7     value8     value9%
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+""",
+                id="RANDOM",
+            ),
+            pytest.param(
+                TableStyle.DOUBLE_BORDER,
+                """
+╔═══╦═════════╦═════════╦═════════╗
+║   ║ Field 1 ║ Field 2 ║ Field 3 ║
+╠═══╬═════════╬═════════╬═════════╣
+║ 1 ║ value 1 ║  value2 ║  value3 ║
+║ 4 ║ value 4 ║  value5 ║  value6 ║
+║ 7 ║ value 7 ║  value8 ║  value9 ║
+╚═══╩═════════╩═════════╩═════════╝
+""",
+            ),
+            pytest.param(
+                TableStyle.SINGLE_BORDER,
+                """
+┌───┬─────────┬─────────┬─────────┐
+│   │ Field 1 │ Field 2 │ Field 3 │
+├───┼─────────┼─────────┼─────────┤
+│ 1 │ value 1 │  value2 │  value3 │
+│ 4 │ value 4 │  value5 │  value6 │
+│ 7 │ value 7 │  value8 │  value9 │
+└───┴─────────┴─────────┴─────────┘
+""",
+            ),
+        ],
+    )
+    def test_style(self, style, expected) -> None:
+        t = helper_table()
+        random.seed(1234)
+        t.set_style(style)
+        assert t.get_string().strip() == expected.strip()
+
+    def test_style_invalid(self) -> None:
+        t = helper_table()
+        # This is an hrule style, not a table style
+        with pytest.raises(ValueError):
+            t.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "original_style,style, expected",
+        [
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.DEFAULT,
+                """
++---+---------+---------+---------+
+|   | Field 1 | Field 2 | Field 3 |
++---+---------+---------+---------+
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
++---+---------+---------+---------+
+""",
+                id="DEFAULT",
+            ),
+            pytest.param(
+                TableStyle.MSWORD_FRIENDLY,
+                TableStyle.MARKDOWN,
+                """
+|     | Field 1 | Field 2 | Field 3 |
+| :-: | :-----: | :-----: | :-----: |
+|  1  | value 1 |  value2 |  value3 |
+|  4  | value 4 |  value5 |  value6 |
+|  7  | value 7 |  value8 |  value9 |
+""",
+                id="MARKDOWN",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.MSWORD_FRIENDLY,
+                """
+|   | Field 1 | Field 2 | Field 3 |
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+""",
+                id="MSWORD_FRIENDLY",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.ORGMODE,
+                """
+|---+---------+---------+---------|
+|   | Field 1 | Field 2 | Field 3 |
+|---+---------+---------+---------|
+| 1 | value 1 |  value2 |  value3 |
+| 4 | value 4 |  value5 |  value6 |
+| 7 | value 7 |  value8 |  value9 |
+|---+---------+---------+---------|
+""",
+                id="ORGMODE",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.PLAIN_COLUMNS,
+                """
+         Field 1        Field 2        Field 3        
+1        value 1         value2         value3        
+4        value 4         value5         value6        
+7        value 7         value8         value9
+""",  # noqa: W291
+                id="PLAIN_COLUMNS",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.RANDOM,
+                """
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+%    1     value 1     value2     value3%
+%    4     value 4     value5     value6%
+%    7     value 7     value8     value9%
+'^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^'
+""",
+                id="RANDOM",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.DOUBLE_BORDER,
+                """
+╔═══╦═════════╦═════════╦═════════╗
+║   ║ Field 1 ║ Field 2 ║ Field 3 ║
+╠═══╬═════════╬═════════╬═════════╣
+║ 1 ║ value 1 ║  value2 ║  value3 ║
+║ 4 ║ value 4 ║  value5 ║  value6 ║
+║ 7 ║ value 7 ║  value8 ║  value9 ║
+╚═══╩═════════╩═════════╩═════════╝
+""",
+                id="DOUBLE_BORDER",
+            ),
+            pytest.param(
+                TableStyle.MARKDOWN,
+                TableStyle.SINGLE_BORDER,
+                """
+┌───┬─────────┬─────────┬─────────┐
+│   │ Field 1 │ Field 2 │ Field 3 │
+├───┼─────────┼─────────┼─────────┤
+│ 1 │ value 1 │  value2 │  value3 │
+│ 4 │ value 4 │  value5 │  value6 │
+│ 7 │ value 7 │  value8 │  value9 │
+└───┴─────────┴─────────┴─────────┘
+""",
+                id="SINGLE_BORDER",
+            ),
+        ],
+    )
+    def test_style_reset(self, original_style, style, expected) -> None:
+        """
+            Testing to ensure that default styling is reset between changes
+            of styles on a PrettyTable
+
+        Args:
+            style (str): Style to be used (Default, markdown, etc)
+            expected (str): The expected format of style as a string representation
+        """
+        t = helper_table()
+        random.seed(1234)
+        t.set_style(original_style)
+        t.set_style(style)
+        assert t.get_string().strip() == expected.strip()
+
+    @pytest.mark.parametrize(
+        "style, expected",
+        [
+            pytest.param(
+                TableStyle.MARKDOWN,
+                """
+| l |  c  | r | Align left | Align centre | Align right |
+| :-| :-: |-: | :----------| :----------: |-----------: |
+| 1 |  2  | 3 | value 1    |    value2    |      value3 |
+| 4 |  5  | 6 | value 4    |    value5    |      value6 |
+| 7 |  8  | 9 | value 7    |    value8    |      value9 |
+""",
+                id="MARKDOWN",
+            ),
+        ],
+    )
+    def test_style_align(self, style, expected) -> None:
+        t = PrettyTable(["l", "c", "r", "Align left", "Align centre", "Align right"])
+        v = 1
+        for row in range(3):
+            # Some have spaces, some not, to help test padding columns of
+            # different widths
+            t.add_row([v, v + 1, v + 2, f"value {v}", f"value{v + 1}", f"value{v + 2}"])
+            v += 3
+
+        t.set_style(style)
+        t.align["l"] = t.align["Align left"] = "l"
+        t.align["c"] = t.align["Align centre"] = "c"
+        t.align["r"] = t.align["Align right"] = "r"
+        assert t.get_string().strip() == expected.strip()
+
+
+@pytest.fixture
+def japanese_pretty_table() -> PrettyTable:
+    table = PrettyTable(["Kanji", "Hiragana", "English"])
+    table.add_row(["神戸", "こうべ", "Kobe"])
+    table.add_row(["京都", "きょうと", "Kyoto"])
+    table.add_row(["長崎", "ながさき", "Nagasaki"])
+    table.add_row(["名古屋", "なごや", "Nagoya"])
+    table.add_row(["大阪", "おおさか", "Osaka"])
+    table.add_row(["札幌", "さっぽろ", "Sapporo"])
+    table.add_row(["東京", "とうきょう", "Tokyo"])
+    table.add_row(["横浜", "よこはま", "Yokohama"])
+    return table
+
+
+@pytest.fixture
+def emoji_pretty_table() -> PrettyTable:
+    thunder1 = [
+        '\033[38;5;226m _`/""\033[38;5;250m.-.    \033[0m',
+        "\033[38;5;226m  ,\\_\033[38;5;250m(   ).  \033[0m",
+        "\033[38;5;226m   /\033[38;5;250m(___(__) \033[0m",
+        "\033[38;5;228;5m    ⚡\033[38;5;111;25mʻ ʻ\033[38;5;228;5m"
+        "⚡\033[38;5;111;25mʻ ʻ \033[0m",
+        "\033[38;5;111m    ʻ ʻ ʻ ʻ  \033[0m",
+    ]
+    thunder2 = [
+        "\033[38;5;240;1m     .-.     \033[0m",
+        "\033[38;5;240;1m    (   ).   \033[0m",
+        "\033[38;5;240;1m   (___(__)  \033[0m",
+        "\033[38;5;21;1m  ‚ʻ\033[38;5;228;5m⚡\033[38;5;21;25mʻ‚\033[38;5;228;5m"
+        "⚡\033[38;5;21;25m‚ʻ   \033[0m",
+        "\033[38;5;21;1m  ‚ʻ‚ʻ\033[38;5;228;5m⚡\033[38;5;21;25mʻ‚ʻ   \033[0m",
+    ]
+    table = PrettyTable(["Thunderbolt", "Lightning"])
+    for i in range(len(thunder1)):
+        table.add_row([thunder1[i], thunder2[i]])
+    return table
+
+
+class TestMultiPattern:
+    @pytest.mark.parametrize(
+        ["pt", "expected_output", "test_type"],
+        [
+            (
+                lf("city_data"),
+                """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+|   Darwin  | 112  |   120900   |      1714.7     |
+|   Hobart  | 1357 |   205556   |      619.5      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+| Melbourne | 1566 |  3806092   |      646.9      |
+|   Perth   | 5386 |  1554769   |      869.4      |
++-----------+------+------------+-----------------+
+""",
+                "English Table",
+            ),
+            (
+                lf("japanese_pretty_table"),
+                """
++--------+------------+----------+
+| Kanji  |  Hiragana  | English  |
++--------+------------+----------+
+|  神戸  |   こうべ   |   Kobe   |
+|  京都  |  きょうと  |  Kyoto   |
+|  長崎  |  ながさき  | Nagasaki |
+| 名古屋 |   なごや   |  Nagoya  |
+|  大阪  |  おおさか  |  Osaka   |
+|  札幌  |  さっぽろ  | Sapporo  |
+|  東京  | とうきょう |  Tokyo   |
+|  横浜  |  よこはま  | Yokohama |
++--------+------------+----------+
+
+""",
+                "Japanese table",
+            ),
+            (
+                lf("emoji_pretty_table"),
+                """
++-----------------+-----------------+
+|   Thunderbolt   |    Lightning    |
++-----------------+-----------------+
+|  \x1b[38;5;226m _`/""\x1b[38;5;250m.-.    \x1b[0m  |  \x1b[38;5;240;1m     .-.     \x1b[0m  |
+|  \x1b[38;5;226m  ,\\_\x1b[38;5;250m(   ).  \x1b[0m  |  \x1b[38;5;240;1m    (   ).   \x1b[0m  |
+|  \x1b[38;5;226m   /\x1b[38;5;250m(___(__) \x1b[0m  |  \x1b[38;5;240;1m   (___(__)  \x1b[0m  |
+| \x1b[38;5;228;5m    ⚡\x1b[38;5;111;25mʻ ʻ\x1b[38;5;228;5m⚡\x1b[38;5;111;25mʻ ʻ \x1b[0m | \x1b[38;5;21;1m  ‚ʻ\x1b[38;5;228;5m⚡\x1b[38;5;21;25mʻ‚\x1b[38;5;228;5m⚡\x1b[38;5;21;25m‚ʻ   \x1b[0m |
+|  \x1b[38;5;111m    ʻ ʻ ʻ ʻ  \x1b[0m  |  \x1b[38;5;21;1m  ‚ʻ‚ʻ\x1b[38;5;228;5m⚡\x1b[38;5;21;25mʻ‚ʻ   \x1b[0m |
++-----------------+-----------------+
+            """,  # noqa: E501
+                "Emoji table",
+            ),
+        ],
+    )
+    def test_multi_pattern_outputs(
+        self, pt: PrettyTable, expected_output: str, test_type: str
+    ) -> None:
+        printed_table = pt.get_string()
+        assert (
+            printed_table.strip() == expected_output.strip()
+        ), f"Error output for test output of type {test_type}"

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -376,7 +376,7 @@ class TestStyle:
             ),
         ],
     )
-    def test_style_reset(self, helper_table, original_style, style, expected) -> None:
+    def test_style_reset(self, helper_table: PrettyTable, original_style: TableStyle, style: TableStyle, expected: str) -> None:
         """
             Testing to ensure that default styling is reset between changes
             of styles on a PrettyTable

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -262,7 +262,7 @@ class TestStyle:
         helper_table.set_style(style)
         assert helper_table.get_string().strip() == expected.strip()
 
-    def test_style_invalid(self, helper_table) -> None:
+    def test_style_invalid(self, helper_table: PrettyTable) -> None:
         # This is an hrule style, not a table style
         with pytest.raises(ValueError):
             helper_table.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -4,7 +4,6 @@ import random
 
 import pytest
 from pytest_lazy_fixtures import lf
-from test_prettytable import helper_table
 
 from prettytable import HRuleStyle, PrettyTable, TableStyle, VRuleStyle
 
@@ -258,17 +257,15 @@ class TestStyle:
             ),
         ],
     )
-    def test_style(self, style, expected) -> None:
-        t = helper_table()
+    def test_style(self, helper_table, style, expected) -> None:
         random.seed(1234)
-        t.set_style(style)
-        assert t.get_string().strip() == expected.strip()
+        helper_table.set_style(style)
+        assert helper_table.get_string().strip() == expected.strip()
 
-    def test_style_invalid(self) -> None:
-        t = helper_table()
+    def test_style_invalid(self, helper_table) -> None:
         # This is an hrule style, not a table style
         with pytest.raises(ValueError):
-            t.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]
+            helper_table.set_style(HRuleStyle.ALL)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
         "original_style,style, expected",
@@ -377,7 +374,7 @@ class TestStyle:
             ),
         ],
     )
-    def test_style_reset(self, original_style, style, expected) -> None:
+    def test_style_reset(self, helper_table, original_style, style, expected) -> None:
         """
             Testing to ensure that default styling is reset between changes
             of styles on a PrettyTable
@@ -386,11 +383,10 @@ class TestStyle:
             style (str): Style to be used (Default, markdown, etc)
             expected (str): The expected format of style as a string representation
         """
-        t = helper_table()
         random.seed(1234)
-        t.set_style(original_style)
-        t.set_style(style)
-        assert t.get_string().strip() == expected.strip()
+        helper_table.set_style(original_style)
+        helper_table.set_style(style)
+        assert helper_table.get_string().strip() == expected.strip()
 
     @pytest.mark.parametrize(
         "style, expected",

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -257,7 +257,7 @@ class TestStyle:
             ),
         ],
     )
-    def test_style(self, helper_table, style, expected) -> None:
+    def test_style(self, helper_table: PrettyTable, style: TableStyle, expected: str) -> None:
         random.seed(1234)
         helper_table.set_style(style)
         assert helper_table.get_string().strip() == expected.strip()

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -376,7 +376,13 @@ class TestStyle:
             ),
         ],
     )
-    def test_style_reset(self, helper_table: PrettyTable, original_style: TableStyle, style: TableStyle, expected: str) -> None:
+    def test_style_reset(
+        self,
+        helper_table: PrettyTable,
+        original_style: TableStyle,
+        style: TableStyle,
+        expected: str,
+    ) -> None:
         """
             Testing to ensure that default styling is reset between changes
             of styles on a PrettyTable

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -453,8 +453,8 @@ def emoji_pretty_table() -> PrettyTable:
         "\033[38;5;21;1m  ‚ʻ‚ʻ\033[38;5;228;5m⚡\033[38;5;21;25mʻ‚ʻ   \033[0m",
     ]
     table = PrettyTable(["Thunderbolt", "Lightning"])
-    for i in range(len(thunder1)):
-        table.add_row([thunder1[i], thunder2[i]])
+    for i, t1 in enumerate(thunder1):
+        table.add_row([t1, thunder2[i]])
     return table
 
 
@@ -518,7 +518,6 @@ class TestMultiPattern:
     def test_multi_pattern_outputs(
         self, pt: PrettyTable, expected_output: str, test_type: str
     ) -> None:
-        printed_table = pt.get_string()
         assert (
-            printed_table.strip() == expected_output.strip()
+            pt.get_string().strip() == expected_output.strip()
         ), f"Error output for test output of type {test_type}"

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -257,7 +257,9 @@ class TestStyle:
             ),
         ],
     )
-    def test_style(self, helper_table: PrettyTable, style: TableStyle, expected: str) -> None:
+    def test_style(
+        self, helper_table: PrettyTable, style: TableStyle, expected: str
+    ) -> None:
         random.seed(1234)
         helper_table.set_style(style)
         assert helper_table.get_string().strip() == expected.strip()


### PR DESCRIPTION
After comments from @hugovk I thought about refactoring the tests:

* splitted tests into several files
* Only one definition of city test data
* use a fixture with city test data where possible
* moved helper_table into a fixture

WDYT?