### PR TITLE
Added export/import to MediaWiki tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ This string is guaranteed to look exactly the same as what would be printed by d
 your table to a file or insert it into a GUI.
 
 The table can be displayed in several different formats using `get_formatted_string` by
-changing the `out_format=<text|html|json|csv|latex>`. This function passes through
+changing the `out_format=<text|html|json|csv|latex|mediawiki>`. This function passes through
 arguments to the functions that render the table, so additional arguments can be given.
 This provides a way to let a user choose the output formatting.
 
@@ -599,6 +599,10 @@ table.
 PrettyTable will also print your tables in JSON, as a list of fields and an array of
 rows. Just like in ASCII form, you can actually get a string representation - just use
 `get_json_string()`.
+
+### Displaying your table in MediaWiki Markup
+
+PrettyTable can also print your tables in MediaWiki table markup, making it easy to format tables for wikis. Similar to the ASCII format, you can get a string representation using get_mediawiki_string().
 
 ### Displaying your table in HTML form
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ This string is guaranteed to look exactly the same as what would be printed by d
 your table to a file or insert it into a GUI.
 
 The table can be displayed in several different formats using `get_formatted_string` by
-changing the `out_format=<text|html|json|csv|latex|mediawiki>`. This function passes through
-arguments to the functions that render the table, so additional arguments can be given.
-This provides a way to let a user choose the output formatting.
+changing the `out_format=<text|html|json|csv|latex|mediawiki>`. This function passes
+through arguments to the functions that render the table, so additional arguments can be
+given. This provides a way to let a user choose the output formatting.
 
 ```python
 def my_cli_function(table_format: str = 'text'):
@@ -638,7 +638,9 @@ rows. Just like in ASCII form, you can actually get a string representation - ju
 
 ### Displaying your table in MediaWiki Markup
 
-PrettyTable can also print your tables in MediaWiki table markup, making it easy to format tables for wikis. Similar to the ASCII format, you can get a string representation using get_mediawiki_string().
+PrettyTable can also print your tables in MediaWiki table markup, making it easy to
+format tables for wikis. Similar to the ASCII format, you can get a string
+representation using get_mediawiki_string().
 
 ### Displaying your table in HTML form
 


### PR DESCRIPTION
Directly referencing issue #297  (Mediawiki output), I've added in the necessary functionality of integrating mediawiki tables as a potential output format. First, made the changes to get_formatted_string() function


       if out_format == "mediawiki": return self.get_mediawiki_string(**kwargs)

Next, I've added a new get_mediawiki_string() function that returns a string representation of the table in MediaWiki table markup.

I've also added in a from_mediawiki() function that takes in a multiline string of mediawiki markdown and converts it to a prettytable.

Lastly, I've also updated the documentation to reflect the changes.