### PR TITLE
feat: Add custom value formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,33 @@ print(table.get_string(border=False))
 print(table)
 ```
 
+### Changing the appearance of your values
+
+You can modify the appearance of your values by using colors. E.g. you want positive
+values green and negative values red. The standard formatting has been already processed
+before calling this function, e.g. float values are already formatted with given
+precision. Because of this the colorization function gets two parameters, the original
+value (with its type) and the preprocessed formatted value.
+
+```python
+import colorama
+
+def colorUpYourLife(value, representation):
+    if isinstance(value,  (int, float)):
+        if value >= 0:
+            return f"{colorama.Fore.GREEN}{representation}{colorama.Fore.RESET}"
+        else:
+            return f"{colorama.Fore.RED}{representation}{colorama.Fore.RESET}"
+    if value is not None:
+        return f"{colorama.Fore.BLUE}{representation}{colorama.Fore.RESET}"
+    return representation
+
+table = PrettyTable(custom_value_format = colorUpYourLife)
+table.title = "Here be Table caption"
+table.add_row(["bla", 24, None])
+table.add_row(["blu", -1, None])
+```
+
 ### Changing the appearance of your table - with _colors_!
 
 PrettyTable has the functionality of printing your table with ANSI color codes. This

--- a/README.md
+++ b/README.md
@@ -602,13 +602,14 @@ print(table)
 You can modify the appearance of your values by using colors. E.g. you want positive
 values green and negative values red. The standard formatting has been already processed
 before calling this function, e.g. float values are already formatted with given
-precision. Because of this the colorization function gets two parameters, the original
-value (with its type) and the preprocessed formatted value.
+precision. Because of this the colorization function gets three parameters, the field
+name, the original value (with its type) and the preprocessed formatted value and must
+return the new representation.
 
 ```python
 import colorama
 
-def colorUpYourLife(value, representation):
+def colorUpYourLife(field, value, representation):
     if isinstance(value,  (int, float)):
         if value >= 0:
             return f"{colorama.Fore.GREEN}{representation}{colorama.Fore.RESET}"

--- a/README.md
+++ b/README.md
@@ -599,18 +599,19 @@ print(table)
 
 ### Changing the appearance of your values
 
-You can modify the appearance of your values by using colors. E.g. you want positive
-values green and negative values red. The standard formatting has been already processed
-before calling this function, e.g. float values are already formatted with given
-precision. Because of this the colorization function gets three parameters, the field
-name, the original value (with its type) and the preprocessed formatted value and must
-return the new representation.
+You can modify the appearance of your values by using colors. For example, you want 
+positive values green and negative values red. The standard formatting has been already
+processed before calling this function, so for instance, float values are already
+formatted to the required precision. Because of this, the colorization function gets
+three parameters, the field name, the original value (with its type) and the
+preprocessed formatted value, and must return the new representation.
 
 ```python
 import colorama
+from prettytable import PrettyTable
 
-def colorUpYourLife(field, value, representation):
-    if isinstance(value,  (int, float)):
+def color_up_your_life(field, value, representation):
+    if isinstance(value, (int, float)):
         if value >= 0:
             return f"{colorama.Fore.GREEN}{representation}{colorama.Fore.RESET}"
         else:
@@ -619,8 +620,7 @@ def colorUpYourLife(field, value, representation):
         return f"{colorama.Fore.BLUE}{representation}{colorama.Fore.RESET}"
     return representation
 
-table = PrettyTable(custom_value_format = colorUpYourLife)
-table.title = "Here be Table caption"
+table = PrettyTable(custom_value_format = color_up_your_life)
 table.add_row(["bla", 24, None])
 table.add_row(["blu", -1, None])
 ```

--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ print(table)
 
 ### Changing the appearance of your values
 
-You can modify the appearance of your values by using colors. For example, you want 
+You can modify the appearance of your values by using colors. For example, you want
 positive values green and negative values red. The standard formatting has been already
 processed before calling this function, so for instance, float values are already
 formatted to the required precision. Because of this, the colorization function gets

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1039,7 +1039,7 @@ class PrettyTable:
         Arguments:
 
         value - the original value
