### PR TITLE
Overwrite int/float formatter with `custom_formatter`

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1235,7 +1235,9 @@ class PrettyTable:
             if field_name in self._none_format:
                 del self._none_format[field_name]
 
-        if isinstance(val, dict):
+        if val is None:
+            self._custom_format = {}
+        elif isinstance(val, dict):
             for field, fval in val.items():
                 self._validate_function(f"custom_value.{field}", fval)
                 remove_column_formatter(field)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -1289,6 +1289,17 @@ class PrettyTable:
         self,
         val: Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]] | None,
     ):
+        """Set custom format for columns using callable functions.
+
+        Arguments:
+            val: Can be:
+                - None: Clears all custom formats
+                - dict: Dictionary mapping field names to callable functions
+                - callable: A single callable function applied to all fields
+
+        Raises:
+            TypeError: If val is not None, a dict, or a callable
+        """
         if val is None:
             self._custom_format.clear()
         elif isinstance(val, dict):
@@ -1299,11 +1310,9 @@ class PrettyTable:
             self._validate_function("custom_value", val)
             for field in self._field_names:
                 self._custom_format[field] = val
-        elif isinstance(val, str):
+        else:
             msg = "The custom_format property need to be a dictionary or callable"
             raise TypeError(msg)
-        else:
-            self._custom_format.clear()
 
     @property
     def padding_width(self) -> int:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -789,10 +789,14 @@ class PrettyTable:
                 self._none_format[field] = None
             self._validate_none_format(val)
             for field in self._field_names:
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._none_format[field] = val
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_none_format(fval)
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._none_format[field] = fval
         else:
             for field in self._field_names:
@@ -1174,10 +1178,14 @@ class PrettyTable:
         if isinstance(val, str):
             self._validate_option("int_format", val)
             for field in self._field_names:
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._int_format[field] = val
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_option("int_format", fval)
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._int_format[field] = fval
         else:
             self._int_format = {}
@@ -1195,10 +1203,14 @@ class PrettyTable:
         if isinstance(val, str):
             self._validate_option("float_format", val)
             for field in self._field_names:
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._float_format[field] = val
         elif isinstance(val, dict) and val:
             for field, fval in val.items():
                 self._validate_option("float_format", fval)
+                if field in self._custom_format:
+                    del self._custom_format[field]
                 self._float_format[field] = fval
         else:
             self._float_format = {}
@@ -1216,21 +1228,27 @@ class PrettyTable:
         self,
         val: Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]] | None,
     ):
-        def replace_formatter(fld, func):
-            if fld in self._float_format:
-                del self._float_format[fld]
-            if fld in self._int_format:
-                del self._int_format[fld]
-            self._custom_format[field] = func
+        def remove_column_formatter(field_name: str) -> None:
+            """
+            remove all existing column formatters
+            """
+            if field_name in self._float_format:
+                del self._float_format[field_name]
+            if field_name in self._int_format:
+                del self._int_format[field_name]
+            if field_name in self._none_format:
+                del self._none_format[field_name]
 
         if isinstance(val, dict):
             for field, fval in val.items():
                 self._validate_function(f"custom_value.{field}", fval)
-                replace_formatter(field, fval)
+                remove_column_formatter(field)
+                self._custom_format[field] = fval
         elif hasattr(val, "__call__"):
             self._validate_function("custom_value", val)
             for field in self._field_names:
