### PR TITLE
Fix align setter dropping value validation on string assignment

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -891,7 +891,7 @@ class PrettyTable:
     def align(self, val: AlignType | dict[str, AlignType] | None) -> None:
         if isinstance(val, str):
             if not self._field_names:
-                self._align = {BASE_ALIGN_VALUE: val}
+                self._align[BASE_ALIGN_VALUE] = val
             else:
                 for field in self._field_names:
                     self._align[field] = val
@@ -902,7 +902,7 @@ class PrettyTable:
             for field in self._field_names:
                 self._align[field] = "c"
         else:
-            self._align = {BASE_ALIGN_VALUE: "c"}
+            self._align[BASE_ALIGN_VALUE] = "c"
 
     def _valign_callback(self, field_name, old_value, new_value):
         """Callback to call validators if dict attrs are modified.

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -389,6 +389,18 @@ class TestAlignment:
         with pytest.raises(ValueError):
             city_data.align = {"Population": "unexpected"}  # type: ignore[dict-item]
 
+    def test_align_string_invalid_without_field_names(self) -> None:
+        with pytest.raises(ValueError):
+            PrettyTable().align = "unexpected"  # type: ignore[assignment]
+
+    def test_align_validation_survives_string_set(self) -> None:
+        # Setting align to a string must not replace the validating dict.
+        table = PrettyTable()
+        table.align = "l"
+        table.field_names = ["a", "b"]
+        with pytest.raises(ValueError):
+            table.align["a"] = "unexpected"  # type: ignore[assignment]
+
     def test_rename_drops_stale_align_keys(self) -> None:
         table = PrettyTable()
         table.field_names = ["a", "b", "c"]


### PR DESCRIPTION
### Summary

`self._align` is an `ObservableDict` whose callback (`_align_callback` → `_validate_align`) rejects any value other than `l`/`c`/`r`. Two branches of the `align` setter reassign `self._align` to a **plain `dict`**, which both skips validation of the assigned value and permanently replaces the `ObservableDict`, so *all subsequent* per-field assignments stop validating too:

```python
@align.setter
def align(self, val):
    if isinstance(val, str):
        if not self._field_names:
            self._align = {BASE_ALIGN_VALUE: val}   # no validation, drops ObservableDict
        ...
    else:
        self._align = {BASE_ALIGN_VALUE: "c"}       # same
```

Reproduction on `main`:

```python
t = PrettyTable()
t.align = "banana"          # silently accepted (should raise ValueError)
t.field_names = ["a", "b"]
t.align["a"] = "zzz"        # also silently accepted — validation is gone
```

### Fix

Assign through the dict (`self._align[BASE_ALIGN_VALUE] = val`) instead of replacing it, so the validating callback fires and the `ObservableDict` is preserved. This mirrors the sibling `valign` setter and every other branch of this same setter, which all mutate the dict in place.

### Tests

Added `test_align_string_invalid_without_field_names` and `test_align_validation_survives_string_set` (both fail on `main`, pass after the fix). Full `tests/test_prettytable.py` passes locally (216 passed); `ruff check` clean.
