### PR TITLE
Support OSC 8 hyperlinks

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -150,7 +150,10 @@ class OptionsType(TypedDict):
     break_on_hyphens: bool
 
 
+# ANSI colour codes
 _re = re.compile(r"\033\[[0-9;]*m|\033\(B")
+# OSC 8 hyperlinks
+_osc8_re = re.compile(r"\033\]8;;.*?\033\\(.*?)\033\]8;;\033\\")
 
 
 @lru_cache
@@ -2855,6 +2858,7 @@ class PrettyTable:
 def _str_block_width(val: str) -> int:
     import wcwidth  # type: ignore[import-untyped]
 
+    val = _osc8_re.sub(r"\1", val)
     return wcwidth.wcswidth(_re.sub("", val))
 
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -414,19 +414,23 @@ class TestStyle:
         ],
     )
     def test_style_align(self, style: TableStyle, expected: str) -> None:
-        t = PrettyTable(["l", "c", "r", "Align left", "Align centre", "Align right"])
+        table = PrettyTable(
+            ["l", "c", "r", "Align left", "Align centre", "Align right"]
+        )
         v = 1
         for row in range(3):
             # Some have spaces, some not, to help test padding columns of
             # different widths
-            t.add_row([v, v + 1, v + 2, f"value {v}", f"value{v + 1}", f"value{v + 2}"])
+            table.add_row(
+                [v, v + 1, v + 2, f"value {v}", f"value{v + 1}", f"value{v + 2}"]
+            )
             v += 3
 
-        t.set_style(style)
-        t.align["l"] = t.align["Align left"] = "l"
-        t.align["c"] = t.align["Align centre"] = "c"
-        t.align["r"] = t.align["Align right"] = "r"
-        assert t.get_string().strip() == expected.strip()
+        table.set_style(style)
+        table.align["l"] = table.align["Align left"] = "l"
+        table.align["c"] = table.align["Align centre"] = "c"
+        table.align["r"] = table.align["Align right"] = "r"
+        assert table.get_string().strip() == expected.strip()
 
 
 @pytest.fixture

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_lazy_fixtures import lf
 
 from prettytable import HRuleStyle, PrettyTable, TableStyle, VRuleStyle
+from prettytable.prettytable import _str_block_width
 
 
 class TestPositionalJunctions:
@@ -531,16 +532,56 @@ class TestMultiPattern:
         ), f"Error output for test output of type {test_type}"
 
 
-class TestColoredTitle:
-    def test_colored_table(self) -> None:
-        table = PrettyTable(field_names=["Namespace", "Count"])
-        table.title = "\x1b[34mHere be Table caption\x1b[39m"
-        assert (
-            table.get_string()
-            == """+-----------------------+
+def test_colored_table() -> None:
+    table = PrettyTable(field_names=["Namespace", "Count"])
+    table.title = "\x1b[34mHere be Table caption\x1b[39m"
+    assert (
+        table.get_string()
+        == """+-----------------------+
 | \x1b[34mHere be Table caption\x1b[39m |
 +-------------+---------+
 |  Namespace  |  Count  |
 +-------------+---------+
 +-------------+---------+"""
-        )
+    )
+
+
+def test_link_and_color() -> None:
+    table = PrettyTable(["Link", "Count"])
+    # Add link
+    text = "Click here"
+    table.add_row([f"\033]8;;https://example.com\033\\{text}\033]8;;\033\\", "1"])
+    table.add_row(["No link", "2"])
+    # Add link with colour
+    text = "Click \x1b[34mhere\x1b[39m"
+    table.add_row([f"\033]8;;https://example.com\033\\{text}\033]8;;\033\\", "3"])
+
+    assert (
+        table.get_string()
+        == """\
++------------+-------+
+|    Link    | Count |
++------------+-------+
+| \033]8;;https://example.com\033\\Click here\033]8;;\033\\ |   1   |
+|  No link   |   2   |
+| \033]8;;https://example.com\033\\Click \x1b[34mhere\x1b[39m\033]8;;\033\\ |   3   |
++------------+-------+"""
+    )
+
+
+@pytest.mark.parametrize(
+    ["test_input", "expected"],
+    [
+        ("a", 1),
+        ("abc", 3),
+        ("abc def", 7),
+        ("\x1b[34mblue\x1b[39m", 4),
+        ("\033]8;;https://example.com\033\\link\033]8;;\033\\", 4),
+        # colour inside link
+        ("\033]8;;https://example.com\033\\\x1b[34mblue link\x1b[39m\033]8;;\033\\", 9),
+        # link inside colour
+        ("\x1b[34m\033]8;;https://example.com\033\\blue link\033]8;;\033\\\x1b[39m", 9),
+    ],
+)
+def test__str_block_width(test_input: str, expected: int) -> None:
+    assert _str_block_width(test_input) == expected


### PR DESCRIPTION
Fixes https://github.com/prettytable/prettytable/issues/121.

```python
from prettytable import PrettyTable

output_table = PrettyTable()
output_table.add_rows([
    (f'No link',),
    (f'\u001b]8;;https://example.com/\u001b\\With link\u001b]8;;\u001b\\',)
])
print(output_table)
```


<img width="726" alt="image" src="https://github.com/user-attachments/assets/1f37a1ee-6292-40ee-8477-bbc45cd751eb" />
