### PR TITLE
respect explicit zero left/right padding in constructor

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -453,8 +453,8 @@ class PrettyTable:
             self._padding_width = 1
         else:
             self._padding_width = kwargs["padding_width"]
-        self._left_padding_width = kwargs["left_padding_width"] or None
-        self._right_padding_width = kwargs["right_padding_width"] or None
+        self._left_padding_width = kwargs["left_padding_width"]
+        self._right_padding_width = kwargs["right_padding_width"]
 
         self._vertical_char = kwargs["vertical_char"] or "|"
         self._horizontal_char = kwargs["horizontal_char"] or "-"

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1421,6 +1421,14 @@ g..
 """
         assert result.strip() == expected.strip()
 
+    def test_zero_left_right_padding_via_constructor(self) -> None:
+        # explicit 0 must be honoured, not coerced back to the default of 1
+        table = PrettyTable(
+            header=False, left_padding_width=0, right_padding_width=0
+        )
+        table.add_row(list("abc"))
+        assert table.get_string().strip() == "+-+-+-+\n|a|b|c|\n+-+-+-+"
+
 
 class TestCustomFormatter:
     def test_init_custom_format_is_empty(self) -> None:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1423,9 +1423,7 @@ g..
 
     def test_zero_left_right_padding_via_constructor(self) -> None:
         # explicit 0 must be honoured, not coerced back to the default of 1
-        table = PrettyTable(
-            header=False, left_padding_width=0, right_padding_width=0
-        )
+        table = PrettyTable(header=False, left_padding_width=0, right_padding_width=0)
         table.add_row(list("abc"))
         assert table.get_string().strip() == "+-+-+-+\n|a|b|c|\n+-+-+-+"
 


### PR DESCRIPTION
Fixes #220.

Passing `left_padding_width=0` (or `right_padding_width=0`) to the constructor had no effect — the cell still got one space of padding. `kwargs["left_padding_width"] or None` coerced the explicit `0` to `None`, which then falls back to `padding_width` (default 1). The property setters were already fine; only the constructor path was affected.

Dropped the `or None` (the kwarg already defaults to `None` when unset, so unset behaviour is unchanged). Added a test.