-                replace_formatter(field, val)
+                remove_column_formatter(field)
+                self._custom_format[field] = val
         elif isinstance(val, str):
             msg = "The custom_format property need to be a dictionary or callable"
             raise TypeError(msg)

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -782,9 +782,7 @@ class PrettyTable:
 
         val - The alternative representation to be used for None values
         """
-        if not self._field_names:
-            self._none_format = {}
-        elif isinstance(val, str):
+        if isinstance(val, str):
             for field in self._field_names:
                 self._none_format[field] = None
             self._validate_none_format(val)
@@ -799,8 +797,7 @@ class PrettyTable:
                     del self._custom_format[field]
                 self._none_format[field] = fval
         else:
-            for field in self._field_names:
-                self._none_format[field] = None
+            self._none_format = {}
 
     @property
     def field_names(self) -> list[str]:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -343,7 +343,9 @@ class PrettyTable:
         ]
 
         self._none_format: dict[str, str | None] = {}
-        self._custom_format: dict[str, Callable[[str, Any], str]] = {}
+        self._custom_format: (
+            Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]]
+        ) = {}
         self._kwargs = {}
         if field_names:
             self.field_names = field_names
@@ -1225,10 +1227,7 @@ class PrettyTable:
         self,
         val: Callable[[str, Any], str] | dict[str, Callable[[str, Any], str]] | None,
     ):
-        def remove_column_formatter(field_name: str) -> None:
-            """
-            remove all existing column formatters
-            """
+        def remove_column_formatter(field_name):
             if field_name in self._float_format:
                 del self._float_format[field_name]
             if field_name in self._int_format:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -764,22 +764,6 @@ class TestFloatFormat:
         assert "002.72" in string
         assert "001.41" in string
 
-    def test_overwrite_default_format(self, float_pt: PrettyTable) -> None:
-        float_pt.float_format = "6.2"
-        # FIXME: Why? This type of call is not logged?
-        float_pt.custom_format["Value"] = lambda f, v: f"+++{v}+++"
-        assert (
-            float_pt.get_string()
-            == """
-+----------+--------------------------+
-| Constant |          Value           |
-+----------+--------------------------+
-|    Pi    | +++3.141592653589793+++  |
-|    e     | +++2.718281828459045+++  |
-| sqrt(2)  | +++1.4142135623730951+++ |
-+----------+--------------------------+""".strip()
-        )
-
     def test_overwrite_default_format_dict(self, float_pt: PrettyTable) -> None:
         float_pt.float_format = "6.2"
         float_pt.custom_format = {"Value": lambda f, v: f"+++{v:.4f}+++"}

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -154,6 +154,38 @@ class TestNoneOption:
 """.strip()
         )
 
+    def test_replace_custom_format_with_none(self) -> None:
+        table = PrettyTable()
+        table.custom_format = {"Field 2": lambda f, v: f"'{v}'"}
+        table.add_row(["Hello", None, "World"])
+        table.none_format = "0123456789"
+        assert (
+            table.get_string().strip()
+            == """
++---------+------------+---------+
+| Field 1 |  Field 2   | Field 3 |
++---------+------------+---------+
+|  Hello  | 0123456789 |  World  |
++---------+------------+---------+
+""".strip()
+        )
+
+    def test_replace_custom_format_with_none_dict(self) -> None:
+        table = PrettyTable()
+        table.custom_format = {"Field 2": lambda f, v: f"'{v}'"}
+        table.add_row(["Hello", None, "World"])
+        table.none_format = {"Field 2": "0123456789"}
+        assert (
+            table.get_string().strip()
+            == """
++---------+------------+---------+
+| Field 1 |  Field 2   | Field 3 |
++---------+------------+---------+
+|  Hello  | 0123456789 |  World  |
++---------+------------+---------+
+""".strip()
+        )
+
 
 class TestBuildEquivalence:
     """Make sure that building a table row-by-row and column-by-column yield the same
@@ -899,8 +931,87 @@ class TestColumnFormattingfromDict:
 """.strip()
         )
 
+    def test_set_int_format_overwrite_dict(self, city_data: PrettyTable) -> None:
+        city_data.custom_format = {"Population": lambda f, v: f"'{v}'"}
+        city_data.int_format = {"Population": "20"}
+        assert (
+            city_data.get_string()
+            == """
++-----------+------+----------------------+-----------------+
+| City name | Area |      Population      | Annual Rainfall |
++-----------+------+----------------------+-----------------+
+|  Adelaide | 1295 |              1158259 |      600.5      |
+|  Brisbane | 5905 |              1857594 |      1146.4     |
+|   Darwin  | 112  |               120900 |      1714.7     |
+|   Hobart  | 1357 |               205556 |      619.5      |
+|   Sydney  | 2058 |              4336374 |      1214.8     |
+| Melbourne | 1566 |              3806092 |      646.9      |
+|   Perth   | 5386 |              1554769 |      869.4      |
++-----------+------+----------------------+-----------------+
+""".strip()
+        )
+
+    def test_set_int_format_overwrite(self, city_data: PrettyTable) -> None:
+        city_data.custom_format = {"Population": lambda f, v: f"'{v}'"}
+        city_data.int_format = "20"
+        assert (
+            city_data.get_string()
+            == """
++-----------+----------------------+----------------------+-----------------+
+| City name |         Area         |      Population      | Annual Rainfall |
++-----------+----------------------+----------------------+-----------------+
+|  Adelaide |                 1295 |              1158259 |      600.5      |
+|  Brisbane |                 5905 |              1857594 |      1146.4     |
+|   Darwin  |                  112 |               120900 |      1714.7     |
+|   Hobart  |                 1357 |               205556 |      619.5      |
+|   Sydney  |                 2058 |              4336374 |      1214.8     |
+| Melbourne |                 1566 |              3806092 |      646.9      |
+|   Perth   |                 5386 |              1554769 |      869.4      |
++-----------+----------------------+----------------------+-----------------+""".strip()
+        )
+
     def test_set_float_format(self, city_data: PrettyTable) -> None:
         city_data.float_format = {"Annual Rainfall": "4.2"}
