### PR TITLE
Speed up import time

### DIFF
--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Any
-
 from ._version import __version__
 from .prettytable import (  # noqa: F401
     _DEPRECATED_ALL,
@@ -30,6 +28,11 @@ from .prettytable import (  # noqa: F401
     from_json,
     from_mediawiki,
 )
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
+
 
 __all__ = [
     "ALL",

--- a/src/prettytable/__init__.py
+++ b/src/prettytable/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"prettytable._version", "prettytable.prettytable"}
+
 from ._version import __version__
 from .prettytable import (  # noqa: F401
     _DEPRECATED_ALL,

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -31,7 +31,6 @@
 
 from __future__ import annotations
 
-import io
 from enum import IntEnum
 from functools import lru_cache
 from typing import Any, Literal, cast
@@ -2592,6 +2591,7 @@ class PrettyTable:
         delimiter as a csv.writer keyword argument.
         """
         import csv
+        import io
 
         options = self._get_options(kwargs)
         csv_options = {


### PR DESCRIPTION
# For all versions

* Only import `typing` only when `TYPE_CHECKING` -- doesn't make much difference on its own, as it gets imported anyway by `prettytable.prettytable`
* Defer importing `io`

## Python 3.14: `main`: 5 ms

<img width="2117" height="1292" alt="image" src="https://github.com/user-attachments/assets/6b18df61-2683-47c6-a114-5f2a70107324" />

## Python 3.14: PR: 4 ms

<img width="2117" height="1494" alt="image" src="https://github.com/user-attachments/assets/b331c2e9-c887-4cd1-a924-106d9e37066c" />

# For Python 3.15+: 4ms

* Use `__lazy_modules__` to lazily import `prettytable._version` and `prettytable.prettytable`

## Python 3.15: `main`

<img width="2117" height="1292" alt="image" src="https://github.com/user-attachments/assets/f85fa0de-ff76-44ca-a8ec-61daabcb3cdf" />

## Python 3.15: PR: ~0 ms

<img width="2117" height="1090" alt="image" src="https://github.com/user-attachments/assets/293aea4b-bdcf-42be-a42b-ba7f6a3b0ee5" />

