### PR TITLE
Fix title overflowing the table with border=True and vrules=NONE

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2100,7 +2100,7 @@ class PrettyTable:
                     max(_str_block_width(line) for line in options["title"].split("\n"))
                     + per_col_padding
                 )
-                if options["vrules"] in (VRuleStyle.FRAME, VRuleStyle.ALL):
+                if options["border"]:
                     title_width += 2
             else:
                 title_width = 0

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -601,6 +601,15 @@ class TestBasic:
         city_data.title = "My table (75 characters wide) " + "=" * 45
         self._test_all_length_equal(city_data)
 
+    def test_all_lengths_equal_with_long_title_no_vrules(
+        self, city_data: PrettyTable
+    ) -> None:
+        """A long title must not overflow the table when vrules=NONE."""
+        city_data.title = "My table (75 characters wide) " + "=" * 45
+        string = city_data.get_string(vrules=VRuleStyle.NONE)
+        lengths = {len(line) for line in string.split("\n")}
+        assert len(lengths) == 1
+
     def test_multiline_title(self, city_data: PrettyTable) -> None:
         """A title with \\n should produce multiple bordered title lines."""
         city_data.title = "Line 1\nLine 2"


### PR DESCRIPTION
### The bug

With `border=True` and `vrules=NONE`, a title wider than the columns overflows the table — the title line is rendered 2 characters wider than every other line:

```python
from prettytable import PrettyTable, VRuleStyle
t = PrettyTable(["A", "B"]); t.add_row(["x", "y"])
t.title = "a long wide title"
print(t.get_string(vrules=VRuleStyle.NONE, padding_width=0))
```

```
 a long wide title
-----------------
    A       B
-----------------
    x       y
-----------------
```

The title line is 19 wide, every other line is 17. This breaks the "all lines the same length" invariant that the project documents and tests (`test_all_lengths_equal_with_long_title`, `_test_all_length_equal`). The same schedule with the default `vrules` (ALL) already renders correctly.

### Root cause

`src/prettytable/prettytable.py`, when sizing columns to fit the title:

```python
if options["vrules"] in (VRuleStyle.FRAME, VRuleStyle.ALL):
    title_width += 2
```

But `_stringify_title` always wraps the title with two outer endpoint columns whenever `border=True` — they render as bars for FRAME/ALL and as spaces for NONE, but occupy 2 columns either way — and the `borders = len(widths) + 1` accounting just below is gated on `border`, not on `vrules`. So for `border=True, vrules=NONE` the columns are under-sized by 2, and the (never-truncating) title justification overhangs.

### The fix

Gate the `+2` on `border`, matching the endpoint columns `_stringify_title` actually adds and the `borders` accounting:

```python
if options["border"]:
    title_width += 2
```

### Verification

- All lines are now equal width for `vrules=NONE` (ASCII and CJK/wide-title); FRAME/ALL are unchanged; `border=False` is unaffected (that branch's condition was `False` before and after).
- The existing `test_all_lengths_equal_with_long_title` only exercised the default `vrules=ALL`, which is why this was never caught. Added `test_all_lengths_equal_with_long_title_no_vrules`; it fails on `main` (`assert 2 == 1`) and passes with the fix.
- Full suite: 339 passed (was 338 + the new test); `ruff check` clean.

No open issue/PR covers this (the nearest, #386/#474, are unrelated HTML/`from_html` bugs).

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
