### PR TITLE
fix: avoid IndexError when sizing a zero-column titled table

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2118,7 +2118,7 @@ class PrettyTable:
             # What is being scaled is content so we sum column widths
             content_width = sum(widths) or 1
 
-            if content_width < min_width:
+            if content_width < min_width and widths:
                 # Grow widths in proportion
                 scale = 1.0 * min_width / content_width
                 widths = [int(w * scale) for w in widths]

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -864,7 +864,7 @@ class TestEmptyTable:
         result = table.get_string(title="Hello World")
         assert "Hello World" in result
         table.min_table_width = 30
-        assert table.get_string().strip() != ""
+        assert table.get_string() == "++\n||\n++\n++"
 
     def test_print_empty(self) -> None:
         table = PrettyTable(print_empty=False)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -858,6 +858,14 @@ Field 1  Field 2  Field 3
 class TestEmptyTable:
     """Make sure the print_empty option works"""
 
+    def test_title_without_columns(self) -> None:
+        """Zero-column tables with a title must not IndexError in width scaling."""
+        table = PrettyTable()
+        result = table.get_string(title="Hello World")
+        assert "Hello World" in result
+        table.min_table_width = 30
+        assert table.get_string().strip() != ""
+
     def test_print_empty(self) -> None:
         table = PrettyTable(print_empty=False)
         assert table.get_string().strip() == ""


### PR DESCRIPTION
PrettyTable._compute_widths hits IndexError when get_string(title=...) with zero columns. This PR fixes the regression with a focused test covering the case.
