### PR TITLE
Support multiline headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,39 @@ to get a table like this:
 
 Any added dividers will be removed if a table is sorted.
 
+### Adding a title to your table
+
+You can add a title to your table with the `title` attribute:
+
+```python
+table.title = "Australian Cities"
+```
+
+Titles can span multiple lines by including `\n` in the string:
+
+```python
+table.title = "Australian Cities\nPopulation Data"
+print(table)
+```
+
+This produces:
+
+```
++-------------------------------------------------+
+|                Australian Cities                |
+|                 Population Data                 |
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+|   Darwin  | 112  |   120900   |      1714.7     |
++-----------+------+------------+-----------------+
+```
+
+Each line of the title is centered and bordered independently. Multiline titles also
+work with HTML output (using `<br>` in the `<caption>` tag) and Markdown output.
+
 ### Changing the appearance of your table - the easy way
 
 By default, PrettyTable produces ASCII tables that look like the ones used in SQL

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2370,12 +2370,10 @@ class PrettyTable:
         lpad, rpad = self._get_padding_widths(options)
         sum_widths = sum([n + lpad + rpad + 1 for n in self._widths])
         for title_line in title.split("\n"):
-            bits: list[str] = []
-            bits.append(endpoint)
             padded = " " * lpad + title_line + " " * rpad
-            bits.append(self._justify(padded, sum_widths - 1, "c"))
-            bits.append(endpoint)
-            lines.append("".join(bits))
+            lines.append(
+                endpoint + self._justify(padded, sum_widths - 1, "c") + endpoint
+            )
         return "\n".join(lines)
 
     def _stringify_header(self, options: OptionsType) -> str:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2046,7 +2046,10 @@ class PrettyTable:
         # Are we under min_table_width or title width?
         if self._min_table_width or options["title"]:
             if options["title"]:
-                title_width = _str_block_width(options["title"]) + per_col_padding
+                title_width = (
+                    max(_str_block_width(line) for line in options["title"].split("\n"))
+                    + per_col_padding
+                )
                 if options["vrules"] in (VRuleStyle.FRAME, VRuleStyle.ALL):
                     title_width += 2
             else:
@@ -2220,7 +2223,7 @@ class PrettyTable:
             if self._style != TableStyle.MARKDOWN:
                 lines.append(self._stringify_title(title, options))
             else:
-                lines.extend([f"**{title}**", ""])
+                lines.extend([f"**{line}**" for line in title.split("\n")] + [""])
 
         # Add header or top of border
         if options["header"]:
@@ -2319,21 +2322,21 @@ class PrettyTable:
                 options["vrules"] = VRuleStyle.ALL
             elif options["vrules"] == VRuleStyle.FRAME:
                 lines.append(self._stringify_hrule(options, "top_"))
-        bits: list[str] = []
         endpoint = (
             options["vertical_char"]
             if options["vrules"] in (VRuleStyle.ALL, VRuleStyle.FRAME)
             and options["border"]
             else " "
         )
-        bits.append(endpoint)
-        title = " " * lpad + title + " " * rpad
         lpad, rpad = self._get_padding_widths(options)
         sum_widths = sum([n + lpad + rpad + 1 for n in self._widths])
-
-        bits.append(self._justify(title, sum_widths - 1, "c"))
-        bits.append(endpoint)
-        lines.append("".join(bits))
+        for title_line in title.split("\n"):
+            bits: list[str] = []
+            bits.append(endpoint)
+            padded = " " * lpad + title_line + " " * rpad
+            bits.append(self._justify(padded, sum_widths - 1, "c"))
+            bits.append(endpoint)
+            lines.append("".join(bits))
         return "\n".join(lines)
 
     def _stringify_header(self, options: OptionsType) -> str:
@@ -2669,7 +2672,11 @@ class PrettyTable:
         # Title
         title = options["title"] or self._title
         if title:
-            lines.append(f"    <caption>{escape(title)}</caption>")
+            lines.append(
+                f"    <caption>"
+                f"{escape(title).replace(chr(10), linebreak)}"
+                f"</caption>"
+            )
 
         # Headers
         if options["header"]:
@@ -2755,7 +2762,11 @@ class PrettyTable:
         # Title
         title = options["title"] or self._title
         if title:
-            lines.append(f"    <caption>{escape(title)}</caption>")
+            lines.append(
+                f"    <caption>"
+                f"{escape(title).replace(chr(10), linebreak)}"
+                f"</caption>"
+            )
 
         # Headers
         if options["header"]:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2720,11 +2720,8 @@ class PrettyTable:
         # Title
         title = options["title"] or self._title
         if title:
