### PR TITLE
Group Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: monthly
       time: "03:00"
+    groups:
+      actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     labels:
       - "changelog: skip"
@@ -22,6 +26,10 @@ updates:
     schedule:
       interval: monthly
       time: "03:00"
+    groups:
+      actions:
+        patterns:
+          - "*"
     open-pull-requests-limit: 10
     labels:
       - "changelog: skip"


### PR DESCRIPTION
To avoid multiple like #453, #454, #455.

Docs: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--