### PR TITLE
Fix title overhanging the table when border is disabled

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -2379,12 +2379,18 @@ class PrettyTable:
             else " "
         )
         lpad, rpad = self._get_padding_widths(options)
-        sum_widths = sum([n + lpad + rpad + 1 for n in self._widths])
+        if options["border"]:
+            # Every column is followed by a vertical separator, and the line is
+            # wrapped in the frame characters added as endpoints below.
+            inner_width = sum(n + lpad + rpad + 1 for n in self._widths) - 1
+        else:
+            # Without a border no separators are drawn, so the title only spans
+            # the columns themselves, less the two endpoints added below.
+            inner_width = sum(n + lpad + rpad for n in self._widths) - 2
+        inner_width = max(inner_width, 0)
         for title_line in title.split("\n"):
             padded = " " * lpad + title_line + " " * rpad
-            lines.append(
-                endpoint + self._justify(padded, sum_widths - 1, "c") + endpoint
-            )
+            lines.append(endpoint + self._justify(padded, inner_width, "c") + endpoint)
         return "\n".join(lines)
 
     def _stringify_header(self, options: OptionsType) -> str:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -601,6 +601,22 @@ class TestBasic:
         city_data.title = "My table (75 characters wide) " + "=" * 45
         self._test_all_length_equal(city_data)
 
+    def test_all_lengths_equal_with_title_and_no_border(
+        self, city_data: PrettyTable
+    ) -> None:
+        """A title must not overhang the table when the border is disabled."""
+        city_data.title = "My table"
+        city_data.border = False
+        self._test_all_length_equal(city_data)
+
+    def test_all_lengths_equal_with_long_title_and_no_border(
+        self, city_data: PrettyTable
+    ) -> None:
+        """A long title must not overhang the table when the border is disabled."""
+        city_data.title = "My table (75 characters wide) " + "=" * 45
+        city_data.border = False
+        self._test_all_length_equal(city_data)
+
     def test_multiline_title(self, city_data: PrettyTable) -> None:
         """A title with \\n should produce multiple bordered title lines."""
         city_data.title = "Line 1\nLine 2"

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -213,7 +213,7 @@ class TestStyle:
             pytest.param(
                 TableStyle.PLAIN_COLUMNS,
                 """
-Table Caption                           
+Table Caption                         
          Field 1        Field 2        Field 3        
 1        value 1         value2         value3        
 4        value 4         value5         value6        


### PR DESCRIPTION
## Problem

`_stringify_title` sizes the title line as if every column were followed by a
vertical separator:

```python
sum_widths = sum([n + lpad + rpad + 1 for n in self._widths])
```

With `border=False` no separators are drawn, so that `+ 1` per column is counted
but never rendered, and the title line comes out wider than the table it sits on:

```python
t = PrettyTable()
t.field_names = ["a", "bb"]
t.add_row(["1", "2"])
t.add_row(["long value", "x"])
t.title = "T"
t.border = False
print(t)
```

```
         T                <- 19 columns
     a       bb           <- 16
     1       2
 long value  x
```

The same table with `border=True` is consistent at 19 across every line.

## Changes

Compute the inner width from the columns alone when there is no border, and keep
the existing calculation when there is one. The result is clamped at 0 so a very
narrow table (single column, zero padding) can't produce a negative width.

## Effect

Sweeping the 432 combinations of `title` × `border` × `hrules` × `vrules` ×
`header` × `padding_width` and asserting every rendered line has the same display
width:

| | ragged combinations |
|---|---|
| before | 168 / 432 |
| after | 48 / 432 |

## Note on #485

Every one of the 48 that remain is a `vrules=NONE` case, which is what #485
addresses — so the two are aimed at different halves of the problem. One thing
worth flagging before both land, though: I measured them together and they
interact rather than compose.

| | ragged combinations |
|---|---|
| baseline | 168 |
| #485 alone | 144 |
| this PR alone | 48 |
| both together | 72 |

Applying both is worse than this PR on its own, because #485 changes the minimum
table width in `_compute_widths` while this changes how the title line is
rendered, and the two adjustments overlap. I've deliberately kept #485's change
out of this PR — just noting it so whichever lands second can be checked against
the other rather than assumed additive.

## Tests

Two tests added next to the existing title tests, reusing the project's own
`_test_all_length_equal` helper:

- `test_all_lengths_equal_with_title_and_no_border`
- `test_all_lengths_equal_with_long_title_and_no_border`

Both fail without the change (`assert 2 == 1`, `len({79, 84})` — the title
overhangs by 5) and pass with it.

### One existing expectation changed

`test_style.py`'s `PLAIN_COLUMNS` case encoded the old behaviour: its title line
was 59 columns against a 54 column table. The test compares
`get_string().strip() == expected.strip()`, and stripping the whole string
removed the title's leading padding, which is why the overhang was never visible
in the fixture. Only the title line changes; the four other lines are byte
identical.

## Verification

- `python -m pytest tests/` — 340 passed (338 existing + 2 new)
- `ruff check` — clean on all three files
- `black --check` — clean on `prettytable.py`. It also wants to reformat the two
  test files, but it does that on an unmodified checkout too (I have 25.12.0
  locally, pre-commit pins 26.5.1), and none of the reformatting touches lines
  this PR adds.

I can't self-apply a `changelog:` label from a fork, so the required-label check
will need one — `changelog: Fixed` looks right.
