### PR TITLE
Add support for Python 3.15 (and test 3.13t-3.15t)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ permissions: {}
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   test:
@@ -13,7 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - "pypy3.11"
+          - "3.15t"
+          - "3.15"
+          - "3.14t"
+          - "3.14"
+          - "3.13t"
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -27,12 +38,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      - name: Set PYTHON_GIL
+        if: endsWith(matrix.python-version, 't')
+        run: |
+          echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Tox tests
         run: |
-          uvx --with tox-uv tox -e py
+          uvx --python ${{ matrix.python-version }} --with tox-uv tox -e py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Text Processing",
@@ -85,7 +86,7 @@ lint.isort.known-first-party = [ "prettytable" ]
 lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 env_list =
     lint
     mypy
-    py{py3, 314, 313, 312, 311, 310}
+    py{py3, 315, 314, 313, 312, 311, 310, 315t, 314t, 313t}
 
 [testenv]
 extras =


### PR DESCRIPTION
Currently in alpha:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0790/

Also test the free-threaded `x.yt` versions.