### PR TITLE
fix: handle rows with fewer cells than header in from_html()

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3200,7 +3200,7 @@ def _make_table_handler():
             for row in self.rows:
                 if len(row[0]) < self.max_row_width:
                     appends = self.max_row_width - len(row[0])
-                    for i in range(1, appends):
+                    for i in range(appends):
                         row[0].append("-")
 
                 if row[1]:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -22,6 +22,18 @@ class TestHtmlConstructor:
         with pytest.raises(ValueError):
             from_html_one(html_string)
 
+    def test_html_ragged_row(self) -> None:
+        """from_html() must not raise when a data row has fewer cells than the header."""
+        html = "<table><tr><th>a</th><th>b</th></tr><tr><td>1</td></tr></table>"
+        tables = from_html(html)
+        assert len(tables) == 1
+        table = tables[0]
+        assert table.field_names == ["a", "b"]
+        rows = table._rows
+        assert len(rows) == 1
+        assert rows[0][0] == "1"
+        assert rows[0][1] == "-"
+
 
 class TestHtmlOutput:
     def test_html_output(self, helper_table: PrettyTable) -> None:


### PR DESCRIPTION
from_html() raises ValueError when a table row has fewer cells than the header row, due to an off-by-one in the padding loop. This fixes the loop bounds and adds a regression test.

Closes #474