### PR TITLE
Fix colspan DoS in from_html()

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3165,8 +3165,15 @@ def _make_table_handler():
             if tag == "th":
                 self.is_last_row_header = True
             for key, value in attrs:
-                if key == "colspan":
-                    self.colspan = int(value)  # type: ignore[arg-type]
+                if key == "colspan" and value:
+                    try:
+                        span = int(value)
+                    except ValueError:
+                        msg = f"Invalid colspan value: {value!r}"
+                        raise ValueError(msg)
+                    # Clamp to HTML spec valid range [1, 1000] to prevent
+                    # memory exhaustion from malicious large values (CWE-409)
+                    self.colspan = max(1, min(span, 1000))
 
         def handle_endtag(self, tag: str) -> None:
             if tag in ["th", "td"]:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -575,3 +575,33 @@ class TestHtmlOutput:
     </tbody>
 </table>
 """.strip()
+
+
+class TestFromHtmlColspan:
+    """Tests for colspan bounds checking in from_html()."""
+
+    def test_colspan_clamped_to_max(self) -> None:
+        """Large colspan values are clamped to prevent memory exhaustion (CWE-409)."""
+        html = '<table><tr><th colspan="100000000">A</th></tr><tr><td colspan="100000000">data</td></tr></table>'
+        table = from_html_one(html)
+        assert len(table.rows) == 1
+        # colspan clamped to 1000, so row has at most 1000 cells
+        assert len(table.rows[0]) <= 1000
+
+    def test_colspan_invalid_value_raises(self) -> None:
+        """Non-integer colspan raises ValueError instead of crashing."""
+        html = '<table><tr><th>A</th></tr><tr><td colspan="abc">data</td></tr></table>'
+        with pytest.raises(ValueError, match="Invalid colspan"):
+            from_html_one(html)
+
+    def test_colspan_negative_clamped(self) -> None:
+        """Negative colspan is clamped to 1 (no extra cells)."""
+        html = '<table><tr><th>A</th></tr><tr><td colspan="-5">data</td></tr></table>'
+        table = from_html_one(html)
+        assert len(table.rows[0]) == 1
+
+    def test_colspan_within_bounds(self) -> None:
+        """Normal colspan values work correctly."""
+        html = '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td colspan="2">merged</td><td>x</td></tr></table>'
+        table = from_html_one(html)
+        assert table.rows[0] == ["merged", "", "x"]


### PR DESCRIPTION
## Summary

Fixes an unbounded `colspan` memory-exhaustion DoS (CWE-409) in the `from_html()` HTML parser.

### Unbounded `colspan` causes memory exhaustion DoS (CWE-409)

The `_TableHandler` parser parsed the `colspan` attribute via `int(value)` without any bounds checking. A malicious HTML input with a very large `colspan` value (e.g. `colspan="100000000"`) caused the parser to attempt allocating ~100M list entries in:

```python
for _ in range(1, self.colspan):
    self.last_row.append("")
```

This leads to memory exhaustion and process hang/kill.

**Fix:** Validate the integer value (raising `ValueError` on invalid input) and clamp `colspan` to the HTML spec valid range `[1, 1000]`.

## Testing

- All 342 existing tests pass
- Added 4 new unit tests covering: colspan clamping, invalid colspan, negative colspan, and normal colspan

---

Note: As requested in the review, this PR has been reduced to only the colspan DoS fix. The off-by-one row-padding issue (#474) will be handled separately in #475.
