### PR TITLE
annotate the `PrettyTable.__init__` kwargs

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import io
 from enum import IntEnum
 from functools import lru_cache
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -42,9 +42,9 @@ if TYPE_CHECKING:
     from typing import Final, TypeAlias, TypedDict
 
     from _typeshed import SupportsRichComparison
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
-    class OptionsType(TypedDict):
+    class OptionsType(TypedDict, total=False):
         title: str | None
         start: int
         end: int | None
@@ -88,8 +88,8 @@ if TYPE_CHECKING:
         top_left_junction_char: str
         bottom_right_junction_char: str
         bottom_left_junction_char: str
-        align: dict[str, AlignType]
-        valign: dict[str, VAlignType]
+        align: AlignType
+        valign: VAlignType
         min_width: int | dict[str, int] | None
         max_width: int | dict[str, int] | None
         none_format: str | dict[str, str | None] | None
@@ -144,6 +144,57 @@ RowType: TypeAlias = list[Any]
 AlignType: TypeAlias = Literal["l", "c", "r"]
 VAlignType: TypeAlias = Literal["t", "m", "b"]
 HeaderStyleType: TypeAlias = Literal["cap", "title", "upper", "lower"] | None
+_OptionKey: TypeAlias = Literal[
+    "title",
+    "start",
+    "end",
+    "fields",
+    "header",
+    "use_header_width",
+    "border",
+    "preserve_internal_border",
+    "sortby",
+    "reversesort",
+    "sort_key",
+    "row_filter",
+    "attributes",
+    "format",
+    "hrules",
+    "vrules",
+    "int_format",
+    "float_format",
+    "custom_format",
+    "min_table_width",
+    "max_table_width",
+    "padding_width",
+    "left_padding_width",
+    "right_padding_width",
+    "vertical_char",
+    "horizontal_char",
+    "horizontal_align_char",
+    "header_horizontal_char",
+    "junction_char",
+    "header_style",
+    "xhtml",
+    "print_empty",
+    "oldsortslice",
+    "top_junction_char",
+    "bottom_junction_char",
+    "right_junction_char",
+    "left_junction_char",
+    "top_right_junction_char",
+    "top_left_junction_char",
+    "bottom_right_junction_char",
+    "bottom_left_junction_char",
+    "align",
+    "valign",
+    "max_width",
+    "min_width",
+    "none_format",
+    "escape_header",
+    "escape_data",
+    "break_on_hyphens",
+]
 
 
 class ObservableDict(dict[str, Any]):
@@ -243,7 +294,9 @@ class PrettyTable:
     _hrule: str
     _break_on_hyphens: bool
 
-    def __init__(self, field_names: Sequence[str] | None = None, **kwargs) -> None:
+    def __init__(
+        self, field_names: Sequence[str] | None = None, **kwargs: Unpack[OptionsType]
+    ) -> None:
         """Return a new PrettyTable instance
 
         Arguments:
@@ -311,7 +364,7 @@ class PrettyTable:
         self._style = None
 
         # Options
-        self._options = [
+        self._options: list[_OptionKey] = [
             "title",
             "start",
             "end",
@@ -388,7 +441,7 @@ class PrettyTable:
         self._min_width: dict[str, int | None] = ObservableDict()
         self._min_width.callback = self._min_width_callback
 
-        self._kwargs = {}
+        self._kwargs: OptionsType = {}
         if field_names:
             self.field_names = field_names
         else:
@@ -432,8 +485,10 @@ class PrettyTable:
             self._reversesort = kwargs["reversesort"]
         else:
             self._reversesort = False
-        self._sort_key = kwargs["sort_key"] or (lambda x: x)
-        self._row_filter = kwargs["row_filter"] or (lambda x: True)
+
+        # using `.get` here avoids a mypy error
+        self._sort_key = kwargs.get("sort_key") or (lambda x: x)
+        self._row_filter = kwargs.get("row_filter") or (lambda x: True)
 
         if kwargs["escape_data"] in (True, False):
             self._escape_data = kwargs["escape_data"]
@@ -835,7 +890,7 @@ class PrettyTable:
 
     @field_names.setter
     def field_names(self, val: Sequence[Any]) -> None:
-        val = cast("list[str]", [str(x) for x in val])
+        val = [str(x) for x in val]
         self._validate_option("field_names", val)
         old_names = None
         if self._field_names:
@@ -1686,14 +1741,14 @@ class PrettyTable:
     ##############################
 
     def _get_options(self, kwargs: Mapping[str, Any]) -> OptionsType:
-        options: dict[str, Any] = {}
+        options: OptionsType = {}
         for option in self._options:
             if option in kwargs:
                 self._validate_option(option, kwargs[option])
                 options[option] = kwargs[option]
             else:
                 options[option] = getattr(self, option)
-        return cast("OptionsType", options)
+        return options
 
     ##############################
     # PRESET STYLE LOGIC         #

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -46,7 +46,7 @@ class TestNoneOption:
 
     def test_none_char_invalid_option(self) -> None:
         with pytest.raises(TypeError) as exc:
-            PrettyTable(["Field 1", "Field 2", "Field 3"], none_format=2)
+            PrettyTable(["Field 1", "Field 2", "Field 3"], none_format=2)  # type: ignore[arg-type]
         assert "must be a string" in str(exc.value)
 
     def test_no_value_replace_none(self) -> None:
@@ -796,7 +796,7 @@ class TestBasic:
 
     def test_header_style_invalid(self) -> None:
         with pytest.raises(ValueError):
-            PrettyTable(header_style="FooBar")
+            PrettyTable(header_style="FooBar")  # type: ignore[arg-type]
 
     @pytest.mark.usefixtures("init_db")
     def test_no_blank_lines_from_db(self, db_cursor: sqlite3.Cursor) -> None:
@@ -1414,7 +1414,7 @@ class TestCustomFormatter:
 
     def test_init_custom_format_throw_error_is_not_callable(self) -> None:
         with pytest.raises(ValueError) as e:
-            PrettyTable(custom_format={"col1": "{:.2}"})
+            PrettyTable(custom_format={"col1": "{:.2}"})  # type: ignore[dict-item]
 
         assert "Invalid value for custom_format.col1. Must be a function." in str(
             e.value


### PR DESCRIPTION
following #459, this uses [PEP 692](https://peps.python.org/pep-0692/) to annotate the `**kwargs` of `PrettyTable.__init__`.

As you can see, I had to `# type: ignore` some new mypy true positives in the tests, demonstrating that this can indeed prevent bugs.

---

I struggled a bit with the `align` kwarg. Because in the options `TypedDict` this was annotated as a `dict[str, AlignType]`. But this lead to an issue in the `PrettyTable.add_autoindex` method, because the implementation there suggests that the `align` kwarg should be a `AlignType` rather than a `dict[str, AlignType]`:

https://github.com/prettytable/prettytable/blob/858f1b2bfc03dd349eabc449605a5df43fbc3380/src/prettytable/prettytable.py#L1935-L1936

So assuming that this is intentional, I changed the `align` type of the `OptionsType` dict to a `AlignType`. This was the only way I was able to avoid this mypy error without changing the implementation of `add_autoindex`. But I'm getting the feeling that I may have stumbled upon a bug in `add_autoindex` here...