### PR TITLE
Fix bleeding of wrapped colours into table edges

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2408,7 +2408,7 @@ class PrettyTable:
         return "".join(bits)
 
     def _stringify_row(self, row: list[str], options: OptionsType, hrule: str) -> str:
-        import textwrap
+        import wcwidth
 
         for index, field, value, width in zip(
             range(len(row)), self._field_names, row, self._widths
@@ -2423,8 +2423,10 @@ class PrettyTable:
                 ):
                     line = none_val
                 if _str_block_width(line) > width:
-                    line = textwrap.fill(
-                        line, width, break_on_hyphens=options["break_on_hyphens"]
+                    line = "\n".join(
+                        wcwidth.wrap(
+                            line, width, break_on_hyphens=options["break_on_hyphens"]
+                        )
                     )
                 new_lines.append(line)
             lines = new_lines

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -692,3 +692,41 @@ def test_table_alignment_with_emoji(
     with open(os.path.join(DATA_DIR, expected_file), encoding="utf-8") as fin:
         expected_from_file = fin.read()
     assert table.get_string().rstrip() == expected_from_file.strip()
+
+
+def test_ansi_wrap_width():
+    """ANSI escape sequences should not count toward column width when wrapping."""
+    table = PrettyTable(["Key", "Value"])
+    table.header = False
+    table.max_width["Value"] = 35
+    table.add_row(
+        [
+            "NEW_ENVIRON",
+            "\x1b[38;5;208mOversharing: HOME, PWD, SHELL,"
+            " SSH_AUTH_SOCK, XDG_SESSION_PATH\x1b[0m",
+        ]
+    )
+    result = table.get_string()
+    for line in result.split("\n"):
+        if "|" not in line:
+            continue
+        parts = line.split("|")
+        value_cell = parts[2] if len(parts) > 2 else ""
+        assert "\x1b[38;5;208m" not in value_cell or "\x1b[0m" in value_cell
+
+
+def test_ansi_wrap_no_bleed():
+    """Wrapped ANSI-colored text must close SGR on every line."""
+    table = PrettyTable(["Key", "Value"])
+    table.header = False
+    table.max_width["Value"] = 30
+    table.add_row(
+        [
+            "TEST",
+            "\x1b[31mRed text that is long enough to wrap across lines\x1b[0m",
+        ]
+    )
+    result = table.get_string()
+    for line in result.split("\n"):
+        if "\x1b[31m" in line:
+            assert "\x1b[0m" in line


### PR DESCRIPTION
Problem
------------

Standard python ``textwrap.wrap()`` was used, it is not "sequence-aware".

- "bleeding" of colors into the edges of table, eg. '║'
- mismeasurements cause textwrap.wrap to wrap very early, too early
- probably also mismeasurements of emojis, regional flags, OSC hyperlinks, possible breaking on graphemes, corruption by "hard wrapp" of very long sequences, etc.

<img width="1070" height="944" alt="prettytable-bleeding-and-badly-wrapped" src="https://github.com/user-attachments/assets/2c8d93b8-5c67-41a0-9861-c9084f582326" />

> bleeding of orange color and too-early wrapping of orange text seen near red mouse cursor

Solution
------------

use [wcwidth.wrap](https://wcwidth.readthedocs.io/en/latest/intro.html#wrap) function that handles measuring and breaking on graphemes and terminal output sequences correctly

<img width="1070" height="944" alt="prettytable-fixed" src="https://github.com/user-attachments/assets/147a45c9-4232-4d80-a77c-c6b02c9484c8" />
