### PR TITLE
Add header_vertical_char option for the header row

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ Table-specific options are:
 | `bottom_right_junction_char` | Single character string used to draw bottom-right line junctions. Default: `junction_char`.                                                 |
 | `break_on_hyphens`           | Whether long lines are wrapped on hyphens. Default: `True`.                                                                                 |
 | `header`                     | A Boolean option (must be `True` or `False`). Controls whether the first row of the table is a header showing the names of all the fields.  |
+| `header_vertical_char`       | Single character string used to draw vertical lines in the header row. Default: `vertical_char`.                                            |
 | `horizontal_char`            | Single character string used to draw horizontal lines. Default: `-`.                                                                        |
 | `hrules`                     | Controls printing of horizontal rules after rows. Allowed values: `FRAME`, `HEADER`, `ALL`, `NONE`.                                         |
 | `junction_char`              | Single character string used to draw line junctions. Default: `+`.                                                                          |

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -74,6 +74,7 @@ if TYPE_CHECKING:
         horizontal_char: str
         horizontal_align_char: str
         header_horizontal_char: str | None
+        header_vertical_char: str | None
         junction_char: str
         header_style: HeaderStyleType
         xhtml: bool
@@ -221,6 +222,7 @@ class PrettyTable:
     _horizontal_char: str
     _horizontal_align_char: str | None
     _header_horizontal_char: str | None
+    _header_vertical_char: str | None
     _junction_char: str
     _top_junction_char: str | None
     _bottom_junction_char: str | None
@@ -280,6 +282,8 @@ class PrettyTable:
         horizontal_align_char - single character string used to indicate alignment
         header_horizontal_char - single character string used to draw the header
             separator, or None to use the same as horizontal_char
+        header_vertical_char - single character string used to draw vertical lines
+            in the header row, or None to use the same as vertical_char
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
         bottom_junction_char -
@@ -341,6 +345,7 @@ class PrettyTable:
             "horizontal_char",
             "horizontal_align_char",
             "header_horizontal_char",
+            "header_vertical_char",
             "junction_char",
             "header_style",
             "xhtml",
@@ -460,6 +465,7 @@ class PrettyTable:
         self._horizontal_char = kwargs["horizontal_char"] or "-"
         self._horizontal_align_char = kwargs["horizontal_align_char"]
         self._header_horizontal_char = kwargs["header_horizontal_char"]
+        self._header_vertical_char = kwargs["header_vertical_char"]
         self._junction_char = kwargs["junction_char"] or "+"
         self._top_junction_char = kwargs["top_junction_char"]
         self._bottom_junction_char = kwargs["bottom_junction_char"]
@@ -617,6 +623,7 @@ class PrettyTable:
             "horizontal_char",
             "horizontal_align_char",
             "header_horizontal_char",
+            "header_vertical_char",
             "junction_char",
             "top_junction_char",
             "bottom_junction_char",
@@ -1454,6 +1461,23 @@ class PrettyTable:
         self._header_horizontal_char = val
 
     @property
