### PR TITLE
Add first_col_is_header option to use the first column as row headers in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Table-specific options are:
 | `bottom_left_junction_char`  | Single character string used to draw bottom-left line junctions. Default: `junction_char`.                                                  |
 | `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                 |
 | `break_on_hyphens`           | Whether long lines are wrapped on hyphens. Default: `True`.                                                                                 |
+| `first_col_is_header`        | A Boolean option (must be `True` or `False`). Renders the first cell of each HTML data row as a `<th scope="row">`. Default: `False`.       |
 | `header`                     | A Boolean option (must be `True` or `False`). Controls whether the first row of the table is a header showing the names of all the fields.  |
 | `horizontal_char`            | Single character string used to draw horizontal lines. Default: `-`.                                                                        |
 | `hrules`                     | Controls printing of horizontal rules after rows. Allowed values: `FRAME`, `HEADER`, `ALL`, `NONE`.                                         |

--- a/README.md
+++ b/README.md
@@ -844,6 +844,39 @@ when sending output to HTML. This can be disabled by setting the `escape_header`
 print(table.get_html_string(escape_header=False, escape_data=False))
 ```
 
+#### Using the first column as a row header
+
+For tables whose first column labels each row, you can pass `first_col_is_header=True`
+to `get_html_string` (or set `table.first_col_is_header = True`). PrettyTable will then
+render the first cell of every data row as a `<th scope="row">` element instead of
+`<td>`, and mark the column headers with `scope="col"`, producing more accessible
+markup. For example:
+
+```python
+print(table.get_html_string(first_col_is_header=True))
+```
+
+will print:
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th scope="col">City name</th>
+      <th scope="col">Area</th>
+      ...
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">Adelaide</th>
+      <td>1295</td>
+      ...
+    </tr>
+  </tbody>
+</table>
+```
+
 ### Miscellaneous things
 
 #### Copying a table

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -95,6 +95,7 @@ if TYPE_CHECKING:
         escape_header: bool
         escape_data: bool
         break_on_hyphens: bool
+        first_col_is_header: bool
 
 
 class HRuleStyle(IntEnum):
@@ -236,6 +237,7 @@ class PrettyTable:
     _attributes: dict[str, str]
     _escape_header: bool
     _escape_data: bool
+    _first_col_is_header: bool
     _style: TableStyle | None
     orgmode: bool
     _widths: list[int]
@@ -362,6 +364,7 @@ class PrettyTable:
             "escape_header",
             "escape_data",
             "break_on_hyphens",
+            "first_col_is_header",
         ]
 
         self._none_format: dict[str, str | None] = ObservableDict()
@@ -444,6 +447,10 @@ class PrettyTable:
             self._escape_header = kwargs["escape_header"]
         else:
             self._escape_header = True
+        if kwargs["first_col_is_header"] in (True, False):
+            self._first_col_is_header = kwargs["first_col_is_header"]
+        else:
+            self._first_col_is_header = False
 
         self._column_specific_args()
 
@@ -601,6 +608,7 @@ class PrettyTable:
             "escape_header",
             "escape_data",
             "break_on_hyphens",
+            "first_col_is_header",
         ):
             self._validate_true_or_false(option, val)
         elif option == "header_style":
@@ -1682,6 +1690,21 @@ class PrettyTable:
         self._validate_option("break_on_hyphens", val)
         self._break_on_hyphens = val
 
+    @property
+    def first_col_is_header(self) -> bool:
+        """Render the first column of each row as a row header in HTML output
+
+        When True, ``get_html_string`` emits the first (leftmost) cell of every
+        data row as a ``<th scope="row">`` element instead of ``<td>``, and marks
+        the column headers with ``scope="col"``. This is useful for tables whose
+        first column labels each row. Only affects HTML output (True or False)."""
+        return self._first_col_is_header
+
+    @first_col_is_header.setter
+    def first_col_is_header(self, val: bool) -> None:
+        self._validate_option("first_col_is_header", val)
+        self._first_col_is_header = val
+
     ##############################
     # OPTION MIXER               #
     ##############################
@@ -2698,6 +2721,9 @@ class PrettyTable:
         format - Controls whether or not HTML tables are formatted to match
             styling options (True or False)
         escape_data - escapes the text within a data field (True or False)
+        first_col_is_header - render the first column of each row as a row header,
+            emitting <th scope="row"> instead of <td> and marking column headers
+            with scope="col" (True or False)
         xhtml - print <br/> tags if True, <br> tags if False
         break_on_hyphens - Whether long lines are broken on hyphens or not, default: True
         """
@@ -2743,8 +2769,11 @@ class PrettyTable:
                 if options["escape_header"]:
                     field = escape(field)
 
+                th_attrs = ' scope="col"' if options["first_col_is_header"] else ""
                 lines.append(
-                    "            <th>{}</th>".format(field.replace("\n", linebreak))
+                    "            <th{}>{}</th>".format(
+                        th_attrs, field.replace("\n", linebreak)
+                    )
                 )
 
             lines.append("        </tr>")
@@ -2756,15 +2785,19 @@ class PrettyTable:
         formatted_rows = self._format_rows(rows)
         for row in formatted_rows:
             lines.append("        <tr>")
+            first_col = True
             for field, datum in zip(self._field_names, row):
                 if options["fields"] and field not in options["fields"]:
                     continue
                 if options["escape_data"]:
                     datum = escape(datum)
 
-                lines.append(
-                    "            <td>{}</td>".format(datum.replace("\n", linebreak))
-                )
+                content = datum.replace("\n", linebreak)
+                if first_col and options["first_col_is_header"]:
+                    lines.append(f'            <th scope="row">{content}</th>')
+                else:
+                    lines.append(f"            <td>{content}</td>")
+                first_col = False
             lines.append("        </tr>")
         lines.append("    </tbody>")
         lines.append("</table>")
@@ -2831,8 +2864,10 @@ class PrettyTable:
                     field = escape(field)
 
                 content = field.replace("\n", linebreak)
+                th_attrs = ' scope="col"' if options["first_col_is_header"] else ""
                 lines.append(
-                    f'            <th style="'
+                    f"            <th{th_attrs} "
+                    f'style="'
                     f"padding-left: {lpad}em; "
                     f"padding-right: {rpad}em; "
                     f'text-align: center">{content}</th>'
@@ -2854,6 +2889,7 @@ class PrettyTable:
         ]
         for row in formatted_rows:
             lines.append("        <tr>")
+            first_col = True
             for field, datum, align, valign in zip(
                 self._field_names, row, aligns, valigns
             ):
@@ -2863,13 +2899,19 @@ class PrettyTable:
                     datum = escape(datum)
 
                 content = datum.replace("\n", linebreak)
+                if first_col and options["first_col_is_header"]:
+                    tag, tag_attrs = "th", ' scope="row"'
+                else:
+                    tag, tag_attrs = "td", ""
                 lines.append(
-                    f'            <td style="'
+                    f"            <{tag}{tag_attrs} "
+                    f'style="'
                     f"padding-left: {lpad}em; "
                     f"padding-right: {rpad}em; "
                     f"text-align: {align}; "
-                    f'vertical-align: {valign}">{content}</td>'
+                    f'vertical-align: {valign}">{content}</{tag}>'
                 )
+                first_col = False
             lines.append("        </tr>")
         lines.append("    </tbody>")
         lines.append("</table>")

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -94,6 +94,127 @@ class TestHtmlOutput:
 </table>
 """.strip()
 
+    def test_html_output_first_col_is_header(self, helper_table: PrettyTable) -> None:
+        result = helper_table.get_html_string(first_col_is_header=True)
+        assert result.strip() == """
+<table>
+    <thead>
+        <tr>
+            <th scope="col"></th>
+            <th scope="col">Field 1</th>
+            <th scope="col">Field 2</th>
+            <th scope="col">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th scope="row">1</th>
+            <td>value 1</td>
+            <td>value2</td>
+            <td>value3</td>
+        </tr>
+        <tr>
+            <th scope="row">4</th>
+            <td>value 4</td>
+            <td>value5</td>
+            <td>value6</td>
+        </tr>
+        <tr>
+            <th scope="row">7</th>
+            <td>value 7</td>
+            <td>value8</td>
+            <td>value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+
+    def test_html_output_formatted_first_col_is_header(
+        self, helper_table: PrettyTable
+    ) -> None:
+        result = helper_table.get_html_string(first_col_is_header=True, format=True)
+        assert result.strip() == """
+<table frame="box" rules="cols">
+    <thead>
+        <tr>
+            <th scope="col" style="padding-left: 1em; padding-right: 1em; text-align: center"></th>
+            <th scope="col" style="padding-left: 1em; padding-right: 1em; text-align: center">Field 1</th>
+            <th scope="col" style="padding-left: 1em; padding-right: 1em; text-align: center">Field 2</th>
+            <th scope="col" style="padding-left: 1em; padding-right: 1em; text-align: center">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th scope="row" style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">1</th>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 1</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value2</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value3</td>
+        </tr>
+        <tr>
+            <th scope="row" style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">4</th>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 4</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value5</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value6</td>
+        </tr>
+        <tr>
+            <th scope="row" style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">7</th>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value 7</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value8</td>
+            <td style="padding-left: 1em; padding-right: 1em; text-align: center; vertical-align: top">value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+
+    def test_html_output_first_col_is_header_respects_fields(
+        self, helper_table: PrettyTable
+    ) -> None:
+        # The row header follows the first *rendered* column, not the first
+        # column of the underlying table.
+        result = helper_table.get_html_string(
+            first_col_is_header=True, fields=["Field 1", "Field 3"]
+        )
+        assert result.strip() == """
+<table>
+    <thead>
+        <tr>
+            <th scope="col">Field 1</th>
+            <th scope="col">Field 3</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th scope="row">value 1</th>
+            <td>value3</td>
+        </tr>
+        <tr>
+            <th scope="row">value 4</th>
+            <td>value6</td>
+        </tr>
+        <tr>
+            <th scope="row">value 7</th>
+            <td>value9</td>
+        </tr>
+    </tbody>
+</table>
+""".strip()
+
+    def test_html_output_first_col_is_header_default_off(
+        self, helper_table: PrettyTable
+    ) -> None:
+        # Default output must be unchanged: no scope attributes, no <th> in body.
+        result = helper_table.get_html_string()
+        assert "scope=" not in result
+        assert '<th scope="row">' not in result
+
+    def test_first_col_is_header_setter(self, helper_table: PrettyTable) -> None:
+        assert helper_table.first_col_is_header is False
+        helper_table.first_col_is_header = True
+        assert helper_table.first_col_is_header is True
+        assert '<th scope="row">1</th>' in helper_table.get_html_string()
+        with pytest.raises(ValueError):
+            helper_table.first_col_is_header = "yes"  # type: ignore[assignment]
+
     def test_html_output_with_title(self, helper_table: PrettyTable) -> None:
         helper_table.title = "Title & Title"
         result = helper_table.get_html_string(


### PR DESCRIPTION
Closes #38.

Adds a `first_col_is_header` option (default `False`, so existing output is unchanged) to `get_html_string`. When enabled, PrettyTable renders the first cell of every data row as a `<th scope="row">` element instead of `<td>`, and marks the column headers with `scope="col"`. This is the accessible "row header" markup from the [W3C tables tutorial](https://www.w3.org/WAI/tutorials/tables/two-headers/), which #38 asked for.

It works with both the plain and `format=True` HTML renderers, can be set via the constructor, the `table.first_col_is_header` property, or a per-call keyword argument, and follows the first *rendered* column when `fields` reorders/filters columns.

Example:

```python
table = PrettyTable()
table.field_names = ["City", "Area", "Population"]
table.add_row(["Adelaide", 1295, 1158259])
print(table.get_html_string(first_col_is_header=True))
```

```html
<table>
    <thead>
        <tr>
            <th scope="col">City</th>
            <th scope="col">Area</th>
            <th scope="col">Population</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <th scope="row">Adelaide</th>
            <td>1295</td>
            <td>1158259</td>
        </tr>
    </tbody>
</table>
```

### Notes

- Default behaviour is unchanged: with `first_col_is_header=False` no `scope` attributes are emitted and the body stays all `<td>` (covered by a regression test).
- Column headers stay in `<thead>`; only the `scope` attributes are added in this mode, so the markup remains valid for tables that have both column headers and per-row headers.

### Tests

Added five tests in `tests/test_html.py` covering the plain renderer, the formatted renderer, `fields` interaction, the default-off invariant, and the property setter/validation. Full suite passes (`343 passed`); `black` and `mypy` are clean.
