### PR TITLE
Replace `re.split` with `str.split` and remove `re` import

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -32,7 +32,6 @@
 from __future__ import annotations
 
 import io
-import re
 from enum import IntEnum
 from functools import lru_cache
 from html.parser import HTMLParser
@@ -3207,11 +3206,11 @@ def from_mediawiki(wiki_text: str, **kwargs) -> PrettyTable:
         if line.startswith("|+"):
             continue
         if line.startswith("!"):
-            header = [cell.strip() for cell in re.split(r"\s*!!\s*", line[1:])]
+            header = [cell.strip() for cell in line[1:].split("!!")]
             table.field_names = header
             continue
         if line.startswith("|"):
-            row_data = [cell.strip() for cell in re.split(r"\s*\|\|\s*", line[1:])]
+            row_data = [cell.strip() for cell in line[1:].split("||")]
             rows.append(row_data)
             continue
 


### PR DESCRIPTION
https://github.com/prettytable/prettytable/pull/440 removed some regexes, and the remaining two don't need to be regexes:

```python
[cell.strip() for cell in re.split(r"\s*!!\s*", line[1:])]
```

We call `strip()` on each `cell`, so the `\s*` handling is redundant.

Let's use `str.split` instead and remove the `re` import.