### PR TITLE
fix(from_html): correct off-by-one in short-row padding loop (#474)

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3200,7 +3200,7 @@ def _make_table_handler():
             for row in self.rows:
                 if len(row[0]) < self.max_row_width:
                     appends = self.max_row_width - len(row[0])
-                    for i in range(1, appends):
+                    for i in range(appends):
                         row[0].append("-")
 
                 if row[1]:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -28,7 +28,9 @@ class TestHtmlConstructor:
         The loop was range(1, appends) which ran only (n-1) iterations,
         leaving the first missing cell un-padded.
         """
-        html = "<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td></tr></table>"
+        html = (
+            "<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td></tr></table>"
+        )
         tables = from_html(html)
         assert len(tables) == 1
         table = tables[0]

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -22,6 +22,23 @@ class TestHtmlConstructor:
         with pytest.raises(ValueError):
             from_html_one(html_string)
 
+    def test_html_ragged_row_padding(self) -> None:
+        """Regression for #474: rows shorter than the header are padded correctly.
+
+        The loop was range(1, appends) which ran only (n-1) iterations,
+        leaving the first missing cell un-padded.
+        """
+        html = "<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td></tr></table>"
+        tables = from_html(html)
+        assert len(tables) == 1
+        table = tables[0]
+        assert table.field_names == ["a", "b", "c"]
+        rows = table._rows
+        assert len(rows) == 1
+        assert rows[0][0] == "1"
+        assert rows[0][1] == "-"
+        assert rows[0][2] == "-"
+
 
 class TestHtmlOutput:
     def test_html_output(self, helper_table: PrettyTable) -> None:


### PR DESCRIPTION
## Problem

Fixes #474.

`from_html()` and `from_html_one()` raise `ValueError` when a data row has fewer `<td>` cells than the header `<th>` cells.

```python
from prettytable import from_html
from_html("<table><tr><th>a</th><th>b</th></tr><tr><td>1</td></tr></table>")
# ValueError: Row has incorrect number of values, (actual) 1!=2 (expected)
```

## Root Cause

The short-row padding loop inside `_make_table_handler()` has an off-by-one error:

```python
appends = self.max_row_width - len(row[0])  # number of cells to add
for i in range(1, appends):                  # WRONG: iterates appends-1 times
    row[0].append("-")
```

`range(1, appends)` produces `appends - 1` iterations:

| `appends` | `range(1, appends)` | cells added | cells still missing |
|---|---|---|---|
| 1 | empty | 0 | **1** (bug) |
| 2 | `[1]` | 1 | **1** (bug) |
| 3 | `[1, 2]` | 2 | **1** (bug) |

## Fix

```diff
- for i in range(1, appends):
+ for i in range(appends):
      row[0].append("-")
```

`range(appends)` starts at 0 and iterates exactly `appends` times, filling every missing cell with a placeholder `"-"`.

## Verification

```python
from prettytable import from_html

# Two missing cells
tables = from_html("<table><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>1</td></tr></table>")
print(tables[0])  # a=1, b=-, c=-

# One missing cell (previously always failed)
tables = from_html("<table><tr><th>a</th><th>b</th></tr><tr><td>1</td></tr></table>")
print(tables[0])  # a=1, b=-
```
