### PR TITLE
Set dicts with column-specific config for all column-specific attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ PrettyTable has a number of style options which control various aspects of how t
 are displayed. You have the freedom to set each of these options individually to
 whatever you prefer. The `set_style` method just does this automatically for you.
 
-Table specific options are:
+Table-specific options are:
 
 | Option                       | Details                                                                                                                                     |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -544,9 +544,9 @@ Table specific options are:
 For options that can be set individually for each column (`align`, `valign`,
 `custom_format`, `max_width`, `min_width`, `int_format`, `float_format`, `none_format`)
 you can either set a value, that applies to all columns or set a dict with column names
-and individual values).
+and individual values.
 
-Column specific options are:
+Column-specific options are:
 
 | Option          | Details                                                                                                                                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -542,22 +542,22 @@ Table specific options are:
 | `vrules`                     | Controls printing of vertical rules between columns. Allowed values: `FRAME`, `ALL`, `NONE`.                                                |
 
 For options that can be set individually for each column (`align`, `valign`,
-`max_width`, `min_width`, `int_format`, `float_format`, `none_format`) you can either
-set a value, that applies to all columns or set a dict with column names and individual
-values).
+`custom_format`, `max_width`, `min_width`, `int_format`, `float_format`, `none_format`)
+you can either set a value, that applies to all columns or set a dict with column names
+and individual values).
 
 Column specific options are:
 
-| Option          | Details                                                                                                                                                                                          |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `align`         | Controls alignment of fields, one of "l", "c", or "r" or a dictionary with column and value.                                                                                                     |
-| `custom_format` | A dictionary of field and callable. This allows you to set any format you want `pf.custom_format["my_col_int"] = lambda f, v: f"{v:,}"`. The type of the callable is `Callable[[str, Any], str]` |
-| `float_format`  | A string which controls the way floating point data is printed or a dictionary with column and value. This works like: `print("%<float_format>f" % data)`.                                       |
-| `int_format`    | A string which controls the way integer data is printed or a dictionary with column and value. This works like: `print("%<int_format>d" % data)`.                                                |
-| `max_width`     | Number of characters used for maximum width of a column or a dictionary with column and value.                                                                                                   |
-| `min_width`     | Number of characters used for minimum width of a column or a dictionary with column and value.                                                                                                   |
-| `none_format`   | Representation of None values or a dictionary with column and value.                                                                                                                             |
-| `valign`        | Controls vertical alignment of fields, one of "t", "m", or "b" or a dictionary with column and value.                                                                                            |
+| Option          | Details                                                                                                                                                                                                                                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `align`         | Controls alignment of fields, one of "l", "c", or "r" or a dictionary with column and value.                                                                                                                                                                                                               |
+| `custom_format` | Set any format, by setting a function that gets the original value,the formatted representation and returns the new string. E.g. `pf.custom_format["my_col_int"] = lambda f, v: f"{v:,}"`. The type of the callable is `Callable[[str, Any], str]`. This also takes a dictionary with column and function. |
+| `float_format`  | A string which controls the way floating point data is printed or a dictionary with column and value. This works like: `print("%<float_format>f" % data)`.                                                                                                                                                 |
+| `int_format`    | A string which controls the way integer data is printed or a dictionary with column and value. This works like: `print("%<int_format>d" % data)`.                                                                                                                                                          |
+| `max_width`     | Number of characters used for maximum width of a column or a dictionary with column and value.                                                                                                                                                                                                             |
+| `min_width`     | Number of characters used for minimum width of a column or a dictionary with column and value.                                                                                                                                                                                                             |
+| `none_format`   | Representation of None values or a dictionary with column and value.                                                                                                                                                                                                                                       |
+| `valign`        | Controls vertical alignment of fields, one of "t", "m", or "b" or a dictionary with column and value.                                                                                                                                                                                                      |
 
 You can set the style options to your own settings in two ways:
 

--- a/README.md
+++ b/README.md
@@ -511,40 +511,53 @@ PrettyTable has a number of style options which control various aspects of how t
 are displayed. You have the freedom to set each of these options individually to
 whatever you prefer. The `set_style` method just does this automatically for you.
 
-The options are:
+Table specific options are:
 
