### PR TITLE
Fix from_csv() on a one-column CSV

### DIFF
--- a/src/prettytable/prettytable.py
+++ b/src/prettytable/prettytable.py
@@ -3104,8 +3104,21 @@ def from_csv(fp, field_names: Sequence[str] | None = None, **kwargs) -> PrettyTa
     if fmtparams:
         reader = csv.reader(fp, **fmtparams)
     else:
-        dialect = csv.Sniffer().sniff(fp.read(1024))
+        sample = fp.read(1024)
         fp.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample)
+        except csv.Error:
+            # No delimiter to find: a one-column CSV, which is what
+            # get_csv_string() writes for a one-column table.
+            dialect = csv.excel
+        else:
+            if dialect.delimiter.isalnum():
+                # csv.Sniffer widens its search to every character when the
+                # usual delimiters do not fit, so a one-column CSV can be
+                # split on a letter or digit that happens to occur the same
+                # number of times on every line.
+                dialect = csv.excel
         reader = csv.reader(fp, dialect)
 
     table = PrettyTable(**kwargs)

--- a/tests/test_prettytable.py
+++ b/tests/test_prettytable.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import io
 import sqlite3
 from collections.abc import Generator
 from math import e, pi, sqrt
@@ -16,6 +17,7 @@ from prettytable import (
     RowType,
     TableStyle,
     VRuleStyle,
+    from_csv,
     from_db_cursor,
 )
 
@@ -1342,6 +1344,39 @@ class TestCsvOutput:
             "Bob,00000,10.0,0\r\n"
             'Charlie,-0042,-2.7,"-5,678"\r\n'
         )
+
+    @pytest.mark.parametrize(
+        ("field_name", "values"),
+        [
+            # csv.Sniffer raises "Could not determine delimiter" here...
+            ("Area", ["1295", "5386"]),
+            # ...and here it silently settles on "i", because that letter
+            # happens to occur once on every line.
+            ("City name", ["Adelaide", "Brisbane"]),
+        ],
+    )
+    def test_csv_round_trip_single_column(
+        self, field_name: str, values: list[str]
+    ) -> None:
+        # A one-column CSV holds no delimiter for csv.Sniffer to find, and it
+        # is exactly what get_csv_string() writes for a one-column table.
+        table = PrettyTable()
+        table.field_names = [field_name]
+        for value in values:
+            table.add_row([value])
+
+        csv_string = table.get_csv_string()
+        assert from_csv(io.StringIO(csv_string)).get_csv_string() == csv_string
+
+    def test_from_csv_still_sniffs_the_delimiter(self) -> None:
+        # The fallback must not replace sniffing: a non-comma delimiter is
+        # still detected when there is one to detect.
+        table = PrettyTable()
+        table.field_names = ["City name", "Area"]
+        table.add_row(["Adelaide", "1295"])
+
+        semicolons = table.get_csv_string(delimiter=";")
+        assert from_csv(io.StringIO(semicolons)).field_names == ["City name", "Area"]
 
 
 def test_paginate(city_data: PrettyTable) -> None:


### PR DESCRIPTION
`get_csv_string()` on a one-column table writes a CSV with no delimiter in it. `from_csv()` hands that straight to `csv.Sniffer().sniff()` with no fallback, and the sniffer widens its search to every character when the usual delimiters do not fit. So it either raises, or silently splits on a letter:

```python
t = PrettyTable(); t.field_names = ["City name"]
t.add_row(["Adelaide"]); t.add_row(["Brisbane"])
from_csv(io.StringIO(t.get_csv_string())).get_csv_string()
# 'C,ty name\r\nAdela,de\r\nBr,sbane\r\n'   <- split on "i"
```

Round-tripping `get_csv_string()` through `from_csv()`, 1,800 tables (1-3 cols, 1-6 rows):

| | exceptions | silent corruption | broken |
|---|---|---|---|
| main | 484 | 116 | 600 |
| catch `csv.Error` only | 0 | 116 | 116 |
| this PR | 0 | 2 | 2 |

All 600 one-column tables are broken on main. Two- and three-column tables are unaffected in all three variants (0 of 1200) - the negative control.

Catching the exception is the obvious fix and is not enough - that is the middle row, and the new test's second case fails under it.

Residual, deliberately not fixed: the two that remain are headers like `City name`, where a space falls once on every line. Space is a delimiter `csv.Sniffer` legitimately prefers, so excluding it would break real space-delimited input.

341 tests pass; black and mypy clean. Reverting only `prettytable.py` fails both new cases.

Drafted with Claude Opus 5 (`claude-opus-5`); I ran and checked every number above.
