### PR TITLE
Validate column-specific options when dict attrs are modified

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -130,6 +130,7 @@ class ObservableDict(dict[str, Any]):
             self.callback(key, old_value, value)
         super().__setitem__(key, value)
 
+
 class OptionsType(TypedDict):
     title: str | None
     start: int

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -389,10 +389,10 @@ class PrettyTable:
         self._valign: dict[str, str | None] = ObservableDict()
         self._valign.callback = self._valign_callback
 
-        self._max_width: dict[str, str | None] = ObservableDict()
+        self._max_width: dict[str, int | None] = ObservableDict()
         self._max_width.callback = self._max_width_callback
 
-        self._min_width: dict[str, str | None] = ObservableDict()
+        self._min_width: dict[str, int | None] = ObservableDict()
         self._min_width.callback = self._min_width_callback
 
         self._kwargs = {}
@@ -890,10 +890,10 @@ class PrettyTable:
         """Callback to call validators if dict attrs are modified.
 
         This callback is triggered when a field is modified from align dict and
-        calls the validator for the new val.
+        calls the validator for the new value.
 
         Arguments:
-            field_name: Name of the field being removed
+            field_name: Name of the field being modified
             old_value: Previous value (unused)
             new_value: New value (unused)
 
@@ -930,10 +930,10 @@ class PrettyTable:
         """Callback to call validators if dict attrs are modified.
 
         This callback is triggered when a field is modified from valign dict
-        and calls the validator for the new val.
+        and calls the validator for the new value.
 
         Arguments:
-            field_name: Name of the field being removed
+            field_name: Name of the field being modified
             old_value: Previous value (unused)
             new_value: New value (unused)
 
@@ -966,10 +966,10 @@ class PrettyTable:
         """Callback to call validators if dict attrs are modified.
 
         This callback is triggered when a field is modified from max_width dict
-        and calls the validator for the new val.
+        and calls the validator for the new value.
 
         Arguments:
-            field_name: Name of the field being removed
+            field_name: Name of the field being modified
             old_value: Previous value (unused)
             new_value: New value (unused)
 
@@ -999,10 +999,10 @@ class PrettyTable:
         """Callback to call validators if dict attrs are modified.
 
         This callback is triggered when a field is modified from min_width dict
-        and calls the validator for the new val.
+        and calls the validator for the new value.
 
         Arguments:
-            field_name: Name of the field being removed
+            field_name: Name of the field being modified
             old_value: Previous value (unused)
             new_value: New value (unused)
 

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -965,7 +965,7 @@ class PrettyTable:
     def _max_width_callback(self, field_name, old_value, new_value):
         """Callback to call validators if dict attrs are modified.
 
-        This callback is triggered when a field is modified from valign dict
+        This callback is triggered when a field is modified from max_width dict
         and calls the validator for the new val.
 
         Arguments:
@@ -998,7 +998,7 @@ class PrettyTable:
     def _min_width_callback(self, field_name, old_value, new_value):
         """Callback to call validators if dict attrs are modified.
 
-        This callback is triggered when a field is modified from valign dict
+        This callback is triggered when a field is modified from min_width dict
         and calls the validator for the new val.
 
         Arguments:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -316,10 +316,6 @@ class PrettyTable:
         self._field_names: list[str] = []
         self._rows: list[RowType] = []
         self._dividers: list[bool] = []
-        self.align = {}
-        self.valign = {}
-        self.max_width = {}
-        self.min_width = {}
         self._style = None
 
         # Options
@@ -955,7 +951,7 @@ class PrettyTable:
     @valign.setter
     def valign(self, val: VAlignType | dict[str, VAlignType] | None) -> None:
         if not self._field_names:
-            self._valign = {}
+            self._valign.clear()
         if isinstance(val, str):
             for field in self._field_names:
                 self._valign[field] = val
@@ -997,7 +993,7 @@ class PrettyTable:
             for field, fval in val.items():
                 self._max_width[field] = fval
         else:
-            self._max_width = {}
+            self._max_width.clear()
 
     def _min_width_callback(self, field_name, old_value, new_value):
         """Callback to call validators if dict attrs are modified.
@@ -1030,7 +1026,7 @@ class PrettyTable:
             for field, fval in val.items():
                 self._min_width[field] = fval
         else:
-            self._min_width = {}
+            self._min_width.clear()
 
     @property
     def min_table_width(self) -> int | None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -413,12 +413,11 @@ class TestAlignment:
 
     def test_aligned_one_column_invalid(self, city_data: PrettyTable) -> None:
         with pytest.raises(ValueError):
-            city_data.align["Population"] = "rice"
+            city_data.align["Population"] = "rice"  # type: ignore[assignment]
 
     def test_aligned_one_column_invalid_dict(self, city_data: PrettyTable) -> None:
         with pytest.raises(ValueError):
-            city_data.align = {"Population": "rice"}
-
+            city_data.align = {"Population": "rice"}  # type: ignore[dict-item]
 
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -413,11 +413,11 @@ class TestAlignment:
 
     def test_aligned_one_column_invalid(self, city_data: PrettyTable) -> None:
         with pytest.raises(ValueError):
-            city_data.align["Population"] = "rice"  # type: ignore[assignment]
+            city_data.align["Population"] = "unexpected"  # type: ignore[assignment]
 
     def test_aligned_one_column_invalid_dict(self, city_data: PrettyTable) -> None:
         with pytest.raises(ValueError):
-            city_data.align = {"Population": "rice"}  # type: ignore[dict-item]
+            city_data.align = {"Population": "unexpected"}  # type: ignore[dict-item]
 
 
 class TestOptionOverride:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -395,7 +395,9 @@ class TestAlignment:
 
     def test_aligned_one_column(self, city_data: PrettyTable) -> None:
         city_data.align["Population"] = "r"
-        assert city_data.get_string() == """
+        assert (
+            city_data.get_string()
+            == """
 +-----------+------+------------+-----------------+
 | City name | Area | Population | Annual Rainfall |
 +-----------+------+------------+-----------------+
@@ -407,6 +409,7 @@ class TestAlignment:
 | Melbourne | 1566 |    3806092 |      646.9      |
 |   Perth   | 5386 |    1554769 |      869.4      |
 +-----------+------+------------+-----------------+""".strip()
+        )
 
     def test_aligned_one_column_invalid(self, city_data: PrettyTable) -> None:
         with pytest.raises(ValueError) as e:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -412,11 +412,11 @@ class TestAlignment:
         )
 
     def test_aligned_one_column_invalid(self, city_data: PrettyTable) -> None:
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             city_data.align["Population"] = "rice"
 
     def test_aligned_one_column_invalid_dict(self, city_data: PrettyTable) -> None:
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             city_data.align = {"Population": "rice"}
 
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -419,6 +419,7 @@ class TestAlignment:
         with pytest.raises(ValueError):
             city_data.align = {"Population": "rice"}  # type: ignore[dict-item]
 
+
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -393,6 +393,29 @@ class TestAlignment:
             header=True
         ) == aligned_after_table.get_mediawiki_string(header=True)
 
+    def test_aligned_one_column(self, city_data: PrettyTable) -> None:
+        city_data.align["Population"] = "r"
+        assert city_data.get_string() == """
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |    1158259 |      600.5      |
+|  Brisbane | 5905 |    1857594 |      1146.4     |
+|   Darwin  | 112  |     120900 |      1714.7     |
+|   Hobart  | 1357 |     205556 |      619.5      |
+|   Sydney  | 2058 |    4336374 |      1214.8     |
+| Melbourne | 1566 |    3806092 |      646.9      |
+|   Perth   | 5386 |    1554769 |      869.4      |
++-----------+------+------------+-----------------+""".strip()
+
+    def test_aligned_one_column_invalid(self, city_data: PrettyTable) -> None:
+        with pytest.raises(ValueError) as e:
+            city_data.align["Population"] = "rice"
+
+    def test_aligned_one_column_invalid_dict(self, city_data: PrettyTable) -> None:
+        with pytest.raises(ValueError) as e:
+            city_data.align = {"Population": "rice"}
+
 
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""


### PR DESCRIPTION
# Call validators for column specific options if dict attrs where modified

E.g. 
```python 
table["Field 1].align = "rice"
```

should raise an Exception, because of an invalid value

* fixes #202 
* Something similar, only for align/valign was tried in #207 