-        representation - the formatted string representaion of the value"""
+        representation - the preformatted string representation of the value"""
         return self._custom_value_format
 
     @custom_value_format.setter
@@ -1861,8 +1861,7 @@ class PrettyTable:
             result = (f"%{self._int_format[field]}d") % value
         elif isinstance(value, float) and field in self._float_format:
             result = (f"%{self._float_format[field]}f") % value
-
-        if result is None:
+        else:
             formatter = self._custom_format.get(field, (lambda f, v: str(v)))
             result = formatter(field, value)
         return (

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -119,7 +119,7 @@ class OptionsType(TypedDict):
     custom_format: (
         Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]] | None
     )
-    custom_value_format: Callable[[Any, str], str] | None
+    custom_value_format: Callable[[str, Any, str], str] | None
     min_table_width: int | None
     max_table_width: int | None
     padding_width: int
@@ -191,7 +191,7 @@ class PrettyTable:
     _int_format: dict[str, str]
     _float_format: dict[str, str]
     _custom_format: dict[str, Callable[[str, Any], str]]
-    _custom_value_format: Callable[[Any, str], str] | None
+    _custom_value_format: Callable[[str, Any, str], str] | None
     _padding_width: int
     _left_padding_width: int | None
     _right_padding_width: int | None
@@ -1033,7 +1033,7 @@ class PrettyTable:
         self._sort_key = val
 
     @property
-    def custom_value_format(self) -> Callable[[Any, str], str] | None:
+    def custom_value_format(self) -> Callable[[str, Any, str], str] | None:
         """controls formatting of any value using callable
 
         Arguments:
@@ -1043,7 +1043,7 @@ class PrettyTable:
         return self._custom_value_format
 
     @custom_value_format.setter
-    def custom_value_format(self, val: Callable[[Any, str], str] | None) -> None:
+    def custom_value_format(self, val: Callable[[str, Any, str], str] | None) -> None:
         self._validate_option("custom_value_format", val)
         self._custom_value_format = val
 
@@ -1865,7 +1865,7 @@ class PrettyTable:
             formatter = self._custom_format.get(field, (lambda f, v: str(v)))
             result = formatter(field, value)
         return (
-            self._custom_value_format(value, result)
+            self._custom_value_format(field, value, result)
             if self._custom_value_format
             else result
         )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -585,7 +585,7 @@ class TestHtmlOutput:
         )
 
     @staticmethod
-    def _value_colorizer(value, representation):
+    def _value_colorizer(field, value, representation):
         import html
 
         if isinstance(value, int):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -583,3 +583,74 @@ class TestHtmlOutput:
 </table>
 """.strip()
         )
+
+    @staticmethod
+    def _value_colorizer(value, representation):
+        import html
+
+        if isinstance(value, int):
+            return f'<span style="color: red">{html.escape(representation)}</span>'
+        elif isinstance(value, float):
+            return f'<span style="color: green">{html.escape(representation)}</span>'
+        return f'<span style="color: blue">{html.escape(representation)}</span>'
+
+    def test_html_output_value_formatted(self, city_data: PrettyTable) -> None:
+        city_data.custom_value_format = self._value_colorizer
+        city_data.escape_data = False
+        assert (
+            city_data.get_html_string()
+            == """<table>
+    <thead>
+        <tr>
+            <th>City name</th>
+            <th>Area</th>
+            <th>Population</th>
+            <th>Annual Rainfall</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><span style="color: blue">Adelaide</span></td>
+            <td><span style="color: red">1295</span></td>
+            <td><span style="color: red">1158259</span></td>
+            <td><span style="color: green">600.5</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Brisbane</span></td>
+            <td><span style="color: red">5905</span></td>
+            <td><span style="color: red">1857594</span></td>
+            <td><span style="color: green">1146.4</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Darwin</span></td>
+            <td><span style="color: red">112</span></td>
+            <td><span style="color: red">120900</span></td>
+            <td><span style="color: green">1714.7</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Hobart</span></td>
+            <td><span style="color: red">1357</span></td>
+            <td><span style="color: red">205556</span></td>
+            <td><span style="color: green">619.5</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Sydney</span></td>
+            <td><span style="color: red">2058</span></td>
+            <td><span style="color: red">4336374</span></td>
+            <td><span style="color: green">1214.8</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Melbourne</span></td>
+            <td><span style="color: red">1566</span></td>
+            <td><span style="color: red">3806092</span></td>
+            <td><span style="color: green">646.9</span></td>
+        </tr>
+        <tr>
+            <td><span style="color: blue">Perth</span></td>
+            <td><span style="color: red">5386</span></td>
+            <td><span style="color: red">1554769</span></td>
+            <td><span style="color: green">869.4</span></td>
+        </tr>
+    </tbody>
+</table>"""
+        )

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1044,6 +1044,72 @@ class TestCustomFormatter:
         )
 
 
