### PR TITLE
Fix `IndexError` for `add_rows()` with an empty list

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1653,7 +1653,9 @@ class PrettyTable:
         # On rows[:-1]: Value of type "Iterable[list[Any]]" is not indexable
         for row in rows[:-1]:  # type: ignore[index]
             self.add_row(row)
-        self.add_row(rows[-1], divider=divider)  # type: ignore[index]
+
+        if rows:
+            self.add_row(rows[-1], divider=divider)  # type: ignore[index]
 
     def add_row(self, row: RowType, *, divider: bool = False) -> None:
         """Add a row to the table

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -478,6 +478,9 @@ class TestBasic:
         table.add_rows(CITY_DATA)
         assert str(city_data) == str(table)
 
+        table.add_rows([])
+        assert str(city_data) == str(table)
+
     def _test_no_blank_lines(self, table: PrettyTable) -> None:
         string = table.get_string()
         lines = string.split("\n")


### PR DESCRIPTION
Fixes https://github.com/prettytable/prettytable/issues/377.