### PR TITLE
Drop stale `align`/`valign` keys when `field_names` are renamed

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -849,8 +849,8 @@ class PrettyTable:
             for old_name, new_name in zip(old_names, val):
                 self._align[new_name] = self._align[old_name]
             for old_name in old_names:
-                if old_name not in self._align:
-                    self._align.pop(old_name)
+                if old_name not in val:
+                    self._align.pop(old_name, None)
         elif self._align:
             for field_name in self._field_names:
                 self._align[field_name] = self._align[BASE_ALIGN_VALUE]
@@ -860,8 +860,8 @@ class PrettyTable:
             for old_name, new_name in zip(old_names, val):
                 self._valign[new_name] = self._valign[old_name]
             for old_name in old_names:
-                if old_name not in self._valign:
-                    self._valign.pop(old_name)
+                if old_name not in val:
+                    self._valign.pop(old_name, None)
         else:
             self.valign = "t"
 

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -389,6 +389,27 @@ class TestAlignment:
         with pytest.raises(ValueError):
             city_data.align = {"Population": "unexpected"}  # type: ignore[dict-item]
 
+    def test_rename_drops_stale_align_keys(self) -> None:
+        table = PrettyTable()
+        table.field_names = ["a", "b", "c"]
+        table.add_row([1, 2, 3])
+        table.align["a"] = "l"
+        table.field_names = ["x", "y", "z"]
+        assert set(table.field_names) == {"x", "y", "z"}
+        for old in ("a", "b", "c"):
+            assert old not in table._align
+            assert old not in table._valign
+        assert table.align["x"] == "l"
+
+    def test_rename_keeps_overlapping_align_keys(self) -> None:
+        table = PrettyTable()
+        table.field_names = ["a", "b", "c"]
+        table.add_row([1, 2, 3])
+        table.field_names = ["x", "b", "z"]
+        assert "b" in table._align
+        assert "a" not in table._align
+        assert "c" not in table._align
+
 
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""


### PR DESCRIPTION
Renaming a table via the `field_names` setter never removed the previous field names from `self._align` and `self._valign`.

The cleanup loops guarded the `pop` with `if old_name not in self._align`, so the branch only ran when the key was already absent and the old keys were left behind. After a rename the alignment dicts kept growing with dead keys.

This switches the guard to `if old_name not in val` (the new names) and uses `pop(..., None)` so overlapping names are preserved and absent keys do not raise.

Added two regression tests in `TestAlignment` covering a full rename and a partial-overlap rename.