### PR TITLE
fix: from_csv fails on its own output when values contain commas

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3104,9 +3104,7 @@ def from_csv(fp, field_names: Sequence[str] | None = None, **kwargs) -> PrettyTa
     if fmtparams:
         reader = csv.reader(fp, **fmtparams)
     else:
-        dialect = csv.Sniffer().sniff(fp.read(1024))
-        fp.seek(0)
-        reader = csv.reader(fp, dialect)
+        reader = csv.reader(fp)
 
     table = PrettyTable(**kwargs)
     if field_names:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import io
 import sqlite3
 from collections.abc import Generator
 from math import e, pi, sqrt
@@ -16,6 +17,7 @@ from prettytable import (
     RowType,
     TableStyle,
     VRuleStyle,
+    from_csv,
     from_db_cursor,
 )
 
@@ -1342,6 +1344,23 @@ class TestCsvOutput:
             "Bob,00000,10.0,0\r\n"
             'Charlie,-0042,-2.7,"-5,678"\r\n'
         )
+
+    def test_csv_roundtrip_quoted_values(self) -> None:
+        # from_csv must correctly parse the output of get_csv_string, even when
+        # cell values contain commas or quotes (which the writer wraps in quotes).
+        # Previously, csv.Sniffer would misdetect the delimiter as a space for
+        # such input, causing from_csv to fail on its own output.
+        table = PrettyTable(["Name", "Value", "Description"])
+        table.add_row(["Alice, Jr.", 100, "Has a comma, and quoted"])
+        table.add_row(["Bob", 200, 'Has "nested" quotes'])
+
+        csv_out = table.get_csv_string()
+        table2 = from_csv(io.StringIO(csv_out))
+
+        assert table2.field_names == ["Name", "Value", "Description"]
+        assert table2._rows[0][0] == "Alice, Jr."
+        assert table2._rows[0][2] == "Has a comma, and quoted"
+        assert table2._rows[1][2] == 'Has "nested" quotes'
 
 
 def test_paginate(city_data: PrettyTable) -> None:


### PR DESCRIPTION
## Bug

`from_csv` uses `csv.Sniffer` to detect the CSV dialect when no format
params are explicitly given. The sniffer misdetects the delimiter as
a **space** when quoted cell values contain commas (a common case, e.g.
`"Alice, Jr."` or `"Has a comma, and quoted"`), breaking the round-trip:

```python
from prettytable import PrettyTable, from_csv
import io

t = PrettyTable(["Name", "Value", "Description"])
t.add_row(["Alice, Jr.", 100, "Has a comma, and quoted"])
csv_out = t.get_csv_string()

# Raises ValueError: Row has incorrect number of values
t2 = from_csv(io.StringIO(csv_out))
```

The sniffer detects `' '` (space) as the delimiter because spaces appear
inside the quoted fields. This contradicts `get_csv_string()`, which
always writes comma-delimited output (csv.writer Excel dialect).

## Fix

Drop the sniffer when no explicit format params are given. Use
`csv.reader(fp)` (Excel dialect, comma delimiter by default), which
matches what `get_csv_string()` writes. Passing explicit CSV format
params via kwargs still works as before.

## Tests

Added `TestCsvOutput.test_csv_roundtrip_quoted_values` covering commas
and embedded double-quotes inside cell values.