### PR TITLE
Truncate wide-character headers by display width

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2388,6 +2388,8 @@ class PrettyTable:
         return "\n".join(lines)
 
     def _stringify_header(self, options: OptionsType) -> str:
+        import wcwidth
+
         bits: list[str] = []
         lpad, rpad = self._get_padding_widths(options)
         if options["border"]:
@@ -2429,7 +2431,7 @@ class PrettyTable:
             else:
                 fieldname = field
             if _str_block_width(fieldname) > width:
-                fieldname = fieldname[:width]
+                fieldname = wcwidth.clip(fieldname, 0, width)
             bits.append(
                 " " * lpad
                 + self._justify(fieldname, width, self._align[field])

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1795,6 +1795,21 @@ class TestWidth:
 
         assert table.get_string() == expected
 
+    def test_wide_char_header_truncated_by_display_width(self) -> None:
+        # With use_header_width=False, a header wider than its column is
+        # truncated to fit. Wide (e.g. CJK) characters must be truncated by
+        # display width, not character count, otherwise the header overflows
+        # the column and breaks alignment. This mirrors _stringify_row, which
+        # already wraps cell content by display width.
+        table = PrettyTable(["日本語ヘッダー", "col2"], use_header_width=False)
+        table.add_row(["abcd", "yy"])
+        expected = """+------+----+
+| 日本 | co |
++------+----+
+| abcd | yy |
++------+----+"""
+        assert table.get_string() == expected
+
     def test_table_width_on_init_wo_columns(self) -> None:
         """See also #272"""
         table = PrettyTable(max_width=10)


### PR DESCRIPTION
When `use_header_width=False` (or `max_table_width` shrinks a column), a field name wider than its column is truncated to fit. That truncation uses a character slice (`fieldname[:width]`), so wide characters such as CJK overflow the column and break alignment, because each CJK character occupies two display columns but `[:width]` keeps `width` characters.

```python
from prettytable import PrettyTable

t = PrettyTable(["日本語ヘッダー", "col2"], use_header_width=False)
t.add_row(["abcd", "yy"])
print(t)
```

Before:

```
+------+----+
| 日本語ヘ | co |
+------+----+
| abcd | yy |
+------+----+
```

The header row is wider than the border and the data row. After the fix the table stays aligned:

```
+------+----+
| 日本 | co |
+------+----+
| abcd | yy |
+------+----+
```

The truncation guard already measures display width via `_str_block_width` (`wcwidth.width`), and `_stringify_row` already wraps cell content by display width with `wcwidth.wrap`, so the header path was the odd one out. The fix swaps the character slice for `wcwidth.clip(fieldname, 0, width)`, which truncates by display column and is already a dependency. ASCII headers are unaffected (`wcwidth.clip` matches `[:width]` for narrow text).

Added a regression test next to `test_table_max_width_wo_header_width`. The full suite passes locally.
