### PR TITLE
Remove duplicate line

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2925,7 +2925,6 @@ class PrettyTable:
         # Data
         rows = self._get_rows(options)
         formatted_rows = self._format_rows(rows)
-        rows = self._get_rows(options)
         for row in formatted_rows:
             wanted_data = [
                 d for f, d in zip(self._field_names, row) if f in wanted_fields


### PR DESCRIPTION
`rows = self._get_rows(options)` is called twice, and the second time `rows` isn't used.