-| Option                       | Details                                                                                                                                                                                          |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `border`                     | A Boolean option (must be `True` or `False`). Controls whether a border is drawn inside and around the table.                                                                                    |
-| `preserve_internal_border`   | A Boolean option (must be `True` or `False`). Controls whether borders are still drawn within the table even when `border=False`.                                                                |
-| `header`                     | A Boolean option (must be `True` or `False`). Controls whether the first row of the table is a header showing the names of all the fields.                                                       |
-| `hrules`                     | Controls printing of horizontal rules after rows. Allowed values: `FRAME`, `HEADER`, `ALL`, `NONE`.                                                                                              |
-| `HEADER`, `ALL`, `NONE`      | These are variables defined inside the `prettytable` module so make sure you import them or use `prettytable.FRAME` etc.                                                                         |
-| `vrules`                     | Controls printing of vertical rules between columns. Allowed values: `FRAME`, `ALL`, `NONE`.                                                                                                     |
-| `int_format`                 | A string which controls the way integer data is printed. This works like: `print("%<int_format>d" % data)`.                                                                                      |
-| `float_format`               | A string which controls the way floating point data is printed. This works like: `print("%<float_format>f" % data)`.                                                                             |
-| `custom_format`              | A dictionary of field and callable. This allows you to set any format you want `pf.custom_format["my_col_int"] = lambda f, v: f"{v:,}"`. The type of the callable is `Callable[[str, Any], str]` |
-| `padding_width`              | Number of spaces on either side of column data (only used if left and right paddings are `None`).                                                                                                |
-| `left_padding_width`         | Number of spaces on left-hand side of column data.                                                                                                                                               |
-| `right_padding_width`        | Number of spaces on right-hand side of column data.                                                                                                                                              |
-| `vertical_char`              | Single character string used to draw vertical lines. Default: `\|`.                                                                                                                              |
-| `horizontal_char`            | Single character string used to draw horizontal lines. Default: `-`.                                                                                                                             |
-| `_horizontal_align_char`     | Single character string used to indicate column alignment in horizontal lines. Default: `:` for Markdown, otherwise `None`.                                                                      |
-| `junction_char`              | Single character string used to draw line junctions. Default: `+`.                                                                                                                               |
-| `top_junction_char`          | Single character string used to draw top line junctions. Default: `junction_char`.                                                                                                               |
-| `bottom_junction_char`       | single character string used to draw bottom line junctions. Default: `junction_char`.                                                                                                            |
-| `right_junction_char`        | Single character string used to draw right line junctions. Default: `junction_char`.                                                                                                             |
-| `left_junction_char`         | Single character string used to draw left line junctions. Default: `junction_char`.                                                                                                              |
-| `top_right_junction_char`    | Single character string used to draw top-right line junctions. Default: `junction_char`.                                                                                                         |
-| `top_left_junction_char`     | Single character string used to draw top-left line junctions. Default: `junction_char`.                                                                                                          |
-| `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                                                                      |
-| `bottom_left_junction_char`  | Single character string used to draw bottom-left line junctions. Default: `junction_char`.                                                                                                       |
-| `min_table_width`            | Number of characters used for the minimum total table width.                                                                                                                                     |
-| `max_table_width`            | Number of characters used for the maximum total table width.                                                                                                                                     |
-| `max_width`                  | Number of characters used for maximum width of a column.                                                                                                                                         |
-| `min_width`                  | Number of characters used for minimum width of a column.                                                                                                                                         |
-| `use_header_width`           | A Boolean option (must be `True` or `False`). Controls whether the width of the header is used for computing column width. Default: `True`.                                                      |
-| `break_on_hyphens`           | Whether long lines are wrapped on hyphens. Default: `True`.                                                                                                                                      |
+| Option                       | Details                                                                                                                                     |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HEADER`, `ALL`, `NONE`      | These are variables defined inside the `prettytable` module so make sure you import them or use `prettytable.FRAME` etc.                    |
+| `_horizontal_align_char`     | Single character string used to indicate column alignment in horizontal lines. Default: `:` for Markdown, otherwise `None`.                 |
+| `border`                     | A Boolean option (must be `True` or `False`). Controls whether a border is drawn inside and around the table.                               |
+| `bottom_junction_char`       | single character string used to draw bottom line junctions. Default: `junction_char`.                                                       |
+| `bottom_left_junction_char`  | Single character string used to draw bottom-left line junctions. Default: `junction_char`.                                                  |
+| `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                 |
+| `break_on_hyphens`           | Whether long lines are wrapped on hyphens. Default: `True`.                                                                                 |
+| `header`                     | A Boolean option (must be `True` or `False`). Controls whether the first row of the table is a header showing the names of all the fields.  |
+| `horizontal_char`            | Single character string used to draw horizontal lines. Default: `-`.                                                                        |
+| `hrules`                     | Controls printing of horizontal rules after rows. Allowed values: `FRAME`, `HEADER`, `ALL`, `NONE`.                                         |
+| `junction_char`              | Single character string used to draw line junctions. Default: `+`.                                                                          |
+| `left_junction_char`         | Single character string used to draw left line junctions. Default: `junction_char`.                                                         |
+| `left_padding_width`         | Number of spaces on left-hand side of column data.                                                                                          |
+| `max_table_width`            | Number of characters used for the maximum total table width.                                                                                |
+| `min_table_width`            | Number of characters used for the minimum total table width.                                                                                |
+| `padding_width`              | Number of spaces on either side of column data (only used if left and right paddings are `None`).                                           |
+| `preserve_internal_border`   | A Boolean option (must be `True` or `False`). Controls whether borders are still drawn within the table even when `border=False`.           |
+| `right_junction_char`        | Single character string used to draw right line junctions. Default: `junction_char`.                                                        |
+| `right_padding_width`        | Number of spaces on right-hand side of column data.                                                                                         |
+| `top_junction_char`          | Single character string used to draw top line junctions. Default: `junction_char`.                                                          |
+| `top_left_junction_char`     | Single character string used to draw top-left line junctions. Default: `junction_char`.                                                     |
+| `top_right_junction_char`    | Single character string used to draw top-right line junctions. Default: `junction_char`.                                                    |
+| `use_header_width`           | A Boolean option (must be `True` or `False`). Controls whether the width of the header is used for computing column width. Default: `True`. |
+| `vertical_char`              | Single character string used to draw vertical lines. Default: `\|`.                                                                         |
+| `vrules`                     | Controls printing of vertical rules between columns. Allowed values: `FRAME`, `ALL`, `NONE`.                                                |
+
+For options that can be set individually for each column (`align`, `valign`,
+`max_width`, `min_width`, `int_format`, `float_format`, `none_format`) you can either
+set a value, that applies to all columns or set a dict with column names and individual
+values).
+
+Column specific options are:
+
+| Option          | Details                                                                                                                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `align`         | Controls alignment of fields, one of "l", "c", or "r" or a dictionary with column and value.                                                                                                     |
+| `custom_format` | A dictionary of field and callable. This allows you to set any format you want `pf.custom_format["my_col_int"] = lambda f, v: f"{v:,}"`. The type of the callable is `Callable[[str, Any], str]` |
+| `float_format`  | A string which controls the way floating point data is printed or a dictionary with column and value. This works like: `print("%<float_format>f" % data)`.                                       |
+| `int_format`    | A string which controls the way integer data is printed or a dictionary with column and value. This works like: `print("%<int_format>d" % data)`.                                                |
+| `max_width`     | Number of characters used for maximum width of a column or a dictionary with column and value.                                                                                                   |
+| `min_width`     | Number of characters used for minimum width of a column or a dictionary with column and value.                                                                                                   |
+| `none_format`   | Representation of None values or a dictionary with column and value.                                                                                                                             |
+| `valign`        | Controls vertical alignment of fields, one of "t", "m", or "b" or a dictionary with column and value.                                                                                            |
 
 You can set the style options to your own settings in two ways:
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -776,6 +776,12 @@ class PrettyTable:
 
     @none_format.setter
     def none_format(self, val: str | dict[str, str | None] | None):
+        """Representation of None values:
+
+        Arguments:
+
+        val - The alternative representation to be used for None values
+        """
         if not self._field_names:
             self._none_format = {}
         elif isinstance(val, str):

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -852,10 +852,7 @@ class PrettyTable:
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_align(fval)
-                if not self._field_names:
-                    self._align = {BASE_ALIGN_VALUE: fval}
-                else:
-                    self._align[field] = fval
+                self._align[field] = fval
         else:
             if not self._field_names:
                 self._align = {BASE_ALIGN_VALUE: "c"}

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -885,11 +885,15 @@ class PrettyTable:
 
     @max_width.setter
     def max_width(self, val: int | dict[str, int] | None) -> None:
-        if val:
+        if isinstance(val, int):
             self._validate_option("max_width", val)
-            val = cast(int, val)
             for field in self._field_names:
                 self._max_width[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_option("max_width", fval)
+                fval = cast(int, fval)
+                self._max_width[field] = fval
         else:
             self._max_width = {}
 
@@ -903,11 +907,15 @@ class PrettyTable:
 
     @min_width.setter
     def min_width(self, val: int | dict[str, int] | None) -> None:
-        if val:
+        if isinstance(val, int):
             self._validate_option("min_width", val)
-            val = cast(int, val)
             for field in self._field_names:
                 self._min_width[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_option("min_width", fval)
+                fval = cast(int, fval)
+                self._min_width[field] = fval
         else:
             self._min_width = {}
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -892,7 +892,6 @@ class PrettyTable:
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_option("max_width", fval)
-                fval = cast(int, fval)
                 self._max_width[field] = fval
         else:
             self._max_width = {}
@@ -914,7 +913,6 @@ class PrettyTable:
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_option("min_width", fval)
-                fval = cast(int, fval)
                 self._min_width[field] = fval
         else:
             self._min_width = {}

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -778,13 +778,16 @@ class PrettyTable:
     def none_format(self, val: str | dict[str, str | None] | None):
         if not self._field_names:
             self._none_format = {}
-        elif val:
+        elif isinstance(val, str):
             for field in self._field_names:
                 self._none_format[field] = None
             self._validate_none_format(val)
-            val = cast(str, val)
             for field in self._field_names:
                 self._none_format[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_none_format(fval)
+                self._none_format[field] = fval
         else:
             for field in self._field_names:
                 self._none_format[field] = None
@@ -839,7 +842,7 @@ class PrettyTable:
 
     @align.setter
     def align(self, val: AlignType | dict[str, AlignType] | None) -> None:
-        if val:
+        if isinstance(val, str):
             self._validate_align(val)
             val = cast(AlignType, val)
             if not self._field_names:
@@ -847,6 +850,13 @@ class PrettyTable:
             else:
                 for field in self._field_names:
                     self._align[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_align(fval)
+                if not self._field_names:
+                    self._align = {BASE_ALIGN_VALUE: fval}
+                else:
+                    self._align[field] = fval
         else:
             if not self._field_names:
                 self._align = {BASE_ALIGN_VALUE: "c"}
@@ -866,10 +876,14 @@ class PrettyTable:
     def valign(self, val: VAlignType | dict[str, VAlignType] | None) -> None:
         if not self._field_names:
             self._valign = {}
-        elif val:
+        if isinstance(val, str):
             self._validate_valign(val)
             val = cast(VAlignType, val)
             for field in self._field_names:
+                self._valign[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_valign(fval)
                 self._valign[field] = val
         else:
             for field in self._field_names:
@@ -1156,11 +1170,14 @@ class PrettyTable:
 
     @int_format.setter
     def int_format(self, val: str | dict[str, str] | None) -> None:
-        if val:
+        if isinstance(val, str):
             self._validate_option("int_format", val)
-            val = cast(str, val)
             for field in self._field_names:
                 self._int_format[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_option("int_format", fval)
+                self._int_format[field] = fval
         else:
             self._int_format = {}
 
@@ -1174,11 +1191,14 @@ class PrettyTable:
 
     @float_format.setter
     def float_format(self, val: str | dict[str, str] | None) -> None:
-        if val:
+        if isinstance(val, str):
             self._validate_option("float_format", val)
-            val = cast(str, val)
             for field in self._field_names:
                 self._float_format[field] = val
+        elif isinstance(val, dict) and val:
+            for field, fval in val.items():
+                self._validate_option("float_format", fval)
+                self._float_format[field] = fval
         else:
             self._float_format = {}
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -844,7 +844,6 @@ class PrettyTable:
     def align(self, val: AlignType | dict[str, AlignType] | None) -> None:
         if isinstance(val, str):
             self._validate_align(val)
-            val = cast(AlignType, val)
             if not self._field_names:
                 self._align = {BASE_ALIGN_VALUE: val}
             else:
@@ -878,13 +877,12 @@ class PrettyTable:
             self._valign = {}
         if isinstance(val, str):
             self._validate_valign(val)
-            val = cast(VAlignType, val)
             for field in self._field_names:
                 self._valign[field] = val
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_valign(fval)
-                self._valign[field] = val
+                self._valign[field] = fval
         else:
             for field in self._field_names:
                 self._valign[field] = "t"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -765,6 +765,178 @@ class TestFloatFormat:
         assert "001.41" in string
 
 
+class TestColumnFormatingfromDict:
+    def test_set_align_format(self, city_data: PrettyTable) -> None:
+        city_data.align = {"Annual Rainfall": "r"}
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |           600.5 |
+|  Brisbane | 5905 |  1857594   |          1146.4 |
+|   Darwin  | 112  |   120900   |          1714.7 |
+|   Hobart  | 1357 |   205556   |           619.5 |
+|   Sydney  | 2058 |  4336374   |          1214.8 |
+| Melbourne | 1566 |  3806092   |           646.9 |
+|   Perth   | 5386 |  1554769   |           869.4 |
++-----------+------+------------+-----------------+"""
+        )
+
+    def test_set_valign_format(self, city_data: PrettyTable) -> None:
+        table = PrettyTable(
+            ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
+        )
+        table.valign = {"Field 1": "m"}
+        table.max_width = {"Field 2": 20, "Field 4": 10, "Field 6": 10}
+        table.add_row(
+            [
+                "Lorem",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "ipsum",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "dolor",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+            ]
+        )
+
+        assert (
+            table.get_string()
+            == """+---------+----------------------+---------+------------+---------+------------+
+| Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+----------------------+---------+------------+---------+------------+
+|  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         | sit amet, consetetur |         |   ipsum    |         |   ipsum    |
+|         |  sadipscing elitr,   |         | dolor sit  |         | dolor sit  |
+|         |       sed diam       |         |   amet,    |         |   amet,    |
+|         |                      |         | consetetur |         | consetetur |
+|         |                      |         | sadipscing |         | sadipscing |
+|         |                      |         | elitr, sed |         | elitr, sed |
+|         |                      |         |    diam    |         |    diam    |
++---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
+        )
+
+    def test_max_width(
+        self,
+    ) -> None:
+        table = PrettyTable(
+            ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
+        )
+        table.max_width = {"Field 2": 20, "Field 4": 10, "Field 6": 10}
+        table.add_row(
+            [
+                "Lorem",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "ipsum",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "dolor",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+            ]
+        )
+
+        assert (
+            table.get_string()
+            == """+---------+----------------------+---------+------------+---------+------------+
+| Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+----------------------+---------+------------+---------+------------+
+|  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         | sit amet, consetetur |         |   ipsum    |         |   ipsum    |
+|         |  sadipscing elitr,   |         | dolor sit  |         | dolor sit  |
+|         |       sed diam       |         |   amet,    |         |   amet,    |
+|         |                      |         | consetetur |         | consetetur |
+|         |                      |         | sadipscing |         | sadipscing |
+|         |                      |         | elitr, sed |         | elitr, sed |
+|         |                      |         |    diam    |         |    diam    |
++---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
+        )
+
+    def test_min_width(self, city_data: PrettyTable) -> None:
+        city_data.min_width = {
+            "City name": 20,
+            "Area": 10,
+            "Population": 20,
+            "Annual Rainfall": 20,
+        }
+        assert (
+            city_data.get_string()
+            == """+----------------------+------------+----------------------+----------------------+
+|      City name       |    Area    |      Population      |   Annual Rainfall    |
++----------------------+------------+----------------------+----------------------+
+|       Adelaide       |    1295    |       1158259        |        600.5         |
+|       Brisbane       |    5905    |       1857594        |        1146.4        |
+|        Darwin        |    112     |        120900        |        1714.7        |
+|        Hobart        |    1357    |        205556        |        619.5         |
+|        Sydney        |    2058    |       4336374        |        1214.8        |
+|      Melbourne       |    1566    |       3806092        |        646.9         |
+|        Perth         |    5386    |       1554769        |        869.4         |
++----------------------+------------+----------------------+----------------------+"""  # noqa: E501
+        )
+
+    def test_set_int_format(self, city_data: PrettyTable) -> None:
+        city_data.int_format = {"Population": "20"}
+        assert (
+            city_data.get_string()
+            == """+-----------+------+----------------------+-----------------+
+| City name | Area |      Population      | Annual Rainfall |
++-----------+------+----------------------+-----------------+
+|  Adelaide | 1295 |              1158259 |      600.5      |
+|  Brisbane | 5905 |              1857594 |      1146.4     |
+|   Darwin  | 112  |               120900 |      1714.7     |
+|   Hobart  | 1357 |               205556 |      619.5      |
+|   Sydney  | 2058 |              4336374 |      1214.8     |
+| Melbourne | 1566 |              3806092 |      646.9      |
+|   Perth   | 5386 |              1554769 |      869.4      |
++-----------+------+----------------------+-----------------+"""
+        )
+
+    def test_set_float_format(self, city_data: PrettyTable) -> None:
+        city_data.float_format = {"Annual Rainfall": "4.2"}
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.50     |
+|  Brisbane | 5905 |  1857594   |     1146.40     |
+|   Darwin  | 112  |   120900   |     1714.70     |
+|   Hobart  | 1357 |   205556   |      619.50     |
+|   Sydney  | 2058 |  4336374   |     1214.80     |
+| Melbourne | 1566 |  3806092   |      646.90     |
+|   Perth   | 5386 |  1554769   |      869.40     |
++-----------+------+------------+-----------------+"""
+        )
+
+    def test_set_custom_format(self, city_data: PrettyTable) -> None:
+        city_data.custom_format = {"Annual Rainfall": lambda f, v: f"{v:.2f}"}
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.50     |
+|  Brisbane | 5905 |  1857594   |     1146.40     |
+|   Darwin  | 112  |   120900   |     1714.70     |
+|   Hobart  | 1357 |   205556   |      619.50     |
+|   Sydney  | 2058 |  4336374   |     1214.80     |
+| Melbourne | 1566 |  3806092   |      646.90     |
+|   Perth   | 5386 |  1554769   |      869.40     |
++-----------+------+------------+-----------------+"""
+        )
+
+    def test_set_none_format(self, city_data: PrettyTable) -> None:
+        city_data.clear_rows()
+        city_data.add_row((None, None, None, None))
+        city_data.none_format = {"Annual Rainfall": "N/A"}
+        assert (
+            city_data.get_string()
+            == """+-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|    None   | None |    None    |       N/A       |
++-----------+------+------------+-----------------+"""
+        )
+
+
 class TestBreakLine:
     @pytest.mark.parametrize(
         ["rows", "hrule", "expected_result"],
@@ -1375,70 +1547,6 @@ class TestWidth:
 +----------------------+--------------------------------------------------------------------+
 |        Lorem         | Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam  |
 +----------------------+--------------------------------------------------------------------+"""  # noqa: E501
-        )
-
-    def test_minwidth_dict(self, city_data: PrettyTable) -> None:
-        city_data.min_width = {
-            "City name": 20,
-            "Area": 20,
-            "Population": 20,
-            "Annual Rainfall": 20,
-        }
-        assert (
-            city_data.get_string()
-            == """+----------------------+----------------------+----------------------+----------------------+
-|      City name       |         Area         |      Population      |   Annual Rainfall    |
-+----------------------+----------------------+----------------------+----------------------+
-|       Adelaide       |         1295         |       1158259        |        600.5         |
-|       Brisbane       |         5905         |       1857594        |        1146.4        |
-|        Darwin        |         112          |        120900        |        1714.7        |
-|        Hobart        |         1357         |        205556        |        619.5         |
-|        Sydney        |         2058         |       4336374        |        1214.8        |
-|      Melbourne       |         1566         |       3806092        |        646.9         |
-|        Perth         |         5386         |       1554769        |        869.4         |
-+----------------------+----------------------+----------------------+----------------------+"""  # noqa: E501
-        )
-
-    def test_maxwidth_dict(
-        self,
-    ) -> None:
-        table = PrettyTable(
-            ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
-        )
-        table.max_width = {
-            "Field 1": 10,
-            "Field 2": 20,
-            "Field 3": 10,
-            "Field 4": 10,
-            "Field 5": 10,
-            "Field 6": 10,
-        }
-        print(table.max_width)
-        table.add_row(
-            [
-                "Lorem",
-                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
-                "ipsum",
-                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
-                "dolor",
-                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
-            ]
-        )
-
-        assert (
-            table.get_string().strip()
-            == """+---------+----------------------+---------+------------+---------+------------+
-| Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
-+---------+----------------------+---------+------------+---------+------------+
-|  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
-|         | sit amet, consetetur |         |   ipsum    |         |   ipsum    |
-|         |  sadipscing elitr,   |         | dolor sit  |         | dolor sit  |
-|         |       sed diam       |         |   amet,    |         |   amet,    |
-|         |                      |         | consetetur |         | consetetur |
-|         |                      |         | sadipscing |         | sadipscing |
-|         |                      |         | elitr, sed |         | elitr, sed |
-|         |                      |         |    diam    |         |    diam    |
-+---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
         )
 
     def test_table_min_max_width_on_init_with_columns(self) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1377,6 +1377,71 @@ class TestWidth:
 +----------------------+--------------------------------------------------------------------+"""  # noqa: E501
         )
 
+    def test_minwidth_dict(self, city_data: PrettyTable) -> None:
+        city_data.min_width = {
+            "City name": 20,
+            "Area": 20,
+            "Population": 20,
+            "Annual Rainfall": 20,
+        }
+        assert (
+            city_data.get_string()
+            == """+----------------------+----------------------+----------------------+----------------------+
+|      City name       |         Area         |      Population      |   Annual Rainfall    |
++----------------------+----------------------+----------------------+----------------------+
+|       Adelaide       |         1295         |       1158259        |        600.5         |
+|       Brisbane       |         5905         |       1857594        |        1146.4        |
+|        Darwin        |         112          |        120900        |        1714.7        |
+|        Hobart        |         1357         |        205556        |        619.5         |
+|        Sydney        |         2058         |       4336374        |        1214.8        |
+|      Melbourne       |         1566         |       3806092        |        646.9         |
+|        Perth         |         5386         |       1554769        |        869.4         |
++----------------------+----------------------+----------------------+----------------------+"""  # noqa: E501
+        )
+
+    def test_maxwidth_dict(
+        self,
+    ) -> None:
+        table = PrettyTable(
+            ["Field 1", "Field 2", "Field 3", "Field 4", "Field 5", "Field 6"],
+        )
+        table.max_width = {
+            "Field 1": 10,
+            "Field 2": 10,
+            "Field 3": 10,
+            "Field 4": 10,
+            "Field 5": 10,
+            "Field 6": 10,
+        }
+        print(table.max_width)
+        table.add_row(
+            [
+                "Lorem",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "ipsum",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+                "dolor",
+                "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam ",
+            ]
+        )
+
+        assert (
+            table.get_string().strip()
+            == """
++---------+------------+---------+------------+---------+------------+
+| Field 1 |  Field 2   | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+------------+---------+------------+---------+------------+
+|  Lorem  |   Lorem    |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         |   ipsum    |         |   ipsum    |         |   ipsum    |
+|         | dolor sit  |         | dolor sit  |         | dolor sit  |
+|         |   amet,    |         |   amet,    |         |   amet,    |
+|         | consetetur |         | consetetur |         | consetetur |
+|         | sadipscing |         | sadipscing |         | sadipscing |
+|         | elitr, sed |         | elitr, sed |         | elitr, sed |
+|         |    diam    |         |    diam    |         |    diam    |
++---------+------------+---------+------------+---------+------------+""".strip()
+        )
+
     def test_table_min_max_width_on_init_with_columns(self) -> None:
         table = PrettyTable(["Field 1", "Field 2"], min_width=20, max_width=40)
         table.add_row(

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1407,7 +1407,7 @@ class TestWidth:
         )
         table.max_width = {
             "Field 1": 10,
-            "Field 2": 10,
+            "Field 2": 20,
             "Field 3": 10,
             "Field 4": 10,
             "Field 5": 10,
@@ -1427,19 +1427,18 @@ class TestWidth:
 
         assert (
             table.get_string().strip()
-            == """
-+---------+------------+---------+------------+---------+------------+
-| Field 1 |  Field 2   | Field 3 |  Field 4   | Field 5 |  Field 6   |
-+---------+------------+---------+------------+---------+------------+
-|  Lorem  |   Lorem    |  ipsum  |   Lorem    |  dolor  |   Lorem    |
-|         |   ipsum    |         |   ipsum    |         |   ipsum    |
-|         | dolor sit  |         | dolor sit  |         | dolor sit  |
-|         |   amet,    |         |   amet,    |         |   amet,    |
-|         | consetetur |         | consetetur |         | consetetur |
-|         | sadipscing |         | sadipscing |         | sadipscing |
-|         | elitr, sed |         | elitr, sed |         | elitr, sed |
-|         |    diam    |         |    diam    |         |    diam    |
-+---------+------------+---------+------------+---------+------------+""".strip()
+            == """+---------+----------------------+---------+------------+---------+------------+
+| Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
++---------+----------------------+---------+------------+---------+------------+
+|  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         | sit amet, consetetur |         |   ipsum    |         |   ipsum    |
+|         |  sadipscing elitr,   |         | dolor sit  |         | dolor sit  |
+|         |       sed diam       |         |   amet,    |         |   amet,    |
+|         |                      |         | consetetur |         | consetetur |
+|         |                      |         | sadipscing |         | sadipscing |
+|         |                      |         | elitr, sed |         | elitr, sed |
+|         |                      |         |    diam    |         |    diam    |
++---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
         )
 
     def test_table_min_max_width_on_init_with_columns(self) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -896,7 +896,7 @@ class TestColumnFormattingfromDict:
 | Melbourne | 1566 |              3806092 |      646.9      |
 |   Perth   | 5386 |              1554769 |      869.4      |
 +-----------+------+----------------------+-----------------+
-"""strip()
+""".strip()
         )
 
     def test_set_float_format(self, city_data: PrettyTable) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -805,10 +805,10 @@ class TestColumnFormatingfromDict:
             == """+---------+----------------------+---------+------------+---------+------------+
 | Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
 +---------+----------------------+---------+------------+---------+------------+
-|  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
+|         |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
 |         | sit amet, consetetur |         |   ipsum    |         |   ipsum    |
 |         |  sadipscing elitr,   |         | dolor sit  |         | dolor sit  |
-|         |       sed diam       |         |   amet,    |         |   amet,    |
+|  Lorem  |       sed diam       |         |   amet,    |         |   amet,    |
 |         |                      |         | consetetur |         | consetetur |
 |         |                      |         | sadipscing |         | sadipscing |
 |         |                      |         | elitr, sed |         | elitr, sed |
@@ -925,7 +925,7 @@ class TestColumnFormatingfromDict:
 
     def test_set_none_format(self, city_data: PrettyTable) -> None:
         city_data.clear_rows()
-        city_data.add_row((None, None, None, None))
+        city_data.add_row([None, None, None, None])
         city_data.none_format = {"Annual Rainfall": "N/A"}
         assert (
             city_data.get_string()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -765,12 +765,13 @@ class TestFloatFormat:
         assert "001.41" in string
 
 
-class TestColumnFormatingfromDict:
+class TestColumnFormattingfromDict:
     def test_set_align_format(self, city_data: PrettyTable) -> None:
         city_data.align = {"Annual Rainfall": "r"}
         assert (
             city_data.get_string()
-            == """+-----------+------+------------+-----------------+
+            == """
++-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
 |  Adelaide | 1295 |  1158259   |           600.5 |
@@ -780,7 +781,8 @@ class TestColumnFormatingfromDict:
 |   Sydney  | 2058 |  4336374   |          1214.8 |
 | Melbourne | 1566 |  3806092   |           646.9 |
 |   Perth   | 5386 |  1554769   |           869.4 |
-+-----------+------+------------+-----------------+"""
++-----------+------+------------+-----------------+
+""".strip()
         )
 
     def test_set_valign_format(self, city_data: PrettyTable) -> None:
@@ -802,7 +804,8 @@ class TestColumnFormatingfromDict:
 
         assert (
             table.get_string()
-            == """+---------+----------------------+---------+------------+---------+------------+
+            == """
++---------+----------------------+---------+------------+---------+------------+
 | Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
 +---------+----------------------+---------+------------+---------+------------+
 |         |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
@@ -813,7 +816,8 @@ class TestColumnFormatingfromDict:
 |         |                      |         | sadipscing |         | sadipscing |
 |         |                      |         | elitr, sed |         | elitr, sed |
 |         |                      |         |    diam    |         |    diam    |
-+---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
++---------+----------------------+---------+------------+---------+------------+
+""".strip()
         )
 
     def test_max_width(
@@ -836,7 +840,8 @@ class TestColumnFormatingfromDict:
 
         assert (
             table.get_string()
-            == """+---------+----------------------+---------+------------+---------+------------+
+            == """
++---------+----------------------+---------+------------+---------+------------+
 | Field 1 |       Field 2        | Field 3 |  Field 4   | Field 5 |  Field 6   |
 +---------+----------------------+---------+------------+---------+------------+
 |  Lorem  |  Lorem ipsum dolor   |  ipsum  |   Lorem    |  dolor  |   Lorem    |
@@ -847,7 +852,8 @@ class TestColumnFormatingfromDict:
 |         |                      |         | sadipscing |         | sadipscing |
 |         |                      |         | elitr, sed |         | elitr, sed |
 |         |                      |         |    diam    |         |    diam    |
-+---------+----------------------+---------+------------+---------+------------+"""  # noqa: E501
++---------+----------------------+---------+------------+---------+------------+
+""".strip()
         )
 
     def test_min_width(self, city_data: PrettyTable) -> None:
@@ -859,7 +865,8 @@ class TestColumnFormatingfromDict:
         }
         assert (
             city_data.get_string()
-            == """+----------------------+------------+----------------------+----------------------+
+            == """
++----------------------+------------+----------------------+----------------------+
 |      City name       |    Area    |      Population      |   Annual Rainfall    |
 +----------------------+------------+----------------------+----------------------+
 |       Adelaide       |    1295    |       1158259        |        600.5         |
@@ -869,14 +876,16 @@ class TestColumnFormatingfromDict:
 |        Sydney        |    2058    |       4336374        |        1214.8        |
 |      Melbourne       |    1566    |       3806092        |        646.9         |
 |        Perth         |    5386    |       1554769        |        869.4         |
-+----------------------+------------+----------------------+----------------------+"""  # noqa: E501
++----------------------+------------+----------------------+----------------------+
+""".strip()
         )
 
     def test_set_int_format(self, city_data: PrettyTable) -> None:
         city_data.int_format = {"Population": "20"}
         assert (
             city_data.get_string()
-            == """+-----------+------+----------------------+-----------------+
+            == """
++-----------+------+----------------------+-----------------+
 | City name | Area |      Population      | Annual Rainfall |
 +-----------+------+----------------------+-----------------+
 |  Adelaide | 1295 |              1158259 |      600.5      |
@@ -886,14 +895,16 @@ class TestColumnFormatingfromDict:
 |   Sydney  | 2058 |              4336374 |      1214.8     |
 | Melbourne | 1566 |              3806092 |      646.9      |
 |   Perth   | 5386 |              1554769 |      869.4      |
-+-----------+------+----------------------+-----------------+"""
++-----------+------+----------------------+-----------------+
+"""strip()
         )
 
     def test_set_float_format(self, city_data: PrettyTable) -> None:
         city_data.float_format = {"Annual Rainfall": "4.2"}
         assert (
             city_data.get_string()
-            == """+-----------+------+------------+-----------------+
+            == """
++-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
 |  Adelaide | 1295 |  1158259   |      600.50     |
@@ -903,14 +914,16 @@ class TestColumnFormatingfromDict:
 |   Sydney  | 2058 |  4336374   |     1214.80     |
 | Melbourne | 1566 |  3806092   |      646.90     |
 |   Perth   | 5386 |  1554769   |      869.40     |
-+-----------+------+------------+-----------------+"""
++-----------+------+------------+-----------------+
+""".strip()
         )
 
     def test_set_custom_format(self, city_data: PrettyTable) -> None:
         city_data.custom_format = {"Annual Rainfall": lambda f, v: f"{v:.2f}"}
         assert (
             city_data.get_string()
-            == """+-----------+------+------------+-----------------+
+            == """
++-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
 |  Adelaide | 1295 |  1158259   |      600.50     |
@@ -920,7 +933,8 @@ class TestColumnFormatingfromDict:
 |   Sydney  | 2058 |  4336374   |     1214.80     |
 | Melbourne | 1566 |  3806092   |      646.90     |
 |   Perth   | 5386 |  1554769   |      869.40     |
-+-----------+------+------------+-----------------+"""
++-----------+------+------------+-----------------+
+""".strip()
         )
 
     def test_set_none_format(self, city_data: PrettyTable) -> None:
@@ -929,11 +943,13 @@ class TestColumnFormatingfromDict:
         city_data.none_format = {"Annual Rainfall": "N/A"}
         assert (
             city_data.get_string()
-            == """+-----------+------+------------+-----------------+
+            == """
++-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
 |    None   | None |    None    |       N/A       |
-+-----------+------+------------+-----------------+"""
++-----------+------+------------+-----------------+
+""".strip()
         )
 
 


### PR DESCRIPTION
fixes #398 

Enables to set dicts with column specific configuration to all column specific attrs (`align`, `valign`, `max_width`, `min_width`, `int_format`, `float_format`, `custom_format`, `none_format`) as the types definition allowed that.