### PR TITLE
Fix wrong misleading use of float format in tests

### DIFF
--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -577,12 +577,12 @@ class TestBasic:
 
     def test_no_blank_lines_with_float_format(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
-        city_data.float_format = "6.2f"
+        city_data.float_format = "6.2"
         self._test_no_blank_lines(city_data)
 
     def test_all_lengths_equal_with_float_format(self, city_data: PrettyTable) -> None:
         """All lines in a table should be of the same length."""
-        city_data.float_format = "6.2f"
+        city_data.float_format = "6.2"
         self._test_all_length_equal(city_data)
 
     def test_no_blank_lines_from_csv(self, city_data_from_csv: PrettyTable) -> None:
@@ -743,11 +743,11 @@ def float_pt() -> PrettyTable:
 
 class TestFloatFormat:
     def test_no_decimals(self, float_pt: PrettyTable) -> None:
-        float_pt.float_format = ".0f"
+        float_pt.float_format = ".0"
         assert "." not in float_pt.get_string()
 
     def test_round_to_5dp(self, float_pt: PrettyTable) -> None:
-        float_pt.float_format = ".5f"
+        float_pt.float_format = ".5"
         string = float_pt.get_string()
         assert "3.14159" in string
         assert "3.141592" not in string
@@ -758,7 +758,7 @@ class TestFloatFormat:
         assert "1.414213" not in string
 
     def test_pad_with_2zeroes(self, float_pt: PrettyTable) -> None:
-        float_pt.float_format = "06.2f"
+        float_pt.float_format = "06.2"
         string = float_pt.get_string()
         assert "003.14" in string
         assert "002.72" in string


### PR DESCRIPTION
While doing some tests with float_format i used the example from the tests. The trailing  `f` is not needed and misleading 