### PR TITLE
Add `header_align` to align column headers separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,35 @@ gives:
 +-----------+------+------------+-----------------+
 ```
 
+##### Aligning the headers separately
+
+Sometimes you want the data in a column aligned one way and the header aligned another,
+for example right aligned numbers under a centred title. The `header_align` attribute
+works just like `align`, but only affects the header row. Columns without a
+`header_align` fall back to `align`, so setting `align` on its own keeps working as
+before.
+
+```python
+table = PrettyTable()
+table.field_names = ["x", "y"]
+table.add_row([12346.657, 42])
+table.add_row([9.1, 7000])
+table.align = "r"
+table.header_align = "c"
+print(table)
+```
+
+gives:
+
+```
++-----------+------+
+|     x     |  y   |
++-----------+------+
+| 12346.657 |   42 |
+|       9.1 | 7000 |
++-----------+------+
+```
+
 ##### Sorting your table by a field
 
 You can make sure that your ASCII tables are produced with the data sorted by one
@@ -597,16 +626,17 @@ Table-specific options are:
 | `vertical_char`              | Single character string used to draw vertical lines. Default: `\|`.                                                                         |
 | `vrules`                     | Controls printing of vertical rules between columns. Allowed values: `FRAME`, `ALL`, `NONE`.                                                |
 
-For options that can be set individually for each column (`align`, `valign`,
-`custom_format`, `max_width`, `min_width`, `int_format`, `float_format`, `none_format`)
-you can either set a value, that applies to all columns or set a dict with column names
-and individual values.
+For options that can be set individually for each column (`align`, `header_align`,
+`valign`, `custom_format`, `max_width`, `min_width`, `int_format`, `float_format`,
+`none_format`) you can either set a value, that applies to all columns or set a dict
+with column names and individual values.
 
 Column-specific options are:
 
 | Option          | Details                                                                                                                                                                                                                                                                                                    |
 | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `align`         | Controls alignment of fields, one of "l", "c", or "r" or a dictionary with column and value.                                                                                                                                                                                                               |
+| `header_align`  | Controls alignment of column headers, one of "l", "c", or "r" or a dictionary with column and value. Columns without a value fall back to `align`.                                                                                                                                                         |
 | `custom_format` | Set any format, by setting a function that gets the original value,the formatted representation and returns the new string. E.g. `pf.custom_format["my_col_int"] = lambda f, v: f"{v:,}"`. The type of the callable is `Callable[[str, Any], str]`. This also takes a dictionary with column and function. |
 | `float_format`  | A string which controls the way floating point data is printed or a dictionary with column and value. This works like: `print("%<float_format>f" % data)`.                                                                                                                                                 |
 | `int_format`    | A string which controls the way integer data is printed or a dictionary with column and value. This works like: `print("%<int_format>d" % data)`.                                                                                                                                                          |

--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -88,6 +88,7 @@ if TYPE_CHECKING:
         bottom_right_junction_char: str
         bottom_left_junction_char: str
         align: dict[str, AlignType]
+        header_align: dict[str, AlignType]
         valign: dict[str, VAlignType]
         min_width: int | dict[str, int] | None
         max_width: int | dict[str, int] | None
@@ -191,6 +192,7 @@ def _get_size(text: str) -> tuple[int, int]:
 class PrettyTable:
     _xhtml: bool
     _align: dict[str, AlignType]
+    _header_align: dict[str, AlignType]
     _valign: dict[str, VAlignType]
     _min_width: dict[str, int]
     _max_width: dict[str, int]
@@ -298,6 +300,8 @@ class PrettyTable:
         sort_key - sorting key function, applied to data points before sorting
         row_filter - filter function applied on rows
         align - default align for each column (None, "l", "c" or "r")
+        header_align - align for each column header, falling back to align when unset
+            (None, "l", "c" or "r")
         valign - default valign for each row (None, "t", "m" or "b")
         reversesort - True or False to sort in descending or ascending order
         oldsortslice - Slice rows before sorting in the "old style"
@@ -355,6 +359,7 @@ class PrettyTable:
             "bottom_right_junction_char",
             "bottom_left_junction_char",
             "align",
+            "header_align",
             "valign",
             "max_width",
             "min_width",
@@ -379,6 +384,11 @@ class PrettyTable:
         self._align: dict[str, str | None] = ObservableDict()
         self._align[BASE_ALIGN_VALUE] = "c"
         self._align.callback = self._align_callback
+
+        # Header alignment is sparse on purpose: a field only appears here when
+        # the user sets it, otherwise the header falls back to _align.
+        self._header_align: dict[str, str | None] = ObservableDict()
+        self._header_align.callback = self._header_align_callback
 
         self._valign: dict[str, str | None] = ObservableDict()
         self._valign.callback = self._valign_callback
@@ -446,6 +456,7 @@ class PrettyTable:
             self._escape_header = True
 
         self._column_specific_args()
+        self.header_align = kwargs["header_align"]
 
         self._min_table_width = kwargs["min_table_width"] or None
         self._max_table_width = kwargs["max_table_width"] or None
@@ -856,6 +867,19 @@ class PrettyTable:
                 self._align[field_name] = self._align[BASE_ALIGN_VALUE]
         else:
             self.align = "c"
+
+        if self._header_align and old_names:
+            for old_name, new_name in zip(old_names, val):
+                if old_name in self._header_align:
+                    self._header_align[new_name] = self._header_align[old_name]
+            for old_name in old_names:
+                if old_name not in val:
+                    self._header_align.pop(old_name, None)
+        elif self._header_align.get(BASE_ALIGN_VALUE) is not None:
+            base = self._header_align[BASE_ALIGN_VALUE]
+            for field_name in self._field_names:
+                self._header_align[field_name] = base
+
         if self._valign and old_names:
             for old_name, new_name in zip(old_names, val):
                 self._valign[new_name] = self._valign[old_name]
@@ -903,6 +927,33 @@ class PrettyTable:
                 self._align[field] = "c"
         else:
             self._align = {BASE_ALIGN_VALUE: "c"}
+
+    def _header_align_callback(self, field_name, old_value, new_value):
+        """Callback to validate header alignment when the dict is modified."""
+        self._validate_align(new_value)
+
+    @property
+    def header_align(self) -> dict[str, AlignType]:
+        """Controls alignment of column headers
+
+        header_align - alignment, one of "l", "c", or "r". Columns without a
+        header alignment fall back to the value of ``align``."""
+        return self._header_align
+
+    @header_align.setter
+    def header_align(self, val: AlignType | dict[str, AlignType] | None) -> None:
+        if val is None:
+            # Clear back to the align fallback.
+            self._header_align.clear()
+        elif isinstance(val, str):
+            if not self._field_names:
+                self._header_align[BASE_ALIGN_VALUE] = val
+            else:
+                for field in self._field_names:
+                    self._header_align[field] = val
+        elif isinstance(val, dict):
+            for field, fval in val.items():
+                self._header_align[field] = fval
 
     def _valign_callback(self, field_name, old_value, new_value):
         """Callback to call validators if dict attrs are modified.
@@ -2430,10 +2481,9 @@ class PrettyTable:
                 fieldname = field
             if _str_block_width(fieldname) > width:
                 fieldname = fieldname[:width]
+            header_align = self._header_align.get(field) or self._align[field]
             bits.append(
-                " " * lpad
-                + self._justify(fieldname, width, self._align[field])
-                + " " * rpad
+                " " * lpad + self._justify(fieldname, width, header_align) + " " * rpad
             )
             if options["border"] or options["preserve_internal_border"]:
                 if options["vrules"] == VRuleStyle.ALL:

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -411,6 +411,90 @@ class TestAlignment:
         assert "c" not in table._align
 
 
+def numbers_table() -> PrettyTable:
+    table = PrettyTable()
+    table.field_names = ["x", "y"]
+    table.add_row([12346.657, 42])
+    table.add_row([9.1, 7000])
+    return table
+
+
+class TestHeaderAlignment:
+    """Header alignment can be set independently of the body alignment."""
+
+    def test_header_follows_align_by_default(self) -> None:
+        table = numbers_table()
+        table.align = "r"
+        assert table.get_string() == """
++-----------+------+
+|         x |    y |
++-----------+------+
+| 12346.657 |   42 |
+|       9.1 | 7000 |
++-----------+------+""".strip()
+
+    def test_header_align_independent_of_align(self) -> None:
+        table = numbers_table()
+        table.align = "r"
+        table.header_align = "c"
+        assert table.get_string() == """
++-----------+------+
+|     x     |  y   |
++-----------+------+
+| 12346.657 |   42 |
+|       9.1 | 7000 |
++-----------+------+""".strip()
+
+    def test_header_align_one_column(self) -> None:
+        table = numbers_table()
+        table.align = "r"
+        table.header_align["x"] = "l"
+        assert table.get_string() == """
++-----------+------+
+| x         |    y |
++-----------+------+
+| 12346.657 |   42 |
+|       9.1 | 7000 |
++-----------+------+""".strip()
+
+    def test_header_align_via_init(self) -> None:
+        by_init = PrettyTable(["x", "y"], align="r", header_align="c")
+        by_attr = PrettyTable(["x", "y"])
+        by_attr.align = "r"
+        by_attr.header_align = "c"
+        for table in (by_init, by_attr):
+            table.add_row([12346.657, 42])
+        assert by_init.get_string() == by_attr.get_string()
+
+    def test_header_align_reset_to_none(self) -> None:
+        table = numbers_table()
+        table.align = "r"
+        table.header_align = "l"
+        table.header_align = None
+        assert table._header_align == {}
+        # Falls back to align, so it matches a table that only set align.
+        plain = numbers_table()
+        plain.align = "r"
+        assert table.get_string() == plain.get_string()
+
+    def test_header_align_invalid(self) -> None:
+        table = numbers_table()
+        with pytest.raises(ValueError):
+            table.header_align["x"] = "unexpected"  # type: ignore[assignment]
+
+    def test_header_align_invalid_dict(self) -> None:
+        table = numbers_table()
+        with pytest.raises(ValueError):
+            table.header_align = {"x": "unexpected"}  # type: ignore[dict-item]
+
+    def test_rename_keeps_header_align(self) -> None:
+        table = numbers_table()
+        table.header_align["x"] = "l"
+        table.field_names = ["a", "y"]
+        assert table.header_align["a"] == "l"
+        assert "x" not in table._header_align
+
+
 class TestOptionOverride:
     """Make sure all options are properly overwritten by get_string."""
 


### PR DESCRIPTION
Fixes #102.

This adds a `header_align` attribute so the header row can be aligned separately from the column data. It works like `align` (a single string for every column, or treat it like a dict for individual columns), and any column you don't set falls back to `align`, so existing tables render exactly as before.

The motivating case from the issue is right-aligned numbers under a centred header:

```python
table = PrettyTable()
table.field_names = ["x", "y"]
table.add_row([12346.657, 42])
table.add_row([9.1, 7000])
table.align = "r"
table.header_align = "c"
print(table)
```

```
+-----------+------+
|     x     |  y   |
+-----------+------+
| 12346.657 |   42 |
|       9.1 | 7000 |
+-----------+------+
```

I followed the behaviour sketched out earlier on the issue: `align` on its own stays global, `header_align` only touches the header, and when both are set the header uses `header_align` while the body keeps `align`.

Added tests for the fallback, the per-column and whole-table cases, invalid values, the init kwarg and field renaming, plus a short README section. Existing behaviour is unchanged (346 passed).