-            lines.append(
-                f"    <caption>"
-                f"{escape(title).replace(chr(10), linebreak)}"
-                f"</caption>"
-            )
+            caption = escape(title).replace("\n", linebreak)
+            lines.append(f"    <caption>{caption}</caption>")
 
         # Headers
         if options["header"]:
@@ -2810,11 +2807,8 @@ class PrettyTable:
         # Title
         title = options["title"] or self._title
         if title:
-            lines.append(
-                f"    <caption>"
-                f"{escape(title).replace(chr(10), linebreak)}"
-                f"</caption>"
-            )
+            caption = escape(title).replace("\n", linebreak)
+            lines.append(f"    <caption>{caption}</caption>")
 
         # Headers
         if options["header"]:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2353,7 +2353,6 @@ class PrettyTable:
 
     def _stringify_title(self, title: str, options: OptionsType) -> str:
         lines: list[str] = []
-        lpad, rpad = self._get_padding_widths(options)
         if options["border"]:
             if options["vrules"] == VRuleStyle.ALL:
                 options["vrules"] = VRuleStyle.FRAME

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -622,23 +622,25 @@ class TestBasic:
     def test_multiline_title(self, city_data: PrettyTable) -> None:
         """A title with \\n should produce multiple bordered title lines."""
         city_data.title = "Line 1\nLine 2"
-        string = city_data.get_string()
-        lines = string.split("\n")
-        # First line is top hrule, next two are title lines
-        assert lines[1].startswith("|")
-        assert lines[1].endswith("|")
-        assert "Line 1" in lines[1]
-        assert "Line 2" in lines[2]
-
-    def test_multiline_title_no_blank_lines(self, city_data: PrettyTable) -> None:
-        """No table should ever have blank lines in it."""
-        city_data.title = "Line 1\nLine 2"
-        self._test_no_blank_lines(city_data)
-
-    def test_multiline_title_all_lengths_equal(self, city_data: PrettyTable) -> None:
-        """All lines in a table should be of the same length."""
-        city_data.title = "Line 1\nLine 2"
-        self._test_all_length_equal(city_data)
+        assert (
+            city_data.get_string()
+            == """
++-------------------------------------------------+
+|                      Line 1                     |
+|                      Line 2                     |
++-----------+------+------------+-----------------+
+| City name | Area | Population | Annual Rainfall |
++-----------+------+------------+-----------------+
+|  Adelaide | 1295 |  1158259   |      600.5      |
+|  Brisbane | 5905 |  1857594   |      1146.4     |
+|   Darwin  | 112  |   120900   |      1714.7     |
+|   Hobart  | 1357 |   205556   |      619.5      |
+|   Sydney  | 2058 |  4336374   |      1214.8     |
+| Melbourne | 1566 |  3806092   |      646.9      |
+|   Perth   | 5386 |  1554769   |      869.4      |
++-----------+------+------------+-----------------+
+""".strip()
+        )
 
     def test_multiline_title_html(self, city_data: PrettyTable) -> None:
         """Multiline titles should use <br> in HTML caption."""

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -619,6 +619,34 @@ class TestBasic:
         city_data.title = "My table (75 characters wide) " + "=" * 45
         self._test_all_length_equal(city_data)
 
+    def test_multiline_title(self, city_data: PrettyTable) -> None:
+        """A title with \\n should produce multiple bordered title lines."""
+        city_data.title = "Line 1\nLine 2"
+        string = city_data.get_string()
+        lines = string.split("\n")
+        # First line is top hrule, next two are title lines
+        assert lines[1].startswith("|")
+        assert lines[1].endswith("|")
+        assert "Line 1" in lines[1]
+        assert "Line 2" in lines[2]
+
+    def test_multiline_title_no_blank_lines(self, city_data: PrettyTable) -> None:
+        """No table should ever have blank lines in it."""
+        city_data.title = "Line 1\nLine 2"
+        self._test_no_blank_lines(city_data)
+
+    def test_multiline_title_all_lengths_equal(self, city_data: PrettyTable) -> None:
+        """All lines in a table should be of the same length."""
+        city_data.title = "Line 1\nLine 2"
+        self._test_all_length_equal(city_data)
+
+    def test_multiline_title_html(self, city_data: PrettyTable) -> None:
+        """Multiline titles should use <br> in HTML caption."""
+        city_data.title = "Line 1\nLine 2"
+        html = city_data.get_html_string()
+        assert "<br>" in html
+        assert "<caption>" in html
+
     def test_no_blank_lines_without_border(self, city_data: PrettyTable) -> None:
         """No table should ever have blank lines in it."""
         city_data.border = False

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -70,24 +70,28 @@ def test_rst_style_does_not_leak(helper_table: PrettyTable) -> None:
 
 
 def test_rst_output_with_multiline_title(helper_table: PrettyTable) -> None:
