### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["pypy3.11", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,10 @@ license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Luke Maurits", email = "luke@maurits.id.au" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -95,7 +94,7 @@ filterwarnings = [
 testpaths = [ "tests" ]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 pretty = true
 disallow_any_generics = true
 enable_error_code = "ignore-without-code"

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -44,10 +44,10 @@ TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping, Sequence
     from sqlite3 import Cursor
-    from typing import Final
+    from typing import Final, TypeAlias
 
     from _typeshed import SupportsRichComparison
-    from typing_extensions import Self, TypeAlias
+    from typing_extensions import Self
 
 
 class HRuleStyle(IntEnum):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 env_list =
     lint
     mypy
-    py{py3, 314, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
