### PR TITLE
Expand tabs in cell values so columns stay aligned

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2019,9 +2019,18 @@ class PrettyTable:
             return (f"%{self._float_format[field]}f") % value
 
         formatter = self._custom_format.get(field, (lambda f, v: str(v)))
-        # Expand tabs so the width we measure matches what a terminal renders;
-        # a raw "\t" is one character wide to wcwidth but advances to the next
-        # tab stop on display, which otherwise misaligns the column (issue #113).
+        # Prettytable is unaware of a terminal's tabstops, and it does not know at
+        # what specific location of the screen it will be displayed, so it also cannot
+        # calculate tabstop positions or width: A '\t' character is variable-width,
+        # depending on the location of the screen it is displayed.
+        #
+        # Although wcwidth library functions like width() do measure tab control
+        # character as a width of 8, it would require prettytable to display the left
+        # margin of the table's contents to begin "at the tabstop" for the table
+        # contents and dividers to line up correctly.
+        #
+        # PrettyTable is "screen unaware", so it is best to alter tabstops to a fixed
+        # width, to allow same-width display anywhere on the screen.
         return formatter(field, value).expandtabs()
 
     def _compute_table_width(self, options) -> int:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2019,7 +2019,10 @@ class PrettyTable:
             return (f"%{self._float_format[field]}f") % value
 
         formatter = self._custom_format.get(field, (lambda f, v: str(v)))
-        return formatter(field, value)
+        # Expand tabs so the width we measure matches what a terminal renders;
+        # a raw "\t" is one character wide to wcwidth but advances to the next
+        # tab stop on display, which otherwise misaligns the column (issue #113).
+        return formatter(field, value).expandtabs()
 
     def _compute_table_width(self, options) -> int:
         if options["vrules"] == VRuleStyle.FRAME:

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2019,13 +2019,13 @@ class PrettyTable:
             return (f"%{self._float_format[field]}f") % value
 
         formatter = self._custom_format.get(field, (lambda f, v: str(v)))
-        # Prettytable is unaware of a terminal's tabstops, and it does not know at
+        # PrettyTable is unaware of a terminal's tabstops, and it does not know at
         # what specific location of the screen it will be displayed, so it also cannot
         # calculate tabstop positions or width: A '\t' character is variable-width,
         # depending on the location of the screen it is displayed.
         #
         # Although wcwidth library functions like width() do measure tab control
-        # character as a width of 8, it would require prettytable to display the left
+        # character as a width of 8, it would require PrettyTable to display the left
         # margin of the table's contents to begin "at the tabstop" for the table
         # contents and dividers to line up correctly.
         #

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1611,10 +1611,7 @@ class TestWidth:
 """.strip()
 
     def test_tab_expansion_aligns_columns(self) -> None:
-        # Issue #113: a tab in a cell is one character wide to wcwidth but
-        # advances to the next tab stop when rendered, so it must be expanded
-        # for the measured width to match the rendered width. Otherwise the
-        # tab line is shorter than the rest and the column misaligns.
+        """Ensure expandtabs() is used in PrettyTable._format_value()."""
         table = PrettyTable(["code", "note"])
         table.add_row(["if x:\n\treturn 1", "tab-indented"])
         result = table.get_string()

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1610,6 +1610,18 @@ class TestWidth:
 +---------+---------+
 """.strip()
 
+    def test_tab_expansion_aligns_columns(self) -> None:
+        # Issue #113: a tab in a cell is one character wide to wcwidth but
+        # advances to the next tab stop when rendered, so it must be expanded
+        # for the measured width to match the rendered width. Otherwise the
+        # tab line is shorter than the rest and the column misaligns.
+        table = PrettyTable(["code", "note"])
+        table.add_row(["if x:\n\treturn 1", "tab-indented"])
+        result = table.get_string()
+        assert "\t" not in result
+        line_widths = {len(line) for line in result.splitlines()}
+        assert len(line_widths) == 1
+
     @pytest.mark.parametrize(
         "loops, fields, desired_width, border, internal_border",
         [


### PR DESCRIPTION
Fixes #113.

A cell that contains a tab character is rendered misaligned, because the width PrettyTable measures for it does not match the width it displays at:

```python
from prettytable import PrettyTable

t = PrettyTable()
t.field_names = ["code", "note"]
t.add_row(["if x:\n\treturn 1", "tab-indented"])
print(t.get_string())
```

On current `main` this prints (the tab line is short, so the column does not line up):

```
+------------------+--------------+
|       code       |     note     |
+------------------+--------------+
|      if x:       | tab-indented |
| 	return 1 |              |
+------------------+--------------+
```

A `\t` is one column wide to `wcwidth`, so `_str_block_width` under-measures the line, but a terminal advances the tab to the next tab stop on display. The measured width and the rendered width disagree, so the padding is wrong.

(For reference: this is still reproducible after #440's wcwidth work, so the issue is not yet resolved.)

## Fix

Expand tabs once in `_format_value`, which is the single point that produces the cell string used for *both* width measurement and rendering (`_format_rows` feeds `_compute_widths` and `_stringify_row`). With the cell expanded up front, both paths see the same string and agree, so the column lines up:

```
+------------------+--------------+
|       code       |     note     |
+------------------+--------------+
|      if x:       | tab-indented |
|         return 1 |              |
+------------------+--------------+
```

`str.expandtabs()` uses the standard tab size of 8, matching the terminal tab-stop convention. Cells without tabs are unchanged.

## Tests

Added `TestWidth::test_tab_expansion_aligns_columns`, which asserts a tab-containing cell renders with no raw tab and with every line the same display width. It is RED without the fix and GREEN with it; the full suite passes (336 passed).

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
