### PR TITLE
Add MediaWiki table support

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ PrettyTable will also print your tables in JSON, as a list of fields and an arra
 rows. Just like in ASCII form, you can actually get a string representation - just use
 `get_json_string()`.
 
-### Displaying your table in MediaWiki Markup
+### Displaying your table in MediaWiki markup
 
 PrettyTable can also print your tables in MediaWiki table markup, making it easy to
 format tables for wikis. Similar to the ASCII format, you can get a string

--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ This string is guaranteed to look exactly the same as what would be printed by d
 your table to a file or insert it into a GUI.
 
 The table can be displayed in several different formats using `get_formatted_string` by
-changing the `out_format=<text|html|json|csv|latex>`. This function passes through
-arguments to the functions that render the table, so additional arguments can be given.
-This provides a way to let a user choose the output formatting.
+changing the `out_format=<text|html|json|csv|latex|mediawiki>`. This function passes
+through arguments to the functions that render the table, so additional arguments can be
+given. This provides a way to let a user choose the output formatting.
 
 ```python
 def my_cli_function(table_format: str = 'text'):
@@ -635,6 +635,12 @@ table.
 PrettyTable will also print your tables in JSON, as a list of fields and an array of
 rows. Just like in ASCII form, you can actually get a string representation - just use
 `get_json_string()`.
+
+### Displaying your table in MediaWiki Markup
+
+PrettyTable can also print your tables in MediaWiki table markup, making it easy to
+format tables for wikis. Similar to the ASCII format, you can get a string
+representation using `get_mediawiki_string()`.
 
 ### Displaying your table in HTML form
 

--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -28,6 +28,7 @@ from .prettytable import (  # noqa: F401
     from_html,
     from_html_one,
     from_json,
+    from_mediawiki,
 )
 
 __all__ = [
@@ -55,6 +56,7 @@ __all__ = [
     "from_html",
     "from_html_one",
     "from_json",
+    "from_mediawiki",
 ]
 
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1797,10 +1797,12 @@ class PrettyTable:
             return self.get_csv_string(**kwargs)
         if out_format == "latex":
             return self.get_latex_string(**kwargs)
+        if out_format == "mediawiki":
+            return self.get_mediawiki_string(**kwargs)
 
         msg = (
             f"Invalid format {out_format}. "
-            "Must be one of: text, html, json, csv, or latex"
+            "Must be one of: text, html, json, csv, latex or mediawiki"
         )
         raise ValueError(msg)
 
@@ -2773,6 +2775,70 @@ class PrettyTable:
 
         return "\r\n".join(lines)
 
+    ##############################
+    # MEDIAWIKI STRING METHODS   #
+    ##############################
+
+    def get_mediawiki_string(self, **kwargs) -> str:
+        """
+        Return string representation of the table in MediaWiki table markup.
+        The generated markup follows simple MediaWiki syntax. For example:
+            {| class="wikitable"
+            |+ Optional caption
+            |-
+            ! Header1 !! Header2 !! Header3
+            |-
+            | Data1 || Data2 || Data3
+            |-
+            | Data4 || Data5 || Data6
+            |}
+        """
+
+        options = self._get_options(kwargs)
+        lines: list[str] = []
+
+        if (
+            options.get("attributes")
+            and isinstance(options["attributes"], dict)
+            and options["attributes"]
+        ):
+            attr_str = " ".join(f'{k}="{v}"' for k, v in options["attributes"].items())
+            lines.append("{| " + attr_str)
+        else:
+            lines.append('{| class="wikitable"')
+
+        caption = options.get("title", self._title)
+        if caption:
+            lines.append("|+ " + caption)
+
+        if options.get("header"):
+            lines.append("|-")
+            headers = []
+            fields_option = options.get("fields")
+            for field in self._field_names:
+                if fields_option is not None and field not in fields_option:
+                    continue
+                headers.append(field)
+            if headers:
+                header_line = " !! ".join(headers)
+                lines.append("! " + header_line)
+
+        rows = self._get_rows(options)
+        formatted_rows = self._format_rows(rows)
+        for row in formatted_rows:
+            lines.append("|-")
+            cells = []
+            fields_option = options.get("fields")
+            for field, cell in zip(self._field_names, row):
+                if fields_option is not None and field not in fields_option:
+                    continue
+                cells.append(cell)
+            if cells:
+                lines.append("| " + " || ".join(cells))
+
+        lines.append("|}")
+        return "\n".join(lines)
+
 
 ##############################
 # UNICODE WIDTH FUNCTION     #
@@ -2945,6 +3011,53 @@ def from_html_one(html_code: str, **kwargs) -> PrettyTable:
         msg = "More than one <table> in provided HTML code. Use from_html instead."
         raise ValueError(msg)
     return tables[0]
+
+
+def from_mediawiki(wiki_text: str, **kwargs) -> PrettyTable:
+    """
+    Returns a PrettyTable instance from simple MediaWiki table markup.
+    Note that the table should have a header row.
+    Arguments:
+    wiki_text -- Multiline string containing MediaWiki table markup
+    (Enter within '''   ''')
+    """
+    lines = wiki_text.strip().split("\n")
+    table = PrettyTable(**kwargs)
+    header = None
+    rows = []
+    inside_table = False
+    for line in lines:
+        line = line.strip()
+        if line.startswith("{|"):
+            inside_table = True
+            continue
+        if line.startswith("|}"):
+            break
+        if not inside_table:
+            continue
+        if line.startswith("|-"):
+            continue
+        if line.startswith("|+"):
+            continue
+        if line.startswith("!"):
+            header = [cell.strip() for cell in re.split(r"\s*!!\s*", line[1:])]
+            table.field_names = header
+            continue
+        if line.startswith("|"):
+            row_data = [cell.strip() for cell in re.split(r"\s*\|\|\s*", line[1:])]
+            rows.append(row_data)
+            continue
+
+    if header:
+        for row in rows:
+            if len(row) != len(header):
+                error_message = "Row length mismatch between header and body."
+                raise ValueError(error_message)
+            table.add_row(row)
+    else:
+        msg = "No valid header found in the MediaWiki table."
+        raise ValueError(msg)
+    return table
 
 
 def _warn_deprecation(name: str, module_globals: dict[str, Any]) -> Any:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import io
 import pytest
 from test_prettytable import CITY_DATA, CITY_DATA_HEADER
 
-from prettytable import PrettyTable, from_csv
+from prettytable import PrettyTable, from_csv, from_mediawiki
 
 
 @pytest.fixture(scope="function")
@@ -33,6 +33,18 @@ def city_data_from_csv() -> PrettyTable:
         csv_string += "\n" + ",".join(str(fld) for fld in row)
     csv_fp = io.StringIO(csv_string)
     return from_csv(csv_fp)
+
+
+@pytest.fixture(scope="function")
+def city_data_from_mediawiki() -> PrettyTable:
+    wiki_text = '{| class="wikitable"\n'
+    wiki_text += "|-\n"
+    wiki_text += "! " + " !! ".join(CITY_DATA_HEADER) + "\n"
+    for row in CITY_DATA:
+        wiki_text += "|-\n"
+        wiki_text += "| " + " || ".join(str(item) for item in row) + "\n"
+    wiki_text += "|}"
+    return from_mediawiki(wiki_text)
 
 
 @pytest.fixture

--- a/tests/test_mediawiki.py
+++ b/tests/test_mediawiki.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import pytest
+
+from prettytable import PrettyTable, from_mediawiki
+
+
+class TestMediaWikiOutput:
+    def test_mediawiki_output(self, helper_table: PrettyTable) -> None:
+        assert (
+            helper_table.get_mediawiki_string(header=True).strip()
+            == """
+{| class="wikitable"
+|-
+!  !! Field 1 !! Field 2 !! Field 3
+|-
+| 1 || value 1 || value2 || value3
+|-
+| 4 || value 4 || value5 || value6
+|-
+| 7 || value 7 || value8 || value9
+|}
+""".strip()
+        )
+
+    def test_mediawiki_output_without_header(self, helper_table: PrettyTable) -> None:
+        assert (
+            helper_table.get_mediawiki_string(header=False).strip()
+            == """
+{| class="wikitable"
+|-
+| 1 || value 1 || value2 || value3
+|-
+| 4 || value 4 || value5 || value6
+|-
+| 7 || value 7 || value8 || value9
+|}
+""".strip()
+        )
+
+    def test_mediawiki_output_with_caption(self, helper_table: PrettyTable) -> None:
+        assert (
+            helper_table.get_mediawiki_string(
+                title="Optional caption", header=True
+            ).strip()
+            == """
+{| class="wikitable"
+|+ Optional caption
+|-
+!  !! Field 1 !! Field 2 !! Field 3
+|-
+| 1 || value 1 || value2 || value3
+|-
+| 4 || value 4 || value5 || value6
+|-
+| 7 || value 7 || value8 || value9
+|}
+""".strip()
+        )
+
+    def test_mediawiki_output_with_attributes(self, helper_table: PrettyTable) -> None:
+        assert (
+            helper_table.get_mediawiki_string(
+                attributes={"class": "mytable", "id": "table1"}, header=True
+            ).strip()
+            == """
+{| class="mytable" id="table1"
+|-
+!  !! Field 1 !! Field 2 !! Field 3
+|-
+| 1 || value 1 || value2 || value3
+|-
+| 4 || value 4 || value5 || value6
+|-
+| 7 || value 7 || value8 || value9
+|}
+            """.strip()
+        )
+
+    def test_mediawiki_output_with_fields_option(
+        self, helper_table: PrettyTable
+    ) -> None:
+        assert (
+            helper_table.get_mediawiki_string(
+                fields=["Field 1", "Field 3"], header=True
+            ).strip()
+            == """
+{| class="wikitable"
+|-
+! Field 1 !! Field 3
+|-
+| value 1 || value3
+|-
+| value 4 || value6
+|-
+| value 7 || value9
+|}
+            """.strip()
+        )
+
+
+class TestMediaWikiConstructor:
+    def test_mediawiki_and_back(self, city_data: PrettyTable) -> None:
+        mediawiki_string = city_data.get_mediawiki_string()
+        new_table = from_mediawiki(mediawiki_string)
+        assert new_table.get_string() == city_data.get_string()
+
+    def test_from_mediawiki_ignores_non_table_text(
+        self, city_data: PrettyTable
+    ) -> None:
+        wiki_table = city_data.get_mediawiki_string()
+        wiki_text = f"Before table text.\n{wiki_table}\nAfter table text."
+        table = from_mediawiki(wiki_text)
+        output = table.get_string()
+
+        for header in city_data.field_names:
+            assert header in output
+        for row in city_data._rows:
+            for cell in row:
+                assert str(cell) in output
+        assert "Before table text." not in output
+        assert "After table text." not in output
+
+    def test_from_mediawiki_ignores_caption(self) -> None:
+        wiki_text = """
+{| class="wikitable"
+|+ Optional caption
+|-
+! Field 1 !! Field 2
+|-
+| value 1 || value2
+|-
+| value 4 || value5
+|}
+    """
+        table = from_mediawiki(wiki_text)
+        output = table.get_string()
+        assert "Optional caption" not in output
+        assert "value 1" in output
+
+    def test_from_mediawiki_no_header(self) -> None:
+        wiki_text = """
+{| class="wikitable"
+|-
+| value 1 || value2
+|-
+| value 4 || value5
+|-
+| value 7 || value8
+|}
+    """
+        with pytest.raises(
+            ValueError, match="No valid header found in the MediaWiki table."
+        ):
+            from_mediawiki(wiki_text)
+
+    def test_from_mediawiki_row_length_mismatch(self) -> None:
+        wiki_text = """
+{| class="wikitable"
+|-
+! Field 1 !! Field 2
+|-
+| value 1 || value2 || value3
+|-
+| value 4 || value5 || value6
+|}
+    """
+        with pytest.raises(
+            ValueError, match="Row length mismatch between header and body."
+        ):
+            from_mediawiki(wiki_text)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -212,6 +212,24 @@ class TestBuildEquivalence:
     ) -> None:
         assert left_hand.get_latex_string() == right_hand.get_latex_string()
 
+    @pytest.mark.parametrize(
+        ["left_hand", "right_hand"],
+        [
+            (
+                lf("row_prettytable"),
+                lf("col_prettytable"),
+            ),
+            (
+                lf("row_prettytable"),
+                lf("mix_prettytable"),
+            ),
+        ],
+    )
+    def test_equivalence_mediawiki(
+        self, left_hand: PrettyTable, right_hand: PrettyTable
+    ) -> None:
+        assert left_hand.get_mediawiki_string() == right_hand.get_mediawiki_string()
+
 
 class TestDelete:
     def test_delete_column(self, col_prettytable: PrettyTable) -> None:
@@ -278,6 +296,11 @@ class TestFieldNameLessTable:
         assert "Field 1 & Field 2 & Field 3 & Field 4 \\\\" in output
         assert "Adelaide & 1295 & 1158259 & 600.5 \\\\" in output
 
+    def test_can_string_mediawiki(self, field_name_less_table: PrettyTable) -> None:
+        output = field_name_less_table.get_mediawiki_string(header=True)
+        assert "! Field 1 !! Field 2 !! Field 3 !! Field 4" in output
+        assert "| Adelaide || 1295 || 1158259 || 600.5" in output
+
     def test_add_field_names_later(self, field_name_less_table: PrettyTable) -> None:
         field_name_less_table.field_names = CITY_DATA_HEADER
         assert (
@@ -329,6 +352,13 @@ class TestAlignment:
             aligned_before_table.get_latex_string()
             == aligned_after_table.get_latex_string()
         )
+
+    def test_aligned_mediawiki(
+        self, aligned_before_table: PrettyTable, aligned_after_table: PrettyTable
+    ) -> None:
+        assert aligned_before_table.get_mediawiki_string(
+            header=True
+        ) == aligned_after_table.get_mediawiki_string(header=True)
 
 
 class TestOptionOverride:
@@ -558,6 +588,18 @@ class TestBasic:
     def test_all_lengths_equal_from_csv(self, city_data_from_csv: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
         self._test_all_length_equal(city_data_from_csv)
+
+    def test_no_blank_lines_from_mediawiki(
+        self, city_data_from_mediawiki: PrettyTable
+    ) -> None:
+        """No table should ever have blank lines in it."""
+        self._test_no_blank_lines(city_data_from_mediawiki)
+
+    def test_all_lengths_equal_from_mediawiki(
+        self, city_data_from_mediawiki: PrettyTable
+    ) -> None:
+        """All lines in a table should be of the same length."""
+        self._test_all_length_equal(city_data_from_mediawiki)
 
     def test_rowcount(self, city_data: PrettyTable) -> None:
         assert city_data.rowcount == 7
@@ -1510,6 +1552,11 @@ class TestGeneralOutput:
         assert helper_table.get_formatted_string(
             "latex", border=False
         ) == helper_table.get_latex_string(border=False)
+
+    def test_mediawiki(self, helper_table: PrettyTable) -> None:
+        assert helper_table.get_formatted_string(
+            "mediawiki", border=False
+        ) == helper_table.get_mediawiki_string(border=False)
 
     def test_invalid(self, helper_table: PrettyTable) -> None:
         with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #297.

I've addressed the enhancement request made in issue #297 and also the suggestions made while working on this issue.   I've added in the necessary functionality of integrating simple mediawiki table markdown as a potential input/output format. After the recent refactoring of tests, I've reworked the tests to suit the split file structure. I've also updated the documentation where required.