### PR TITLE
Defer type-checking and `warnings` imports

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -36,14 +36,16 @@ from __future__ import annotations
 import io
 import re
 import warnings
-from collections.abc import Callable, Iterable, Mapping, Sequence
 from enum import IntEnum
 from functools import lru_cache
 from html.parser import HTMLParser
-from typing import TYPE_CHECKING, Any, Final, Literal, TypedDict, cast
+from typing import Any, Literal, TypedDict, cast
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping, Sequence
     from sqlite3 import Cursor
+    from typing import Final
 
     from _typeshed import SupportsRichComparison
     from typing_extensions import Self, TypeAlias

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 
 import io
 import re
-import warnings
 from enum import IntEnum
 from functools import lru_cache
 from html.parser import HTMLParser
@@ -3074,6 +3073,9 @@ def _warn_deprecation(name: str, module_globals: dict[str, Any]) -> Any:
         )
     else:
         msg = f"the '{name}' constant is deprecated, use the 'TableStyle' enum instead"
+
+    import warnings
+
     warnings.warn(msg, DeprecationWarning, stacklevel=3)
     return val
 

--- a/tests/test_colortable.py
+++ b/tests/test_colortable.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 import pytest
 from test_prettytable import CITY_DATA, CITY_DATA_HEADER
 
-from prettytable import PrettyTable
 from prettytable.colortable import RESET_CODE, ColorTable, Theme, Themes
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from prettytable import PrettyTable
 
 
 @pytest.fixture


### PR DESCRIPTION
Can't quite eliminate the `typing` import entirely, but can avoid a few others.

Also defer `warnings` import.