### PR TITLE
Preserve per-row dividers when slicing or indexing a table

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -526,10 +526,10 @@ class PrettyTable:
         for attr in self._options:
             setattr(new, f"_{attr}", getattr(self, f"_{attr}"))
         if isinstance(index, slice):
-            for row in self._rows[index]:
-                new.add_row(row)
+            for row, divider in zip(self._rows[index], self._dividers[index]):
+                new.add_row(row, divider=divider)
         elif isinstance(index, int):
-            new.add_row(self._rows[index])
+            new.add_row(self._rows[index], divider=self._dividers[index])
         else:
             msg = f"Index {index} is invalid, must be an integer or slice"
             raise IndexError(msg)

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -47,6 +47,32 @@ class TestRowEndSection:
         table.add_rows(self.TEST_ROWS[2:])
         assert table.get_string().strip() == self.EXPECTED_RESULT
 
+    def test_slice_preserves_dividers(self) -> None:
+        """Slicing a table keeps each row's divider flag (issue: __getitem__
+        re-added rows with the default divider=False, silently dropping section
+        dividers)."""
+        table = PrettyTable()
+        table.field_names = ["value"]
+        table.add_row(["a"])
+        table.add_row(["b"], divider=True)
+        table.add_row(["c"])
+        table.add_row(["d"], divider=True)
+        table.add_row(["e"])
+
+        sliced = table[1:4]
+        assert sliced.rows == [["b"], ["c"], ["d"]]
+        assert sliced.dividers == [True, False, True]
+
+    def test_index_preserves_divider(self) -> None:
+        """Indexing a single row keeps that row's divider flag."""
+        table = PrettyTable()
+        table.field_names = ["value"]
+        table.add_row(["a"])
+        table.add_row(["b"], divider=True)
+
+        assert table[1].dividers == [True]
+        assert table[0].dividers == [False]
+
 
 class TestClearing:
     def test_clear_rows(self, helper_table: PrettyTable) -> None:


### PR DESCRIPTION
## Summary

Slicing or indexing a `PrettyTable` silently drops per-row **section dividers**. The rows are copied correctly, but every `divider=True` flag inside the selection is lost, so a sub-table built with `table[i:j]` (or a single-row `table[i]`) renders without the horizontal rules that the original table had.

## Reproduction

```python
from prettytable import PrettyTable

t = PrettyTable()
t.field_names = ["City", "Pop"]
t.add_row(["Adelaide", 1158259])
t.add_row(["Brisbane", 2189878], divider=True)   # divider after Brisbane
t.add_row(["Darwin", 120900])
t.add_row(["Hobart", 205556], divider=True)       # divider after Hobart
t.add_row(["Sydney", 4336374])

print(t[1:4])          # Brisbane, Darwin, Hobart
print(t[1:4].dividers) # -> [False, False, False]   (expected [True, False, True])
```

Full table (correct):

```
+----------+---------+
|   City   |   Pop   |
+----------+---------+
| Adelaide | 1158259 |
| Brisbane | 2189878 |
+----------+---------+          <- divider
|  Darwin  |  120900 |
|  Hobart  |  205556 |
+----------+---------+          <- divider
|  Sydney  | 4336374 |
+----------+---------+
```

`t[1:4]` **before** this fix (dividers gone):

```
+----------+---------+
|   City   |   Pop   |
+----------+---------+
| Brisbane | 2189878 |
|  Darwin  |  120900 |
|  Hobart  |  205556 |
+----------+---------+
```

`t[1:4]` **after** this fix (dividers preserved):

```
+----------+---------+
|   City   |   Pop   |
+----------+---------+
| Brisbane | 2189878 |
+----------+---------+          <- divider restored
|  Darwin  |  120900 |
|  Hobart  |  205556 |
+----------+---------+          <- divider restored
```

## Root cause

`PrettyTable.__getitem__` rebuilds the sub-table by re-adding each selected row:

```python
for row in self._rows[index]:
    new.add_row(row)          # divider defaults to False
...
new.add_row(self._rows[index])
```

`add_row(..., divider=...)` defaults to `False`, and the corresponding entries from `self._dividers` were never carried over, so the divider information is discarded on every slice/index.

## Fix

Copy each row alongside its divider flag:

```python
if isinstance(index, slice):
    for row, divider in zip(self._rows[index], self._dividers[index]):
        new.add_row(row, divider=divider)
elif isinstance(index, int):
    new.add_row(self._rows[index], divider=self._dividers[index])
```

`_rows` and `_dividers` are maintained in lock-step at every mutation site (`add_row`/`del_row`/`clear_rows`), so the two slices always align.

## Tests

Added `test_slice_preserves_dividers` and `test_index_preserves_divider` to `tests/test_sections.py`. Verified they guard the bug (stash the source change → both fail):

```
# without the fix
>       assert table[1].dividers == [True]
E       assert [False] == [True]
FAILED tests/test_sections.py::TestRowEndSection::test_slice_preserves_dividers
FAILED tests/test_sections.py::TestRowEndSection::test_index_preserves_divider

# with the fix
2 passed
```

Full suite: **340 passed** (was 338). `ruff check`, `ruff format --check`, and `mypy` are all clean on the changed files. Diff is +29/−3 across two files.