+    # Arrange
     helper_table.set_style(TableStyle.RST)
+    # Act
     helper_table.title = "Line 1\nLine 2"
-    result = helper_table.get_string()
-    lines = result.splitlines()
-    # Top border
-    assert lines[0].startswith("+") and lines[0].endswith("+")
-    # Two title lines bordered with |
-    assert lines[1].startswith("|") and lines[1].endswith("|")
-    assert "Line 1" in lines[1]
-    assert lines[2].startswith("|") and lines[2].endswith("|")
-    assert "Line 2" in lines[2]
-    # Separator between title and header uses junction char +
-    assert lines[3].startswith("+") and lines[3].endswith("+")
-    # Header separator uses = (RST distinguishing feature)
-    header_sep = lines[5]
-    assert "=" in header_sep
-    # All lines should be the same length
-    assert len({len(line) for line in lines}) == 1
+    # Assert
+    assert (
+        helper_table.get_string()
+        == """
++---------------------------------+
+|              Line 1             |
+|              Line 2             |
++---+---------+---------+---------+
+|   | Field 1 | Field 2 | Field 3 |
++===+=========+=========+=========+
+| 1 | value 1 |  value2 |  value3 |
++---+---------+---------+---------+
+| 4 | value 4 |  value5 |  value6 |
++---+---------+---------+---------+
+| 7 | value 7 |  value8 |  value9 |
++---+---------+---------+---------+
+""".strip()
+    )
 
 
 def test_markdown_to_rst_does_not_leak(helper_table: PrettyTable) -> None:

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -87,7 +87,7 @@ def test_rst_output_with_multiline_title(helper_table: PrettyTable) -> None:
     header_sep = lines[5]
     assert "=" in header_sep
     # All lines should be the same length
-    assert len(set(len(line) for line in lines)) == 1
+    assert len({len(line) for line in lines}) == 1
 
 
 def test_markdown_to_rst_does_not_leak(helper_table: PrettyTable) -> None:

--- a/tests/test_rst.py
+++ b/tests/test_rst.py
@@ -69,6 +69,27 @@ def test_rst_style_does_not_leak(helper_table: PrettyTable) -> None:
     assert helper_table.get_string() == original
 
 
+def test_rst_output_with_multiline_title(helper_table: PrettyTable) -> None:
+    helper_table.set_style(TableStyle.RST)
+    helper_table.title = "Line 1\nLine 2"
+    result = helper_table.get_string()
+    lines = result.splitlines()
+    # Top border
+    assert lines[0].startswith("+") and lines[0].endswith("+")
+    # Two title lines bordered with |
+    assert lines[1].startswith("|") and lines[1].endswith("|")
+    assert "Line 1" in lines[1]
+    assert lines[2].startswith("|") and lines[2].endswith("|")
+    assert "Line 2" in lines[2]
+    # Separator between title and header uses junction char +
+    assert lines[3].startswith("+") and lines[3].endswith("+")
+    # Header separator uses = (RST distinguishing feature)
+    header_sep = lines[5]
+    assert "=" in header_sep
+    # All lines should be the same length
+    assert len(set(len(line) for line in lines)) == 1
+
+
 def test_markdown_to_rst_does_not_leak(helper_table: PrettyTable) -> None:
     # Arrange
     helper_table.set_style(TableStyle.MARKDOWN)


### PR DESCRIPTION
Fixes #200.

-   Add multiline title support: titles containing \n now render each line as a separate bordered row                                                                                                                                                               
-   Split title width calculation to use the widest line instead of the full string length
-   Replace \n with `<br>` in HTML `<caption>` tags (respects XHTML `<br/>` setting)                                                                                                                                                                                      
-   Render each title line as a separate bold line in Markdown output            
-   Add 4 tests covering multiline title rendering, line consistency, and HTML output
-   Add README section documenting the title and multiline title feature