+class TestCustomValueFormatter:
+    @staticmethod
+    def _value_colorizer(value, representation):
+        if isinstance(value, int):
+            return f"\x1b[32m{representation}\x1b[39m"
+        elif isinstance(value, float):
+            return f"\x1b[33m{representation}\x1b[39m"
+        return f"\x1b[34m{representation}\x1b[39m"
+
+    @staticmethod
+    def _value_changer(value, representation):
+        if isinstance(value, int):
+            return f"## {representation} ##"
+        elif isinstance(value, float):
+            return f"!!! {representation} !!!"
+        return representation
+
+    def test_init_is_empty(self) -> None:
+        table = PrettyTable()
+        assert table.custom_value_format is None
+
+    def test_can_set(self) -> None:
+        table = PrettyTable()
+        table.custom_value_format = self._value_colorizer
+        assert table.custom_value_format == self._value_colorizer
+
+    def test_set_to_none(self) -> None:
+        table = PrettyTable()
+        table.custom_value_format = None
+        assert table.custom_value_format is None
+
+    def test_colorize(self, city_data: PrettyTable) -> None:
+        city_data.custom_value_format = self._value_colorizer
+        assert (
+            city_data.get_string().strip()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  \x1b[34mAdelaide\x1b[39m | \x1b[32m1295\x1b[39m |  \x1b[32m1158259\x1b[39m   |      \x1b[33m600.5\x1b[39m      |
+|  \x1b[34mBrisbane\x1b[39m | \x1b[32m5905\x1b[39m |  \x1b[32m1857594\x1b[39m   |      \x1b[33m1146.4\x1b[39m     |
+|   \x1b[34mDarwin\x1b[39m  | \x1b[32m112\x1b[39m  |   \x1b[32m120900\x1b[39m   |      \x1b[33m1714.7\x1b[39m     |
+|   \x1b[34mHobart\x1b[39m  | \x1b[32m1357\x1b[39m |   \x1b[32m205556\x1b[39m   |      \x1b[33m619.5\x1b[39m      |
+|   \x1b[34mSydney\x1b[39m  | \x1b[32m2058\x1b[39m |  \x1b[32m4336374\x1b[39m   |      \x1b[33m1214.8\x1b[39m     |
+| \x1b[34mMelbourne\x1b[39m | \x1b[32m1566\x1b[39m |  \x1b[32m3806092\x1b[39m   |      \x1b[33m646.9\x1b[39m      |
+|   \x1b[34mPerth\x1b[39m   | \x1b[32m5386\x1b[39m |  \x1b[32m1554769\x1b[39m   |      \x1b[33m869.4\x1b[39m      |
++-----------+------+------------+-----------------+"""  # noqa: E501
+        )
+
+    def test_change_len(self, city_data: PrettyTable) -> None:
+        city_data.custom_value_format = self._value_changer
+        assert (
+            city_data.get_string().strip()
+            == """+-----------+------------+---------------+-----------------+
+| City name |    Area    |   Population  | Annual Rainfall |
++-----------+------------+---------------+-----------------+
+|  Adelaide | ## 1295 ## | ## 1158259 ## |  !!! 600.5 !!!  |
+|  Brisbane | ## 5905 ## | ## 1857594 ## |  !!! 1146.4 !!! |
+|   Darwin  | ## 112 ##  |  ## 120900 ## |  !!! 1714.7 !!! |
+|   Hobart  | ## 1357 ## |  ## 205556 ## |  !!! 619.5 !!!  |
+|   Sydney  | ## 2058 ## | ## 4336374 ## |  !!! 1214.8 !!! |
+| Melbourne | ## 1566 ## | ## 3806092 ## |  !!! 646.9 !!!  |
+|   Perth   | ## 5386 ## | ## 1554769 ## |  !!! 869.4 !!!  |
++-----------+------------+---------------+-----------------+"""
+        )
+
+
 class TestRepr:
     def test_default_repr(self, row_prettytable: PrettyTable) -> None:
         assert row_prettytable.__str__() == row_prettytable.__repr__()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1046,7 +1046,7 @@ class TestCustomFormatter:
 
 class TestCustomValueFormatter:
     @staticmethod
-    def _value_colorizer(value, representation):
+    def _value_colorizer(field, value, representation):
         if isinstance(value, int):
             return f"\x1b[32m{representation}\x1b[39m"
         elif isinstance(value, float):
@@ -1054,7 +1054,7 @@ class TestCustomValueFormatter:
         return f"\x1b[34m{representation}\x1b[39m"
 
     @staticmethod
-    def _value_changer(value, representation):
+    def _value_changer(field, value, representation):
         if isinstance(value, int):
             return f"## {representation} ##"
         elif isinstance(value, float):

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1078,7 +1078,7 @@ class TestCustomValueFormatter:
     def test_colorize(self, city_data: PrettyTable) -> None:
         city_data.custom_value_format = self._value_colorizer
         assert (
-            city_data.get_string().strip()
+            city_data.get_string()
             == """+-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
@@ -1095,7 +1095,7 @@ class TestCustomValueFormatter:
     def test_change_len(self, city_data: PrettyTable) -> None:
         city_data.custom_value_format = self._value_changer
         assert (
-            city_data.get_string().strip()
+            city_data.get_string()
             == """+-----------+------------+---------------+-----------------+
 | City name |    Area    |   Population  | Annual Rainfall |
 +-----------+------------+---------------+-----------------+
@@ -1107,6 +1107,24 @@ class TestCustomValueFormatter:
 | Melbourne | ## 1566 ## | ## 3806092 ## |  !!! 646.9 !!!  |
 |   Perth   | ## 5386 ## | ## 1554769 ## |  !!! 869.4 !!!  |
 +-----------+------------+---------------+-----------------+"""
+        )
+
+    def test_colorize_and_float_formatting(self, city_data: PrettyTable) -> None:
+        city_data.custom_value_format = self._value_colorizer
+        city_data.float_format = "10.2"
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  \x1b[34mAdelaide\x1b[39m | \x1b[32m1295\x1b[39m |  \x1b[32m1158259\x1b[39m   |    \x1b[33m    600.50\x1b[39m   |
+|  \x1b[34mBrisbane\x1b[39m | \x1b[32m5905\x1b[39m |  \x1b[32m1857594\x1b[39m   |    \x1b[33m   1146.40\x1b[39m   |
+|   \x1b[34mDarwin\x1b[39m  | \x1b[32m112\x1b[39m  |   \x1b[32m120900\x1b[39m   |    \x1b[33m   1714.70\x1b[39m   |
+|   \x1b[34mHobart\x1b[39m  | \x1b[32m1357\x1b[39m |   \x1b[32m205556\x1b[39m   |    \x1b[33m    619.50\x1b[39m   |
+|   \x1b[34mSydney\x1b[39m  | \x1b[32m2058\x1b[39m |  \x1b[32m4336374\x1b[39m   |    \x1b[33m   1214.80\x1b[39m   |
+| \x1b[34mMelbourne\x1b[39m | \x1b[32m1566\x1b[39m |  \x1b[32m3806092\x1b[39m   |    \x1b[33m    646.90\x1b[39m   |
+|   \x1b[34mPerth\x1b[39m   | \x1b[32m5386\x1b[39m |  \x1b[32m1554769\x1b[39m   |    \x1b[33m    869.40\x1b[39m   |
++-----------+------+------------+-----------------+"""  # noqa: E501
         )
 
 


### PR DESCRIPTION
With this feature I wanted to define the formatting (colorization)  of values in a single function, which  gets called by prettytable. Previous mechanisms allowed formatting only on columns

Fixes: #266
Fixes: #391 
