### PR TITLE
Support `int_format`, `float_format` and `custom_format` for CSV

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2547,7 +2547,7 @@ class PrettyTable:
             else:
                 csv_writer.writerow(self._field_names)
 
-        rows = self._get_rows(options)
+        rows = self._format_rows(self._get_rows(options))
         if options["fields"]:
             rows = [
                 [d for f, d in zip(self._field_names, row) if f in options["fields"]]

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1376,6 +1376,22 @@ class TestCsvOutput:
             "value 7,value9\r\n"
         )
 
+    def test_csv_formatting(self) -> None:
+        table = PrettyTable()
+        table.add_column("Name", ["Alice", "Bob", "Charlie"])
+        table.add_column("int_format", [7, 0, -42])
+        table.add_column("float_format", [3.14159, 10.0, -2.71828])
+        table.add_column("custom_format", [1234, 0, -5678])
+        table.int_format["int_format"] = "05"
+        table.float_format["float_format"] = ".1"
+        table.custom_format["custom_format"] = lambda f, v: f"{v:,}"
+        assert table.get_csv_string() == (
+            "Name,int_format,float_format,custom_format\r\n"
+            'Alice,00007,3.1,"1,234"\r\n'
+            "Bob,00000,10.0,0\r\n"
+            'Charlie,-0042,-2.7,"-5,678"\r\n'
+        )
+
 
 def test_paginate(city_data: PrettyTable) -> None:
     expected_page_1 = """


### PR DESCRIPTION
# Demo

```python
from prettytable import PrettyTable

table = PrettyTable()
table.add_column("Name", ["Alice", "Bob", "Charlie"])
table.add_column("int_format", [7, 0, -42])
table.add_column("float_format", [3.14159, 10.0, -2.71828])
table.add_column("custom_format", [1234, 0, -5678])
table.int_format["int_format"] = "05"
table.float_format["float_format"] = ".1"
table.custom_format["custom_format"] = lambda f, v: f"{v:,}"

print(table.get_csv_string())
```


# Before

```csv
Name,int_format,float_format,custom_format
Alice,7,3.14159,1234
Bob,0,10.0,0
Charlie,-42,-2.71828,-5678
```

# After

```csv
Name,int_format,float_format,custom_format
Alice,00007,3.1,"1,234"
Bob,00000,10.0,0
Charlie,-0042,-2.7,"-5,678"
```