### PR TITLE
No need to ignore Ruff rule UP038 since 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ lint.ignore = [
   "E226",   # Missing whitespace around arithmetic operator
   "E241",   # Multiple spaces after ','
   "PIE790", # flake8-pie: unnecessary-placeholder
-  "UP038",  # Makes code slower and more verbose
 ]
 lint.flake8-import-conventions.aliases.datetime = "dt"
 lint.flake8-import-conventions.banned-from = [ "datetime" ]


### PR DESCRIPTION
This rule has been removed:
https://docs.astral.sh/ruff/rules/non-pep604-isinstance/