### PR TITLE
Document `header_horizontal_char` and remove a duplicate docstring line

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -279,6 +279,8 @@ class PrettyTable:
         vertical_char - single character string used to draw vertical lines
         horizontal_char - single character string used to draw horizontal lines
         horizontal_align_char - single character string used to indicate alignment
+        header_horizontal_char - single character string used to draw the header
+            separator, or None to use the same as horizontal_char
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
         bottom_junction_char -
@@ -2212,7 +2214,8 @@ class PrettyTable:
         vertical_char - single character string used to draw vertical lines
         horizontal_char - single character string used to draw horizontal lines
         horizontal_align_char - single character string used to indicate alignment
-        junction_char - single character string used to draw line junctions
+        header_horizontal_char - single character string used to draw the header
+            separator, or None to use the same as horizontal_char
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
         bottom_junction_char -


### PR DESCRIPTION
### What

Two small docstring fixes in `prettytable.py`:

1. **Document `header_horizontal_char`.** It is a valid option for both `PrettyTable()` and `get_string()` — it is listed in `self._options` (so `_get_options()` reads it from `kwargs`) and it controls the header separator line in `_stringify_header()`. However, it was the only `*_char` option missing from the "Arguments" lists of both docstrings; every other character option (`vertical_char`, `horizontal_char`, `horizontal_align_char`, `junction_char`, and all eight junction variants) is already documented. It's now documented in its natural position (right after `horizontal_align_char`, matching the order in `self._options`), reusing the wording from its own property docstring.

2. **Remove a duplicated line.** The `get_string()` docstring listed `junction_char - single character string used to draw line junctions` twice in a row; one copy is removed.

### Why

Documents an existing public option and removes a copy-paste duplication, so the rendered API docs match the actual accepted keyword arguments.

Docs-only change — no behaviour change. `ruff check`, `black --check`, and the full test suite (335 passed) are green locally.