+        assert (
+            city_data.get_string()
+            == """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.50     |
+|  Brisbane | 5905 |  1857594   |     1146.40     |
+|   Darwin  | 112  |   120900   |     1714.70     |
+|   Hobart  | 1357 |   205556   |      619.50     |
+|   Sydney  | 2058 |  4336374   |     1214.80     |
+| Melbourne | 1566 |  3806092   |      646.90     |
+|   Perth   | 5386 |  1554769   |      869.40     |
++-----------+------+------------+-----------------+
+""".strip()
+        )
+
+    def test_set_float_format_overwrite_dict(self, city_data: PrettyTable) -> None:
+        city_data.custom_format = {"Annual Rainfall": lambda f, v: f"'{v}'"}
+        city_data.float_format = {"Annual Rainfall": "4.2"}
+        assert (
+            city_data.get_string()
+            == """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.50     |
+|  Brisbane | 5905 |  1857594   |     1146.40     |
+|   Darwin  | 112  |   120900   |     1714.70     |
+|   Hobart  | 1357 |   205556   |      619.50     |
+|   Sydney  | 2058 |  4336374   |     1214.80     |
+| Melbourne | 1566 |  3806092   |      646.90     |
+|   Perth   | 5386 |  1554769   |      869.40     |
++-----------+------+------------+-----------------+
+""".strip()
+        )
+
+    def test_set_float_format_overwrite(self, city_data: PrettyTable) -> None:
+        city_data.custom_format = {"Annual Rainfall": lambda f, v: f"'{v}'"}
+        city_data.float_format = "4.2"
         assert (
             city_data.get_string()
             == """
@@ -1232,6 +1343,7 @@ class TestCustomFormatter:
         )
 
     def test_overwrite_default_format_dict(self, city_data: PrettyTable) -> None:
+        city_data.none_format = "N/A"
         city_data.float_format = "6.2"
         city_data.int_format = "10"
         city_data.custom_format = {"Annual Rainfall": lambda f, v: f"+++{v:.4f}+++"}

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -764,6 +764,37 @@ class TestFloatFormat:
         assert "002.72" in string
         assert "001.41" in string
 
+    def test_overwrite_default_format(self, float_pt: PrettyTable) -> None:
+        float_pt.float_format = "6.2"
+        # FIXME: Why? This type of call is not logged?
+        float_pt.custom_format["Value"] = lambda f, v: f"+++{v}+++"
+        assert (
+            float_pt.get_string()
+            == """
++----------+--------------------------+
+| Constant |          Value           |
++----------+--------------------------+
+|    Pi    | +++3.141592653589793+++  |
+|    e     | +++2.718281828459045+++  |
+| sqrt(2)  | +++1.4142135623730951+++ |
++----------+--------------------------+""".strip()
+        )
+
+    def test_overwrite_default_format_dict(self, float_pt: PrettyTable) -> None:
+        float_pt.float_format = "6.2"
+        float_pt.custom_format = {"Value": lambda f, v: f"+++{v}+++"}
+        assert (
+            float_pt.get_string()
+            == """
++----------+--------------------------+
+| Constant |          Value           |
++----------+--------------------------+
+|    Pi    | +++3.141592653589793+++  |
+|    e     | +++2.718281828459045+++  |
+| sqrt(2)  | +++1.4142135623730951+++ |
++----------+--------------------------+""".strip()
+        )
+
 
 class TestColumnFormattingfromDict:
     def test_set_align_format(self, city_data: PrettyTable) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1342,6 +1342,26 @@ class TestCustomFormatter:
 """.strip()
         )
 
