### PR TITLE
wcwidth now has type hints

### DIFF
--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,3 +1,2 @@
 mypy==1.19.1
 types-colorama
-wcwidth-stubs


### PR DESCRIPTION
So we don't need to use wcwidth-stubs.

https://github.com/jquast/wcwidth/releases/tag/0.3.3