### PR TITLE
pad short rows correctly in from_html

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3200,7 +3200,7 @@ def _make_table_handler():
             for row in self.rows:
                 if len(row[0]) < self.max_row_width:
                     appends = self.max_row_width - len(row[0])
-                    for i in range(1, appends):
+                    for _ in range(appends):
                         row[0].append("-")
 
                 if row[1]:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -22,6 +22,14 @@ class TestHtmlConstructor:
         with pytest.raises(ValueError):
             from_html_one(html_string)
 
+    def test_html_ragged_row_is_padded(self) -> None:
+        # a data row with fewer cells than the header should be padded, not rejected
+        table = from_html_one(
+            "<table><tr><th>a</th><th>b</th></tr><tr><td>1</td></tr></table>"
+        )
+        assert table.field_names == ["a", "b"]
+        assert table.rows == [["1", "-"]]
+
 
 class TestHtmlOutput:
     def test_html_output(self, helper_table: PrettyTable) -> None:


### PR DESCRIPTION
Fixes #474.

`from_html` is supposed to normalise ragged tables, but the short-row padding loop ran `range(1, appends)`, so it always padded one cell short and padded nothing at all when a row was missing exactly one cell. That made it raise `ValueError` on a row with fewer cells than the header.

```python
from prettytable import from_html
from_html("<table><tr><th>a</th><th>b</th></tr><tr><td>1</td></tr></table>")  # used to raise
```

Changed the loop to `range(appends)` and added a test.