+    def test_overwrite_default_format(self, city_data: PrettyTable) -> None:
+        city_data.float_format = "6.2"
+        city_data.int_format = "10"
+        city_data.custom_format["Annual Rainfall"] = lambda f, v: f"+++{v:.4f}+++"
+        assert (
+            city_data.get_string()
+            == """
++-----------+------------+------------+-----------------+
+| City name |    Area    | Population | Annual Rainfall |
++-----------+------------+------------+-----------------+
+|  Adelaide |       1295 |    1158259 |  +++600.5000+++ |
+|  Brisbane |       5905 |    1857594 | +++1146.4000+++ |
+|   Darwin  |        112 |     120900 | +++1714.7000+++ |
+|   Hobart  |       1357 |     205556 |  +++619.5000+++ |
+|   Sydney  |       2058 |    4336374 | +++1214.8000+++ |
+| Melbourne |       1566 |    3806092 |  +++646.9000+++ |
+|   Perth   |       5386 |    1554769 |  +++869.4000+++ |
++-----------+------------+------------+-----------------+""".strip()
+        )
+
     def test_overwrite_default_format_dict(self, city_data: PrettyTable) -> None:
         city_data.none_format = "N/A"
         city_data.float_format = "6.2"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -782,17 +782,17 @@ class TestFloatFormat:
 
     def test_overwrite_default_format_dict(self, float_pt: PrettyTable) -> None:
         float_pt.float_format = "6.2"
-        float_pt.custom_format = {"Value": lambda f, v: f"+++{v}+++"}
+        float_pt.custom_format = {"Value": lambda f, v: f"+++{v:.4f}+++"}
         assert (
             float_pt.get_string()
             == """
-+----------+--------------------------+
-| Constant |          Value           |
-+----------+--------------------------+
-|    Pi    | +++3.141592653589793+++  |
-|    e     | +++2.718281828459045+++  |
-| sqrt(2)  | +++1.4142135623730951+++ |
-+----------+--------------------------+""".strip()
++----------+--------------+
+| Constant |    Value     |
++----------+--------------+
+|    Pi    | +++3.1416+++ |
+|    e     | +++2.7183+++ |
+| sqrt(2)  | +++1.4142+++ |
++----------+--------------+""".strip()
         )
 
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -764,21 +764,6 @@ class TestFloatFormat:
         assert "002.72" in string
         assert "001.41" in string
 
-    def test_overwrite_default_format_dict(self, float_pt: PrettyTable) -> None:
-        float_pt.float_format = "6.2"
-        float_pt.custom_format = {"Value": lambda f, v: f"+++{v:.4f}+++"}
-        assert (
-            float_pt.get_string()
-            == """
-+----------+--------------+
-| Constant |    Value     |
-+----------+--------------+
-|    Pi    | +++3.1416+++ |
-|    e     | +++2.7183+++ |
-| sqrt(2)  | +++1.4142+++ |
-+----------+--------------+""".strip()
-        )
-
 
 class TestColumnFormattingfromDict:
     def test_set_align_format(self, city_data: PrettyTable) -> None:
@@ -1244,6 +1229,26 @@ class TestCustomFormatter:
 | 01 Feb 2021 | February | 54321.123 | 87,654,321 |
 +-------------+----------+-----------+------------+
 """.strip()
+        )
+
+    def test_overwrite_default_format_dict(self, city_data: PrettyTable) -> None:
+        city_data.float_format = "6.2"
+        city_data.int_format = "10"
+        city_data.custom_format = {"Annual Rainfall": lambda f, v: f"+++{v:.4f}+++"}
+        assert (
+            city_data.get_string()
+            == """
++-----------+------------+------------+-----------------+
+| City name |    Area    | Population | Annual Rainfall |
++-----------+------------+------------+-----------------+
+|  Adelaide |       1295 |    1158259 |  +++600.5000+++ |
+|  Brisbane |       5905 |    1857594 | +++1146.4000+++ |
+|   Darwin  |        112 |     120900 | +++1714.7000+++ |
+|   Hobart  |       1357 |     205556 |  +++619.5000+++ |
+|   Sydney  |       2058 |    4336374 | +++1214.8000+++ |
+| Melbourne |       1566 |    3806092 |  +++646.9000+++ |
+|   Perth   |       5386 |    1554769 |  +++869.4000+++ |
++-----------+------------+------------+-----------------+""".strip()
         )
 
 


### PR DESCRIPTION
Fixes #247 

Remove existing float / int / None formatters for column if a custom_formatter is applied.

So either a custom_formatter or a type specific formatter can be set.

Used the same pattern in  custom_formatter setter as with float and int formatters

It's not an ideal solution, because only one formatter should be installed for a column at any time. But that would require a larger rewrite.