+    def header_vertical_char(self) -> str | None:
+        """The character used when printing vertical lines in the header row
+
+        Arguments:
+
+        header_vertical_char - single character string used to draw vertical
+        lines in the header row, or None to use the same as vertical_char"""
+        return self._header_vertical_char
+
+    @header_vertical_char.setter
+    def header_vertical_char(self, val: str | None) -> None:
+        if val is not None:
+            val = str(val)
+            self._validate_option("header_vertical_char", val)
+        self._header_vertical_char = val
+
+    @property
     def junction_char(self) -> str:
         """The character used when printing table borders to draw line junctions
 
@@ -2227,6 +2251,8 @@ class PrettyTable:
         horizontal_align_char - single character string used to indicate alignment
         header_horizontal_char - single character string used to draw the header
             separator, or None to use the same as horizontal_char
+        header_vertical_char - single character string used to draw vertical lines
+            in the header row, or None to use the same as vertical_char
         junction_char - single character string used to draw line junctions
         top_junction_char - single character string used to draw top line junctions
         bottom_junction_char -
@@ -2390,6 +2416,7 @@ class PrettyTable:
     def _stringify_header(self, options: OptionsType) -> str:
         bits: list[str] = []
         lpad, rpad = self._get_padding_widths(options)
+        vertical_char = options["header_vertical_char"] or options["vertical_char"]
         if options["border"]:
             if options["hrules"] in (HRuleStyle.ALL, HRuleStyle.FRAME):
                 bits.append(self._stringify_hrule(options, "top_"))
@@ -2406,13 +2433,13 @@ class PrettyTable:
                     )
                 bits.append("\n")
             if options["vrules"] in (VRuleStyle.ALL, VRuleStyle.FRAME):
-                bits.append(options["vertical_char"])
+                bits.append(vertical_char)
             else:
                 bits.append(" ")
         # For tables with no data or field names
         if not self._field_names:
             if options["vrules"] in (VRuleStyle.ALL, VRuleStyle.FRAME):
-                bits.append(options["vertical_char"])
+                bits.append(vertical_char)
             else:
                 bits.append(" ")
         for field, width in zip(self._field_names, self._widths):
@@ -2437,7 +2464,7 @@ class PrettyTable:
             )
             if options["border"] or options["preserve_internal_border"]:
                 if options["vrules"] == VRuleStyle.ALL:
-                    bits.append(options["vertical_char"])
+                    bits.append(vertical_char)
                 else:
                     bits.append(" ")
 
@@ -2450,7 +2477,7 @@ class PrettyTable:
         # of the last field, when we really want a vertical character
         if options["border"] and options["vrules"] == VRuleStyle.FRAME:
             bits.pop()
-            bits.append(options["vertical_char"])
+            bits.append(vertical_char)
         if (options["border"] or options["preserve_internal_border"]) and options[
             "hrules"
         ] != HRuleStyle.NONE:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -167,7 +167,7 @@ class TestHeaderVerticalChar:
         table = self._table()
         table.header_vertical_char = "^"
         assert table.get_string() == (
-            "+---+---+\n" "^ A ^ B ^\n" "+---+---+\n" "| 1 | 2 |\n" "+---+---+"
+            "+---+---+\n^ A ^ B ^\n+---+---+\n| 1 | 2 |\n+---+---+"
         )
 
     def test_none_matches_vertical_char(self) -> None:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -151,6 +151,37 @@ class TestPositionalJunctions:
 ╚═════════════════════════════════════════════════╝""".strip()
 
 
+class TestHeaderVerticalChar:
+    """Verify header_vertical_char overrides vertical_char in the header row only"""
+
+    def _table(self) -> PrettyTable:
+        table = PrettyTable()
+        table.field_names = ["A", "B"]
+        table.add_row([1, 2])
+        return table
+
+    def test_default_is_none(self) -> None:
+        assert self._table().header_vertical_char is None
+
+    def test_header_uses_own_char(self) -> None:
+        table = self._table()
+        table.header_vertical_char = "^"
+        assert table.get_string() == (
+            "+---+---+\n" "^ A ^ B ^\n" "+---+---+\n" "| 1 | 2 |\n" "+---+---+"
+        )
+
+    def test_none_matches_vertical_char(self) -> None:
+        without = self._table().get_string()
+        table = self._table()
+        table.header_vertical_char = None
+        assert table.get_string() == without
+
+    def test_invalid_length(self) -> None:
+        table = self._table()
+        with pytest.raises(ValueError):
+            table.header_vertical_char = "too long"
+
+
 class TestStyle:
     @pytest.mark.parametrize(
         "style, expected",


### PR DESCRIPTION
This adds a `header_vertical_char` attribute so the header row can use a different vertical separator from the body, which is what #145 was after (the DokuWiki case where header cells are separated by `^`).

It behaves just like the existing `header_horizontal_char`: leave it as `None` and nothing changes, or set it to a single character and only the header row picks it up. I wired the option through validation, the getter/setter and the docstrings the same way that one is done.

Also added a small test class in `test_style.py` and a row in the README options table.
